### PR TITLE
fix(dev): bind Vite to 127.0.0.1 for Electron compatibility

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
 		emptyOutDir: true,
 	},
 	server: {
+		host: '127.0.0.1',
 		port: 5173,
 		strictPort: true,
 	},


### PR DESCRIPTION
Vite 6 defaults to IPv6 localhost, which breaks wait-on and Electron connection on dev mode.