### PR TITLE
chore: bump version to 0.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "async-ide",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "private": true,
   "type": "module",
   "main": "electron/main.bundle.cjs",


### PR DESCRIPTION
Bump application version to **0.0.9** (`package.json`).

No functional changes beyond the release version bump.
