### PR TITLE
BrowserCapture agent tool Telegram markdown bot streaming fixes

### DIFF
--- a/main-src/agent/agentTools.ts
+++ b/main-src/agent/agentTools.ts
@@ -236,7 +236,7 @@ export const AGENT_TOOLS: AgentToolDef[] = [
 	{
 		name: 'Browser',
 		description:
-			'Control the app\'s dedicated browser window for the current Async session. Use this to open or steer pages, read visible page content, capture webpage screenshots, and inspect/update browser networking settings such as User-Agent, Accept-Language, extra request headers, and proxy configuration.',
+			'Control the app\'s dedicated browser window for the current Async session. Use this to open or steer pages, read visible page content, capture webpage screenshots, click or fill page elements, wait for selectors to appear, and inspect/update browser networking settings such as User-Agent, Accept-Language, extra request headers, and proxy configuration.',
 		parameters: {
 			type: 'object',
 			properties: {
@@ -248,6 +248,9 @@ export const AGENT_TOOLS: AgentToolDef[] = [
 						'navigate',
 						'read_page',
 						'screenshot_page',
+						'click_element',
+						'input_text',
+						'wait_for_selector',
 						'close_sidebar',
 						'reload',
 						'stop',
@@ -271,11 +274,12 @@ export const AGENT_TOOLS: AgentToolDef[] = [
 				tab_id: {
 					type: 'string',
 					description:
-						'Optional tab id for reload/stop/go_back/go_forward/close_tab/read_page/screenshot_page. Omit to target the active tab.',
+						'Optional tab id for reload/stop/go_back/go_forward/close_tab/read_page/screenshot_page/click_element/input_text/wait_for_selector. Omit to target the active tab.',
 				},
 				selector: {
 					type: 'string',
-					description: 'For read_page: optional CSS selector to extract from instead of the whole page body.',
+					description:
+						'For read_page: optional CSS selector to extract from instead of the whole page body. For click_element, input_text, and wait_for_selector: required CSS selector to target.',
 				},
 				include_html: {
 					type: 'boolean',
@@ -288,7 +292,22 @@ export const AGENT_TOOLS: AgentToolDef[] = [
 				wait_for_load: {
 					type: 'boolean',
 					description:
-						'For read_page and screenshot_page: wait for the current page load to settle before extracting. Default true.',
+						'For read_page, screenshot_page, click_element, input_text, and wait_for_selector: wait for the current page load to settle before operating. Default true.',
+				},
+				text: {
+					type: 'string',
+					description:
+						'For input_text: the text value to place into the matched element. This replaces the current value or text content.',
+				},
+				press_enter: {
+					type: 'boolean',
+					description:
+						'For input_text: after filling the value, dispatch Enter key events and submit the nearest form when possible.',
+				},
+				visible: {
+					type: 'boolean',
+					description:
+						'For wait_for_selector: if true, require the matched element to be visible with non-zero size.',
 				},
 				file_path: {
 					type: 'string',
@@ -297,7 +316,8 @@ export const AGENT_TOOLS: AgentToolDef[] = [
 				},
 				timeout_ms: {
 					type: 'number',
-					description: 'For read_page and screenshot_page: optional timeout for the browser-side operation.',
+					description:
+						'For read_page, screenshot_page, wait_for_selector, click_element, and input_text: optional timeout for the browser-side operation.',
 				},
 				userAgent: {
 					type: 'string',

--- a/main-src/agent/toolExecutor.ts
+++ b/main-src/agent/toolExecutor.ts
@@ -445,6 +445,162 @@ async function executeBrowserTool(call: ToolCall, execCtx: ToolExecutionContext)
 				isError: false,
 			};
 		}
+		case 'click_element': {
+			const selector =
+				typeof firstBrowserArg(call.arguments, 'selector') === 'string'
+					? String(firstBrowserArg(call.arguments, 'selector'))
+					: '';
+			if (!selector.trim()) {
+				return {
+					toolCallId: call.id,
+					name: call.name,
+					content: 'Error: selector is required for click_element',
+					isError: true,
+				};
+			}
+			const timeoutMsRaw = Number(firstBrowserArg(call.arguments, 'timeout_ms', 'timeoutMs'));
+			const timeoutMs = Number.isFinite(timeoutMsRaw) && timeoutMsRaw > 0 ? timeoutMsRaw : 20_000;
+			const result = await awaitBrowserCommandResult(
+				hostId,
+				{
+					commandId: makeBrowserCommandId(),
+					type: 'clickElement',
+					tabId:
+						typeof firstBrowserArg(call.arguments, 'tab_id', 'tabId') === 'string'
+							? String(firstBrowserArg(call.arguments, 'tab_id', 'tabId'))
+							: undefined,
+					selector: selector.trim(),
+					waitForLoad:
+						firstBrowserArg(call.arguments, 'wait_for_load', 'waitForLoad') === undefined
+							? true
+							: firstBrowserArg(call.arguments, 'wait_for_load', 'waitForLoad') === true ||
+								firstBrowserArg(call.arguments, 'wait_for_load', 'waitForLoad') === 'true',
+				},
+				timeoutMs
+			);
+			if (!result.ok) {
+				return {
+					toolCallId: call.id,
+					name: call.name,
+					content: `Browser click_element failed: ${result.error}`,
+					isError: true,
+				};
+			}
+			return {
+				toolCallId: call.id,
+				name: call.name,
+				content: JSON.stringify(result.result, null, 2),
+				isError: false,
+			};
+		}
+		case 'input_text': {
+			const selector =
+				typeof firstBrowserArg(call.arguments, 'selector') === 'string'
+					? String(firstBrowserArg(call.arguments, 'selector'))
+					: '';
+			if (!selector.trim()) {
+				return {
+					toolCallId: call.id,
+					name: call.name,
+					content: 'Error: selector is required for input_text',
+					isError: true,
+				};
+			}
+			const text =
+				typeof firstBrowserArg(call.arguments, 'text', 'value') === 'string'
+					? String(firstBrowserArg(call.arguments, 'text', 'value'))
+					: '';
+			const timeoutMsRaw = Number(firstBrowserArg(call.arguments, 'timeout_ms', 'timeoutMs'));
+			const timeoutMs = Number.isFinite(timeoutMsRaw) && timeoutMsRaw > 0 ? timeoutMsRaw : 20_000;
+			const result = await awaitBrowserCommandResult(
+				hostId,
+				{
+					commandId: makeBrowserCommandId(),
+					type: 'inputText',
+					tabId:
+						typeof firstBrowserArg(call.arguments, 'tab_id', 'tabId') === 'string'
+							? String(firstBrowserArg(call.arguments, 'tab_id', 'tabId'))
+							: undefined,
+					selector: selector.trim(),
+					text,
+					pressEnter:
+						firstBrowserArg(call.arguments, 'press_enter', 'pressEnter') === true ||
+						firstBrowserArg(call.arguments, 'press_enter', 'pressEnter') === 'true',
+					waitForLoad:
+						firstBrowserArg(call.arguments, 'wait_for_load', 'waitForLoad') === undefined
+							? true
+							: firstBrowserArg(call.arguments, 'wait_for_load', 'waitForLoad') === true ||
+								firstBrowserArg(call.arguments, 'wait_for_load', 'waitForLoad') === 'true',
+				},
+				timeoutMs
+			);
+			if (!result.ok) {
+				return {
+					toolCallId: call.id,
+					name: call.name,
+					content: `Browser input_text failed: ${result.error}`,
+					isError: true,
+				};
+			}
+			return {
+				toolCallId: call.id,
+				name: call.name,
+				content: JSON.stringify(result.result, null, 2),
+				isError: false,
+			};
+		}
+		case 'wait_for_selector': {
+			const selector =
+				typeof firstBrowserArg(call.arguments, 'selector') === 'string'
+					? String(firstBrowserArg(call.arguments, 'selector'))
+					: '';
+			if (!selector.trim()) {
+				return {
+					toolCallId: call.id,
+					name: call.name,
+					content: 'Error: selector is required for wait_for_selector',
+					isError: true,
+				};
+			}
+			const timeoutMsRaw = Number(firstBrowserArg(call.arguments, 'timeout_ms', 'timeoutMs'));
+			const timeoutMs = Number.isFinite(timeoutMsRaw) && timeoutMsRaw > 0 ? timeoutMsRaw : 20_000;
+			const result = await awaitBrowserCommandResult(
+				hostId,
+				{
+					commandId: makeBrowserCommandId(),
+					type: 'waitForSelector',
+					tabId:
+						typeof firstBrowserArg(call.arguments, 'tab_id', 'tabId') === 'string'
+							? String(firstBrowserArg(call.arguments, 'tab_id', 'tabId'))
+							: undefined,
+					selector: selector.trim(),
+					visible:
+						firstBrowserArg(call.arguments, 'visible') === true ||
+						firstBrowserArg(call.arguments, 'visible') === 'true',
+					waitForLoad:
+						firstBrowserArg(call.arguments, 'wait_for_load', 'waitForLoad') === undefined
+							? true
+							: firstBrowserArg(call.arguments, 'wait_for_load', 'waitForLoad') === true ||
+								firstBrowserArg(call.arguments, 'wait_for_load', 'waitForLoad') === 'true',
+					timeoutMs,
+				},
+				timeoutMs + 2_000
+			);
+			if (!result.ok) {
+				return {
+					toolCallId: call.id,
+					name: call.name,
+					content: `Browser wait_for_selector failed: ${result.error}`,
+					isError: true,
+				};
+			}
+			return {
+				toolCallId: call.id,
+				name: call.name,
+				content: JSON.stringify(result.result, null, 2),
+				isError: false,
+			};
+		}
 		case 'close_sidebar': {
 			const sent = await dispatch({
 				commandId: makeBrowserCommandId(),
@@ -572,7 +728,7 @@ async function executeBrowserTool(call: ToolCall, execCtx: ToolExecutionContext)
 				toolCallId: call.id,
 				name: call.name,
 				content:
-					'Unknown Browser action. Supported actions: get_config, get_state, navigate, read_page, screenshot_page, close_sidebar, reload, stop, go_back, go_forward, close_tab, set_config, reset_config.',
+					'Unknown Browser action. Supported actions: get_config, get_state, navigate, read_page, screenshot_page, click_element, input_text, wait_for_selector, close_sidebar, reload, stop, go_back, go_forward, close_tab, set_config, reset_config.',
 				isError: true,
 			};
 	}

--- a/main-src/bots/botController.ts
+++ b/main-src/bots/botController.ts
@@ -5,6 +5,9 @@ import {
 	createBotWorkspaceLspManager,
 	createInitialBotSession,
 	getAvailableBotModels,
+	buildQrLoginResumeUserTurn,
+	looksLikeQrLoginConfirmation,
+	looksLikeQrLoginScreenshotResendRequest,
 	runBotOrchestratorTurn,
 	type BotSessionState,
 } from './botRuntime.js';
@@ -27,6 +30,7 @@ import {
 	writeBotSession,
 } from './botSessionStore.js';
 import * as path from 'node:path';
+import { closeBrowserWindowForHostId } from '../browser/browserController.js';
 
 function looksLikeImagePath(filePath: string): boolean {
 	return /\.(png|jpe?g|webp|gif|bmp|ico|tiff?)$/i.test(path.extname(filePath));
@@ -149,6 +153,7 @@ class BotController {
 			`model: ${session.modelId || '(unset)'}`,
 			`mode: ${session.mode}`,
 			`leader turns cached: ${Math.floor((session.leaderMessages?.length ?? 0) / 2)}`,
+			`qr login pending: ${session.pendingQrLogin ? 'yes' : 'no'}`,
 		].join('\n');
 	}
 
@@ -181,6 +186,11 @@ class BotController {
 				return true;
 			}
 			case 'reset': {
+				if (session.pendingQrLogin?.hostWebContentsId != null) {
+					closeBrowserWindowForHostId(session.pendingQrLogin.hostWebContentsId);
+				}
+				session.pendingQrLogin = undefined;
+				session.browserHostWebContentsId = null;
 				session.leaderMessages = [];
 				session.leaderSummary = undefined;
 				session.leaderSummaryCoversCount = undefined;
@@ -280,6 +290,35 @@ class BotController {
 		}
 
 		const session = this.loadOrCreateSession(integration, settings, message);
+		if (session.pendingQrLogin) {
+			if (looksLikeCancelIntent(message.text)) {
+				closeBrowserWindowForHostId(session.pendingQrLogin.hostWebContentsId);
+				session.pendingQrLogin = undefined;
+				session.browserHostWebContentsId = null;
+				this.persistSession(integration, session);
+				await message.reply('已取消二维码登录等待。').catch(() => {});
+				return;
+			}
+			if (!looksLikeQrLoginConfirmation(message.text)) {
+				if (
+					looksLikeQrLoginScreenshotResendRequest(message.text) &&
+					message.replyImage &&
+					session.pendingQrLogin.screenshotPath
+				) {
+					await message.replyImage(session.pendingQrLogin.screenshotPath).catch(() => {});
+				}
+				await message.reply(session.pendingQrLogin.replyText).catch(() => {});
+				return;
+			}
+			const pending = session.pendingQrLogin;
+			session.pendingQrLogin = undefined;
+			session.browserHostWebContentsId = pending.hostWebContentsId;
+			message = {
+				...message,
+				text: buildQrLoginResumeUserTurn(pending, message.text, settings.language),
+			};
+			this.persistSession(integration, session);
+		}
 
 		const run = async () => {
 			const ac = new AbortController();
@@ -357,15 +396,16 @@ class BotController {
 						: undefined,
 				});
 				const displayText = extractBotReplyText(text || '');
+				const effectiveDisplayText = displayText || session.pendingQrLogin?.replyText || '';
 				const imagePaths = filterUnsentBotReplyImages(
 					extractBotReplyImagePaths(text || ''),
 					sentAttachmentPaths
 				);
 				if (stream) {
-					await stream!.onDone(displayText || '已完成，但没有返回可展示的文本结果。');
+					await stream!.onDone(effectiveDisplayText || '已完成，但没有返回可展示的文本结果。');
 				} else {
-					if (displayText) {
-						await message.reply(renderForPlatform(displayText, integration.platform));
+					if (effectiveDisplayText) {
+						await message.reply(renderForPlatform(effectiveDisplayText, integration.platform));
 					}
 				}
 				if (message.replyImage && imagePaths.length > 0) {
@@ -375,7 +415,7 @@ class BotController {
 						});
 					}
 				}
-				if (!stream && !displayText && imagePaths.length === 0) {
+				if (!stream && !effectiveDisplayText && imagePaths.length === 0) {
 					await message.reply('已完成，但没有返回可展示的文本结果。');
 				}
 			} catch (error) {

--- a/main-src/bots/botController.ts
+++ b/main-src/bots/botController.ts
@@ -1,6 +1,10 @@
 import type { BotIntegrationConfig, BotComposerMode } from '../botSettingsTypes.js';
 import type { ShellSettings } from '../settingsStore.js';
-import { extractBotReplyImagePaths, extractBotReplyText } from '../../src/agentStructuredMessage.js';
+import {
+	extractBotReplyImagePaths,
+	extractBotReplyText,
+	isStructuredAssistantMessage,
+} from '../../src/agentStructuredMessage.js';
 import {
 	createBotWorkspaceLspManager,
 	createInitialBotSession,
@@ -71,6 +75,21 @@ function createAdapter(integration: BotIntegrationConfig): BotPlatformAdapter | 
 		default:
 			return null;
 	}
+}
+
+function sanitizeStreamingBotReply(fullText: string): string {
+	const raw = String(fullText ?? '');
+	const trimmed = raw.trimStart();
+	if (!trimmed) {
+		return '';
+	}
+	if (isStructuredAssistantMessage(raw)) {
+		return extractBotReplyText(raw).trim() || '正在整理结果...';
+	}
+	if (trimmed.startsWith('{') && trimmed.includes('"_asyncAssistant"')) {
+		return '正在整理结果...';
+	}
+	return raw;
 }
 
 function sessionMapKey(integrationId: string, conversationKey: string): string {
@@ -350,7 +369,7 @@ class BotController {
 					onLeaderMessagesPersist: (next) => this.persistSession(integration, next),
 					onStreamDelta: stream
 						? (fullText: string, channel?: BotStreamChannel) => {
-								stream.onDelta(fullText, channel).catch(() => {});
+								stream.onDelta(sanitizeStreamingBotReply(fullText), channel).catch(() => {});
 						  }
 						: undefined,
 					onTodoUpdate: stream

--- a/main-src/bots/botRuntime.test.ts
+++ b/main-src/bots/botRuntime.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import type { BotIntegrationConfig } from '../botSettingsTypes.js';
 import type { ShellSettings } from '../settingsStore.js';
-import { buildBotOrchestratorPrompt, type BotInboundMessage, type BotSessionState } from './botRuntime.js';
+import {
+	buildBotOrchestratorPrompt,
+	looksLikeQrLoginConfirmation,
+	looksLikeQrLoginScreenshotResendRequest,
+	type BotInboundMessage,
+	type BotSessionState,
+} from './botRuntime.js';
 
 describe('buildBotOrchestratorPrompt', () => {
 	it('applies global always rules and auto reply language guidance to bot bridge replies', () => {
@@ -55,6 +61,23 @@ describe('buildBotOrchestratorPrompt', () => {
 		expect(prompt).not.toContain('#### Rule（路径匹配）: TypeScript Only');
 		expect(prompt).toContain('#### Rule: 自动语言：默认使用简体中文回复');
 		expect(prompt).toContain('screenshot_page');
-		expect(prompt).toContain('close_sidebar');
+		expect(prompt).toContain('click_element');
+		expect(prompt).toContain('BrowserCapture');
+		expect(prompt).toContain('pause_for_qr_login');
+	});
+});
+
+describe('QR login helpers', () => {
+	it('recognizes common QR login confirmation phrases', () => {
+		expect(looksLikeQrLoginConfirmation('已登录')).toBe(true);
+		expect(looksLikeQrLoginConfirmation('扫码完成')).toBe(true);
+		expect(looksLikeQrLoginConfirmation('logged in')).toBe(true);
+		expect(looksLikeQrLoginConfirmation('还没扫')).toBe(false);
+	});
+
+	it('detects requests to resend the QR screenshot', () => {
+		expect(looksLikeQrLoginScreenshotResendRequest('请再发一下二维码')).toBe(true);
+		expect(looksLikeQrLoginScreenshotResendRequest('resend the qr')).toBe(true);
+		expect(looksLikeQrLoginScreenshotResendRequest('我已经登录了')).toBe(false);
 	});
 });

--- a/main-src/bots/botRuntime.ts
+++ b/main-src/bots/botRuntime.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow } from 'electron';
+import { app, BrowserWindow, webContents } from 'electron';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { AGENT_TOOLS, type AgentToolDef, ToolCall, ToolResult } from '../agent/agentTools.js';
@@ -38,7 +38,10 @@ import { resolveToolPermissionFromRules } from '../agent/toolPermissionModel.js'
 import { isSafeShellCommandForAutoApprove } from '../agent/toolApprovalGate.js';
 import { getShellPermissionMode } from '../../src/shellPermissionMode.js';
 import type { BotTodoListItem } from './platforms/common.js';
-import { closeBrowserWindowForHostId } from '../browser/browserController.js';
+import {
+	awaitBrowserCommandResult,
+	closeBrowserWindowForHostId,
+} from '../browser/browserController.js';
 
 export type BotInboundMessage = {
 	conversationKey: string;
@@ -60,6 +63,17 @@ export type BotSessionState = {
 	leaderSummaryCoversCount?: number;
 	lastUserId?: string;
 	lastUserName?: string;
+	browserHostWebContentsId?: number | null;
+	pendingQrLogin?: BotPendingQrLoginState;
+};
+
+export type BotPendingQrLoginState = {
+	requestedAt: number;
+	hostWebContentsId: number;
+	screenshotPath: string;
+	tabId?: string;
+	pageUrl?: string;
+	replyText: string;
 };
 
 export type BotAvailableModel = {
@@ -192,6 +206,149 @@ function resolveBotHostWebContentsId(): number | null {
 	return headless?.webContents.id ?? null;
 }
 
+function isLiveWebContentsId(id: number | null | undefined): id is number {
+	if (!Number.isInteger(id) || Number(id) <= 0) {
+		return false;
+	}
+	try {
+		const contents = webContents.fromId(Number(id));
+		return Boolean(contents && !contents.isDestroyed());
+	} catch {
+		return false;
+	}
+}
+
+function resolveSessionBotHostWebContentsId(session: BotSessionState): number | null {
+	if (isLiveWebContentsId(session.browserHostWebContentsId)) {
+		return session.browserHostWebContentsId;
+	}
+	if (session.browserHostWebContentsId != null) {
+		session.browserHostWebContentsId = null;
+	}
+	if (isLiveWebContentsId(session.pendingQrLogin?.hostWebContentsId)) {
+		const pendingId = Number(session.pendingQrLogin?.hostWebContentsId);
+		session.browserHostWebContentsId = pendingId;
+		return pendingId;
+	}
+	return resolveBotHostWebContentsId();
+}
+
+function parsePngDataUrl(dataUrl: string): Buffer {
+	const match = /^data:image\/png;base64,(.+)$/i.exec(String(dataUrl ?? '').trim());
+	if (!match?.[1]) {
+		throw new Error('浏览器截图未返回 PNG 数据。');
+	}
+	return Buffer.from(match[1], 'base64');
+}
+
+function buildBotBrowserAttachmentDir(session: BotSessionState): string {
+	if (session.workspaceRoot) {
+		return path.join(session.workspaceRoot, '.async', 'bot-attachments');
+	}
+	return path.join(app.getPath('userData'), 'async', 'bot-attachments');
+}
+
+function buildBotBrowserScreenshotPath(session: BotSessionState, prefix: string): string {
+	const fileName = `${prefix}-${new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, 'Z')}.png`;
+	return path.join(buildBotBrowserAttachmentDir(session), fileName);
+}
+
+async function captureBrowserScreenshotForBot(params: {
+	hostWebContentsId: number;
+	session: BotSessionState;
+	tabId?: string;
+	timeoutMs?: number;
+}): Promise<{
+	path: string;
+	pageUrl: string;
+	title: string;
+	width: number;
+	height: number;
+}> {
+	const timeoutMs = Math.max(3_000, Math.min(60_000, Math.floor(params.timeoutMs ?? 25_000)));
+	const result = await awaitBrowserCommandResult(
+		params.hostWebContentsId,
+		{
+			commandId: `bot-browser-shot-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+			type: 'screenshotPage',
+			tabId: params.tabId,
+			waitForLoad: true,
+		},
+		timeoutMs
+	);
+	if (!result.ok) {
+		throw new Error(result.error || '浏览器截图失败。');
+	}
+	const payload =
+		result.result && typeof result.result === 'object' ? (result.result as Record<string, unknown>) : {};
+	const png = parsePngDataUrl(String(payload.dataUrl ?? ''));
+	const outputPath = buildBotBrowserScreenshotPath(params.session, 'qr-login');
+	fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+	fs.writeFileSync(outputPath, png);
+	return {
+		path: outputPath,
+		pageUrl: String(payload.url ?? ''),
+		title: String(payload.title ?? ''),
+		width: Number(payload.width ?? 0) || 0,
+		height: Number(payload.height ?? 0) || 0,
+	};
+}
+
+const QR_LOGIN_CONFIRM_PATTERNS = [
+	/\b(?:logged\s*in|login\s*(?:done|complete|completed|ok)|qr\s*(?:done|complete|completed))\b/i,
+	/(已登录|登录完成|登录好了|我已登录|已经登录|扫码完成|扫码好了|我已扫码|已经扫码|扫好了|扫完了)/,
+];
+
+const QR_LOGIN_RESEND_PATTERNS = [
+	/\b(?:qr|code|resend|send again|show again)\b/i,
+	/(二维码|再发|重发|重新发|看不到|发一下|再来一张)/,
+];
+
+export function looksLikeQrLoginConfirmation(text: string): boolean {
+	const trimmed = String(text ?? '').trim();
+	if (!trimmed) {
+		return false;
+	}
+	return QR_LOGIN_CONFIRM_PATTERNS.some((pattern) => pattern.test(trimmed));
+}
+
+export function looksLikeQrLoginScreenshotResendRequest(text: string): boolean {
+	const trimmed = String(text ?? '').trim();
+	if (!trimmed) {
+		return false;
+	}
+	return QR_LOGIN_RESEND_PATTERNS.some((pattern) => pattern.test(trimmed));
+}
+
+function defaultQrLoginReplyText(language: ShellSettings['language']): string {
+	return language === 'en'
+		? 'The QR login page has been sent. Please scan it with your phone, then reply "logged in" here and I will continue.'
+		: '二维码登录页面已经发给你了，请用手机扫码登录；完成后在这里回复“已登录”，我会继续执行。';
+}
+
+export function buildQrLoginResumeUserTurn(
+	pending: BotPendingQrLoginState,
+	userText: string,
+	language: ShellSettings['language']
+): string {
+	const followup = String(userText ?? '').trim() || (language === 'en' ? 'logged in' : '已登录');
+	const lines =
+		language === 'en'
+			? [
+					'[System] QR login was previously paused for manual user confirmation.',
+					`Screenshot path: ${pending.screenshotPath}`,
+					pending.pageUrl ? `Last page URL: ${pending.pageUrl}` : '',
+					'The user has now confirmed the QR login step is complete. Continue from the existing browser session instead of reopening the login page.',
+			  ]
+			: [
+					'[系统] 之前已经因为二维码登录而暂停。',
+					`截图路径：${pending.screenshotPath}`,
+					pending.pageUrl ? `上次页面 URL：${pending.pageUrl}` : '',
+					'用户现在已经确认二维码登录完成。请继续使用现有浏览器会话，不要重新打开登录页。',
+			  ];
+	return `${lines.filter(Boolean).join('\n')}\n\n[User follow-up]\n${followup}`;
+}
+
 function trimBotLeaderMessages(messages: ChatMessage[], maxMessages = 24): ChatMessage[] {
 	if (messages.length <= maxMessages) {
 		return messages;
@@ -253,6 +410,10 @@ function describeBotToolActivity(name: string, args: Record<string, unknown>): s
 			const action = String(args.action ?? '').trim();
 			return action ? `浏览器：${action}` : '正在操作内置浏览器';
 		}
+		case 'BrowserCapture': {
+			const action = String(args.action ?? '').trim();
+			return action ? `浏览器抓包：${action}` : '正在抓取浏览器网络请求';
+		}
 		case 'Bash': {
 			const command = String(args.command ?? '').trim();
 			return command ? `执行命令：${command.slice(0, 80)}` : '执行命令';
@@ -267,6 +428,8 @@ function describeBotToolActivity(name: string, args: Record<string, unknown>): s
 		}
 		case 'send_local_attachment':
 			return '发送本地附件给用户';
+		case 'pause_for_qr_login':
+			return '发送二维码登录截图并等待用户扫码';
 		default:
 			return undefined;
 	}
@@ -371,6 +534,7 @@ export function createInitialBotSession(
 		leaderMessages: [],
 		lastUserId: senderId,
 		lastUserName: senderName,
+		browserHostWebContentsId: null,
 	};
 }
 
@@ -476,10 +640,35 @@ const BOT_TOOL_DEFS: AgentToolDef[] = [
 			required: ['file_path'],
 		},
 	},
+	{
+		name: 'pause_for_qr_login',
+		description:
+			'Capture the current built-in browser page, send the screenshot to the external user for QR-code or other manual login steps, and pause the browser session until the user confirms login is complete. After calling this tool, stop and wait for the user to reply.',
+		parameters: {
+			type: 'object',
+			properties: {
+				message: {
+					type: 'string',
+					description:
+						'Optional short user-facing instruction. If omitted, Async sends a default "scan the QR and reply when done" message.',
+				},
+				tab_id: {
+					type: 'string',
+					description: 'Optional browser tab id. Omit to use the active tab.',
+				},
+				timeout_ms: {
+					type: 'number',
+					description: 'Optional timeout for the screenshot capture. Default about 25 seconds.',
+				},
+			},
+			required: [],
+		},
+	},
 ];
 
 const BOT_LEADER_NATIVE_TOOL_NAMES = new Set([
 	'Browser',
+	'BrowserCapture',
 	'TodoWrite',
 	'Read',
 	'Grep',
@@ -506,6 +695,8 @@ function renderSessionSnapshot(
 				modelId: session.modelId,
 				defaultWorkerMode: session.mode,
 				leaderContextTurns: Math.floor((session.leaderMessages?.length ?? 0) / 2),
+				browserHostWebContentsId: session.browserHostWebContentsId ?? null,
+				qrLoginPending: Boolean(session.pendingQrLogin),
 			},
 			availableModels: models,
 			availableWorkspaces: workspaces,
@@ -534,8 +725,8 @@ export function buildBotOrchestratorPrompt(
 			? 'This leader loop is for app-level orchestration. It can directly use app/browser controls plus the custom bot session tools below.'
 			: '这个 Leader 循环用于应用级调度。它可以直接使用应用/浏览器控制工具，以及下面的 bot 会话工具。',
 		language === 'en'
-			? 'Your priority is fast, direct answers. Default to using your own tools (Read, Grep, Glob, Browser, TodoWrite) to answer the user without spawning a worker.'
-			: '你的首要目标是快速、直接地回答用户。默认优先使用自己的工具（Read、Grep、Glob、Browser、TodoWrite）直接回答，不要动不动就派 worker。',
+			? 'Your priority is fast, direct answers. Default to using your own tools (Read, Grep, Glob, Browser, BrowserCapture, TodoWrite) to answer the user without spawning a worker.'
+			: '你的首要目标是快速、直接地回答用户。默认优先使用自己的工具（Read、Grep、Glob、Browser、BrowserCapture、TodoWrite）直接回答，不要动不动就派 worker。',
 		language === 'en'
 			? 'Use run_async_task ONLY when the task requires Writes/Edits, shell commands, builds/tests, multi-file refactors, or long-running workflows. Simple reads, searches, status questions, and lookups must be answered directly by you.'
 			: '只有在任务需要写文件、改文件、执行 shell、跑构建/测试、多文件重构、或长链路流程时，才使用 run_async_task。简单的读文件、搜索、状态问询、查询必须你自己直接答。',
@@ -546,8 +737,11 @@ export function buildBotOrchestratorPrompt(
 			? 'When delegating via run_async_task, choose mode automatically: agent for direct project implementation/debugging, plan for plan-only analysis, team for larger or cross-cutting project work, and ask for lightweight Q&A that still needs a recorded worker conversation.'
 			: '使用 run_async_task 时，自动判断模式：直接项目实现/调试用 agent，只做方案分析用 plan，较大或跨领域工作用 team，需要保留记录的轻量问答可用 ask。',
 		language === 'en'
-			? 'When the user asks to search the web, open a page, read a webpage, take a screenshot, or close the built-in browser, use the Browser tool directly (for example: navigate, read_page, screenshot_page, close_sidebar).'
-			: '当用户要求搜索网页、打开页面、读取网页内容、截屏，或关闭内置浏览器时，直接使用 Browser 工具（例如：navigate、read_page、screenshot_page、close_sidebar）。',
+			? 'When the user asks to search the web, open a page, read a webpage, interact with a login form, take a screenshot, or close the built-in browser, use Browser and BrowserCapture directly (for example: navigate, input_text, click_element, screenshot_page, list_requests, get_request).'
+			: '当用户要求搜索网页、打开页面、与登录表单交互、读取网页内容、截屏或抓取浏览器网络请求时，直接使用 Browser 和 BrowserCapture 工具（例如：navigate、input_text、click_element、screenshot_page、list_requests、get_request）。',
+		language === 'en'
+			? 'If a site switches to QR-code login or another manual mobile confirmation step, do not ask the user for passwords. Use pause_for_qr_login to send the current browser screenshot to the user, keep the browser session open, and wait for the user to confirm login is complete.'
+			: '如果网站切换到二维码登录或其他需要用户手机确认的登录步骤，不要向用户索要密码。请使用 pause_for_qr_login，把当前浏览器截图发给用户，保持浏览器会话不关闭，并等待用户确认登录完成。',
 		language === 'en'
 			? 'If the user wants the screenshot or a local file to appear in the chat, do not stop at saving it locally. Use send_local_attachment to send the produced or located file back to the user.'
 			: '如果用户希望截图或本地文件直接出现在聊天窗口里，不要只停留在本地保存；拿到文件后继续调用 send_local_attachment 发回给用户。',
@@ -601,7 +795,7 @@ function resolveSessionWorkspace(
 	return { ok: true, workspaceRoot: match };
 }
 
-const READONLY_TOOLS = new Set(['Read', 'Grep', 'Glob', 'Browser', 'TodoWrite']);
+const READONLY_TOOLS = new Set(['Read', 'Grep', 'Glob', 'Browser', 'BrowserCapture', 'TodoWrite', 'pause_for_qr_login']);
 
 function resolveBotPermissionPolicy(integration: BotIntegrationConfig): 'strict' | 'readonly_auto' | 'permissive' {
 	const raw = String(integration.permissionPolicy ?? '').trim().toLowerCase();
@@ -611,9 +805,23 @@ function resolveBotPermissionPolicy(integration: BotIntegrationConfig): 'strict'
 	return 'readonly_auto';
 }
 
-function createHeadlessBeforeExecuteTool(settings: ShellSettings, integration: BotIntegrationConfig) {
+function createHeadlessBeforeExecuteTool(
+	settings: ShellSettings,
+	integration: BotIntegrationConfig,
+	opts?: { hasPendingQrLogin?: () => boolean }
+) {
 	const policy = resolveBotPermissionPolicy(integration);
 	return async (call: ToolCall) => {
+		if (
+			opts?.hasPendingQrLogin?.() &&
+			call.name !== 'pause_for_qr_login' &&
+			call.name !== 'get_async_session'
+		) {
+			return {
+				proceed: false as const,
+				rejectionMessage: '二维码登录等待中，请先等待用户扫码并确认完成。',
+			};
+		}
 		const agent = settings.agent;
 		const permission = resolveToolPermissionFromRules(call, agent, { avoidPermissionPrompts: true });
 		if (permission === 'deny') {
@@ -673,7 +881,7 @@ async function runBotAsyncTask(args: RunBotAsyncTaskArgs): Promise<string> {
 	const { settings, integration, session, task, workspaceLspManager, signal } = args;
 	const mode = args.modeOverride ?? session.mode;
 	const threadId = ensureThreadForSession(session, mode, args.startNewThread === true);
-	const hostWebContentsId = resolveBotHostWebContentsId();
+	const hostWebContentsId = resolveSessionBotHostWebContentsId(session);
 	try {
 		const modelSelection = session.modelId.trim();
 		if (!modelSelection) {
@@ -843,7 +1051,9 @@ async function runBotAsyncTask(args: RunBotAsyncTaskArgs): Promise<string> {
 						signal,
 						composerMode: mode,
 						thinkingLevel,
-						beforeExecuteTool: createHeadlessBeforeExecuteTool(effectiveSettings, integration),
+						beforeExecuteTool: createHeadlessBeforeExecuteTool(effectiveSettings, integration, {
+							hasPendingQrLogin: () => Boolean(session.pendingQrLogin),
+						}),
 						maxConsecutiveMistakes: effectiveSettings.agent?.maxConsecutiveMistakes,
 						mistakeLimitEnabled: effectiveSettings.agent?.mistakeLimitEnabled,
 						workspaceRoot: session.workspaceRoot,
@@ -931,7 +1141,14 @@ async function runBotAsyncTask(args: RunBotAsyncTaskArgs): Promise<string> {
 		});
 	} finally {
 		if (hostWebContentsId != null) {
-			closeBrowserWindowForHostId(hostWebContentsId);
+			if (session.pendingQrLogin?.hostWebContentsId === hostWebContentsId) {
+				session.browserHostWebContentsId = hostWebContentsId;
+			} else {
+				closeBrowserWindowForHostId(hostWebContentsId);
+				if (session.browserHostWebContentsId === hostWebContentsId) {
+					session.browserHostWebContentsId = null;
+				}
+			}
 		}
 	}
 }
@@ -1092,11 +1309,66 @@ export async function runBotOrchestratorTurn(args: RunBotOrchestratorArgs): Prom
 				};
 			}
 		},
+		pause_for_qr_login: async (call) => {
+			if (!args.onSendAttachment) {
+				return {
+					toolCallId: call.id,
+					name: call.name,
+					content: '当前平台不支持发送图片，无法执行二维码登录等待流程。',
+					isError: true,
+				};
+			}
+			const currentHostId = resolveSessionBotHostWebContentsId(session);
+			if (!currentHostId) {
+				return {
+					toolCallId: call.id,
+					name: call.name,
+					content: '当前没有可用的浏览器宿主窗口，无法发送二维码截图。',
+					isError: true,
+				};
+			}
+			try {
+				const screenshot = await captureBrowserScreenshotForBot({
+					hostWebContentsId: currentHostId,
+					session,
+					tabId: typeof call.arguments.tab_id === 'string' ? String(call.arguments.tab_id).trim() : undefined,
+					timeoutMs: Number(call.arguments.timeout_ms ?? 25_000),
+				});
+				await args.onSendAttachment(screenshot.path);
+				const replyText =
+					String(call.arguments.message ?? '').trim() || defaultQrLoginReplyText(settings.language);
+				session.browserHostWebContentsId = currentHostId;
+				session.pendingQrLogin = {
+					requestedAt: Date.now(),
+					hostWebContentsId: currentHostId,
+					screenshotPath: screenshot.path,
+					tabId: typeof call.arguments.tab_id === 'string' ? String(call.arguments.tab_id).trim() || undefined : undefined,
+					pageUrl: screenshot.pageUrl || undefined,
+					replyText,
+				};
+				return {
+					toolCallId: call.id,
+					name: call.name,
+					content:
+						settings.language === 'en'
+							? `QR login screenshot sent to the user at ${screenshot.path}. Stop now and wait for the user to confirm login is complete.`
+							: `已将二维码登录截图发送给用户：${screenshot.path}。现在请停止后续操作，等待用户确认“已登录”。`,
+					isError: false,
+				};
+			} catch (error) {
+				return {
+					toolCallId: call.id,
+					name: call.name,
+					content: error instanceof Error ? error.message : String(error),
+					isError: true,
+				};
+			}
+		},
 	};
 
 	const thinkingLevel = resolveThinkingLevelForSelection(settings, session.modelId.trim());
 	const systemAppend = buildBotOrchestratorPrompt(settings, integration, session, inbound);
-	const hostWebContentsId = resolveBotHostWebContentsId();
+	const hostWebContentsId = resolveSessionBotHostWebContentsId(session);
 	let full = '';
 	let errorMessage = '';
 	let streamFull = '';
@@ -1153,7 +1425,9 @@ export async function runBotOrchestratorTurn(args: RunBotOrchestratorArgs): Prom
 				toolPoolOverride: leaderToolPool,
 				customToolHandlers: handlers,
 				agentSystemAppend: systemAppend,
-				beforeExecuteTool: createHeadlessBeforeExecuteTool(settings, integration),
+				beforeExecuteTool: createHeadlessBeforeExecuteTool(settings, integration, {
+					hasPendingQrLogin: () => Boolean(session.pendingQrLogin),
+				}),
 				mistakeLimitEnabled: settings.agent?.mistakeLimitEnabled,
 				maxConsecutiveMistakes: settings.agent?.maxConsecutiveMistakes,
 			},
@@ -1187,7 +1461,14 @@ export async function runBotOrchestratorTurn(args: RunBotOrchestratorArgs): Prom
 		errorMessage = formatLlmSdkError(error);
 	} finally {
 		if (hostWebContentsId != null) {
-			closeBrowserWindowForHostId(hostWebContentsId);
+			if (session.pendingQrLogin?.hostWebContentsId === hostWebContentsId) {
+				session.browserHostWebContentsId = hostWebContentsId;
+			} else {
+				closeBrowserWindowForHostId(hostWebContentsId);
+				if (session.browserHostWebContentsId === hostWebContentsId) {
+					session.browserHostWebContentsId = null;
+				}
+			}
 		}
 	}
 

--- a/main-src/bots/platforms/platformMarkdown.test.ts
+++ b/main-src/bots/platforms/platformMarkdown.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { renderForPlatform, renderTelegramRichText, splitTelegramRichText } from './platformMarkdown.js';
+
+describe('renderTelegramRichText', () => {
+	it('converts common markdown markers into Telegram entities', () => {
+		const rich = renderTelegramRichText('## Title\n**Bold** and [link](https://example.com) with `code`.');
+
+		expect(rich.text).toBe('Title\nBold and link with code.');
+		expect(rich.entities).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ type: 'bold', offset: 0, length: 5 }),
+				expect.objectContaining({ type: 'bold', offset: 6, length: 4 }),
+				expect.objectContaining({
+					type: 'text_link',
+					offset: 15,
+					length: 4,
+					url: 'https://example.com',
+				}),
+				expect.objectContaining({ type: 'code', offset: 25, length: 4 }),
+			])
+		);
+	});
+
+	it('marks fenced code blocks as pre entities and preserves their text', () => {
+		const rich = renderTelegramRichText('```ts\nconst x = 1;\nconsole.log(x)\n```');
+
+		expect(rich.text).toBe('const x = 1;\nconsole.log(x)');
+		expect(rich.entities).toEqual([
+			expect.objectContaining({
+				type: 'pre',
+				offset: 0,
+				length: rich.text.length,
+				language: 'ts',
+			}),
+		]);
+	});
+
+	it('maps spoiler, horizontal rules, and task list lines to Telegram-friendly plain text', () => {
+		const rich = renderTelegramRichText('||secret||\n---\n- [ ] todo\n- [x] done');
+
+		expect(rich.text).toBe('secret\n──────────\n☐ todo\n☑ done');
+		expect(rich.entities).toEqual(
+			expect.arrayContaining([expect.objectContaining({ type: 'spoiler', offset: 0, length: 6 })])
+		);
+	});
+
+	it('renderForPlatform(telegram) returns plain text compatible with entity-based sendMessage', () => {
+		expect(renderForPlatform('**bold**', 'telegram')).toBe('bold');
+	});
+});
+
+describe('splitTelegramRichText', () => {
+	it('splits long text while keeping entities on the right chunk', () => {
+		const rich = renderTelegramRichText('**Alpha** beta gamma delta epsilon zeta eta theta iota kappa');
+		const chunks = splitTelegramRichText(rich, 20);
+
+		expect(chunks.length).toBeGreaterThan(1);
+		expect(chunks[0]?.entities).toEqual(
+			expect.arrayContaining([expect.objectContaining({ type: 'bold', offset: 0, length: 5 })])
+		);
+		expect(chunks.map((chunk) => chunk.text).join(' ')).toContain('Alpha beta gamma');
+	});
+
+	it('does not split in the middle of a UTF-16 surrogate pair', () => {
+		const emoji = '\uD83D\uDE00';
+		const rich = renderTelegramRichText(`prefix${emoji}`);
+		const chunks = splitTelegramRichText(rich, 'prefix'.length + 1);
+		expect(chunks.map((c) => c.text).join('')).toBe(rich.text);
+		expect(chunks[0]?.text).toBe('prefix');
+		expect(chunks[1]?.text).toBe(emoji);
+	});
+});

--- a/main-src/bots/platforms/platformMarkdown.ts
+++ b/main-src/bots/platforms/platformMarkdown.ts
@@ -1,5 +1,18 @@
 import type { BotPlatform } from '../../botSettingsTypes.js';
 
+export type TelegramMessageEntity = {
+	type: 'bold' | 'italic' | 'strikethrough' | 'spoiler' | 'code' | 'pre' | 'text_link' | 'blockquote';
+	offset: number;
+	length: number;
+	url?: string;
+	language?: string;
+};
+
+export type TelegramRichText = {
+	text: string;
+	entities: TelegramMessageEntity[];
+};
+
 function stripAnsi(text: string): string {
 	return text.replace(/\u001b\[[0-9;]*m/g, '');
 }
@@ -21,78 +34,385 @@ function stripMarkdownLinks(text: string): string {
 	return text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '$1 ($2)');
 }
 
-function escapeTelegramMarkdownV2(text: string): string {
-	return text.replace(/[_*[\]()~`>#+\-=|{}.!\\]/g, (ch) => `\\${ch}`);
+function isEscaped(text: string, index: number): boolean {
+	let backslashes = 0;
+	for (let i = index - 1; i >= 0 && text[i] === '\\'; i -= 1) {
+		backslashes += 1;
+	}
+	return backslashes % 2 === 1;
 }
 
-function renderTelegram(text: string): string {
-	const clean = stripAnsi(text);
-	const parts: string[] = [];
-	let cursor = 0;
-	const fence = /```([a-zA-Z0-9_+.-]*)\n([\s\S]*?)```/g;
-	let match: RegExpExecArray | null;
-	while ((match = fence.exec(clean)) !== null) {
-		if (match.index > cursor) {
-			parts.push(renderTelegramProse(clean.slice(cursor, match.index)));
+function findClosingMarker(text: string, marker: string, from: number): number {
+	let idx = from;
+	while (idx < text.length) {
+		const found = text.indexOf(marker, idx);
+		if (found === -1) {
+			return -1;
 		}
-		const body = escapeTelegramMarkdownV2(match[2].replace(/```/g, ''));
-		parts.push('```\n' + body + '\n```');
-		cursor = fence.lastIndex;
+		if (!isEscaped(text, found)) {
+			return found;
+		}
+		idx = found + marker.length;
 	}
-	if (cursor < clean.length) {
-		parts.push(renderTelegramProse(clean.slice(cursor)));
-	}
-	return parts.join('');
+	return -1;
 }
 
-function renderTelegramProse(text: string): string {
-	const inlineBold: Array<{ start: number; end: number; content: string }> = [];
-	text.replace(/\*\*([^*\n]+?)\*\*/g, (full, content, offset) => {
-		inlineBold.push({ start: offset, end: offset + full.length, content });
-		return full;
+function sortTelegramEntities(entities: TelegramMessageEntity[]): TelegramMessageEntity[] {
+	return [...entities].sort((a, b) => {
+		if (a.offset !== b.offset) {
+			return a.offset - b.offset;
+		}
+		return b.length - a.length;
 	});
-	const inlineCode: Array<{ start: number; end: number; content: string }> = [];
-	text.replace(/`([^`\n]+?)`/g, (full, content, offset) => {
-		inlineCode.push({ start: offset, end: offset + full.length, content });
-		return full;
-	});
-	const marks: Array<{ start: number; end: number; open: string; close: string; content: string }> = [
-		...inlineCode.map((entry) => ({
-			...entry,
-			open: '`',
-			close: '`',
-			content: entry.content,
-		})),
-		...inlineBold.map((entry) => ({
-			...entry,
-			open: '*',
-			close: '*',
-			content: entry.content,
-		})),
-	].sort((a, b) => a.start - b.start);
-	const filtered: typeof marks = [];
-	for (const mark of marks) {
-		if (filtered.length === 0 || filtered[filtered.length - 1].end <= mark.start) {
-			filtered.push(mark);
+}
+
+function parseInlineTelegram(text: string): TelegramRichText {
+	let plain = '';
+	const entities: TelegramMessageEntity[] = [];
+	let index = 0;
+	while (index < text.length) {
+		const char = text[index] ?? '';
+		if (char === '\\' && index + 1 < text.length) {
+			plain += text[index + 1];
+			index += 2;
+			continue;
+		}
+		if (char === '`') {
+			const close = findClosingMarker(text, '`', index + 1);
+			if (close > index + 1) {
+				const content = text.slice(index + 1, close);
+				const start = plain.length;
+				plain += content;
+				entities.push({ type: 'code', offset: start, length: content.length });
+				index = close + 1;
+				continue;
+			}
+		}
+		if (char === '[') {
+			const closeBracket = findClosingMarker(text, ']', index + 1);
+			if (closeBracket !== -1 && text[closeBracket + 1] === '(') {
+				const closeParen = findClosingMarker(text, ')', closeBracket + 2);
+				if (closeParen !== -1) {
+					const label = text.slice(index + 1, closeBracket);
+					const url = text.slice(closeBracket + 2, closeParen).trim();
+					const start = plain.length;
+					plain += label;
+					if (label && url) {
+						entities.push({ type: 'text_link', offset: start, length: label.length, url });
+					}
+					index = closeParen + 1;
+					continue;
+				}
+			}
+		}
+
+		if (text.startsWith('||', index)) {
+			const close = findClosingMarker(text, '||', index + 2);
+			if (close > index + 2) {
+				const inner = parseInlineTelegram(text.slice(index + 2, close));
+				const start = plain.length;
+				plain += inner.text;
+				entities.push(
+					...inner.entities.map((entity) => ({
+						...entity,
+						offset: entity.offset + start,
+					}))
+				);
+				if (inner.text.length > 0) {
+					entities.push({ type: 'spoiler', offset: start, length: inner.text.length });
+				}
+				index = close + 2;
+				continue;
+			}
+		}
+
+		const strongMarker =
+			text.startsWith('**', index) || text.startsWith('__', index)
+				? text.slice(index, index + 2)
+				: text.startsWith('~~', index)
+					? '~~'
+					: null;
+		if (strongMarker) {
+			const close = findClosingMarker(text, strongMarker, index + strongMarker.length);
+			if (close > index + strongMarker.length) {
+				const inner = parseInlineTelegram(text.slice(index + strongMarker.length, close));
+				const start = plain.length;
+				plain += inner.text;
+				entities.push(
+					...inner.entities.map((entity) => ({
+						...entity,
+						offset: entity.offset + start,
+					}))
+				);
+				if (inner.text.length > 0) {
+					entities.push({
+						type: strongMarker === '~~' ? 'strikethrough' : 'bold',
+						offset: start,
+						length: inner.text.length,
+					});
+				}
+				index = close + strongMarker.length;
+				continue;
+			}
+		}
+
+		if ((char === '*' || char === '_') && text[index + 1] && !/\s/.test(text[index + 1]!)) {
+			const close = findClosingMarker(text, char, index + 1);
+			if (close > index + 1) {
+				const inner = parseInlineTelegram(text.slice(index + 1, close));
+				const start = plain.length;
+				plain += inner.text;
+				entities.push(
+					...inner.entities.map((entity) => ({
+						...entity,
+						offset: entity.offset + start,
+					}))
+				);
+				if (inner.text.length > 0) {
+					entities.push({ type: 'italic', offset: start, length: inner.text.length });
+				}
+				index = close + 1;
+				continue;
+			}
+		}
+
+		plain += char;
+		index += 1;
+	}
+	return {
+		text: plain,
+		entities: sortTelegramEntities(entities),
+	};
+}
+
+export function renderTelegramRichText(text: string): TelegramRichText {
+	const clean = stripAnsi(String(text ?? '')).replace(/\r\n/g, '\n');
+	const lines = clean.split('\n');
+	let output = '';
+	const entities: TelegramMessageEntity[] = [];
+	let index = 0;
+
+	const appendLine = (lineText: string, lineEntities: TelegramMessageEntity[], extraEntity?: Omit<TelegramMessageEntity, 'offset' | 'length'>) => {
+		const start = output.length;
+		output += lineText;
+		for (const entity of lineEntities) {
+			entities.push({
+				...entity,
+				offset: entity.offset + start,
+			});
+		}
+		if (extraEntity && lineText.length > 0) {
+			entities.push({
+				...extraEntity,
+				offset: start,
+				length: lineText.length,
+			});
+		}
+	};
+
+	while (index < lines.length) {
+		const rawLine = lines[index] ?? '';
+		const fenceMatch = rawLine.match(/^```([a-zA-Z0-9_+.-]+)?\s*$/);
+		if (fenceMatch) {
+			const language = fenceMatch[1]?.trim() || undefined;
+			const codeLines: string[] = [];
+			index += 1;
+			while (index < lines.length && !/^```\s*$/.test(lines[index] ?? '')) {
+				codeLines.push(lines[index] ?? '');
+				index += 1;
+			}
+			if (index < lines.length && /^```\s*$/.test(lines[index] ?? '')) {
+				index += 1;
+			}
+			const codeText = codeLines.join('\n');
+			const start = output.length;
+			output += codeText;
+			if (codeText.length > 0) {
+				entities.push({
+					type: 'pre',
+					offset: start,
+					length: codeText.length,
+					...(language ? { language } : {}),
+				});
+			}
+			if (index < lines.length) {
+				output += '\n';
+			}
+			continue;
+		}
+
+		const headingMatch = rawLine.match(/^\s{0,3}(#{1,6})\s+(.*)$/);
+		if (headingMatch) {
+			const inline = parseInlineTelegram(headingMatch[2] ?? '');
+			appendLine(inline.text, inline.entities, { type: 'bold' });
+			if (index < lines.length - 1) {
+				output += '\n';
+			}
+			index += 1;
+			continue;
+		}
+
+		const quoteMatch = rawLine.match(/^\s*>\s?(.*)$/);
+		if (quoteMatch) {
+			const inline = parseInlineTelegram(quoteMatch[1] ?? '');
+			appendLine(inline.text, inline.entities, { type: 'blockquote' });
+			if (index < lines.length - 1) {
+				output += '\n';
+			}
+			index += 1;
+			continue;
+		}
+
+		if (/^\s*([-*_])(?:\s*\1){2,}\s*$/.test(rawLine)) {
+			appendLine('──────────', []);
+			if (index < lines.length - 1) {
+				output += '\n';
+			}
+			index += 1;
+			continue;
+		}
+
+		const taskMatch = rawLine.match(/^(\s*)[-*+]\s+\[([ xX])\]\s+(.*)$/);
+		if (taskMatch) {
+			const indent = taskMatch[1] ?? '';
+			const checked = (taskMatch[2] ?? '').toLowerCase() === 'x';
+			const prefix = `${indent}${checked ? '☑ ' : '☐ '}`;
+			const inline = parseInlineTelegram(taskMatch[3] ?? '');
+			appendLine(`${prefix}${inline.text}`, inline.entities.map((entity) => ({
+				...entity,
+				offset: entity.offset + prefix.length,
+			})));
+			if (index < lines.length - 1) {
+				output += '\n';
+			}
+			index += 1;
+			continue;
+		}
+
+		const unorderedMatch = rawLine.match(/^(\s*)[-*+]\s+(.*)$/);
+		if (unorderedMatch) {
+			const indent = unorderedMatch[1] ?? '';
+			const prefix = indent ? `${indent}• ` : '• ';
+			const inline = parseInlineTelegram(unorderedMatch[2] ?? '');
+			appendLine(`${prefix}${inline.text}`, inline.entities.map((entity) => ({
+				...entity,
+				offset: entity.offset + prefix.length,
+			})));
+			if (index < lines.length - 1) {
+				output += '\n';
+			}
+			index += 1;
+			continue;
+		}
+
+		const orderedMatch = rawLine.match(/^(\s*)(\d+)\.\s+(.*)$/);
+		if (orderedMatch) {
+			const indent = orderedMatch[1] ?? '';
+			const prefix = `${indent}${orderedMatch[2]}. `;
+			const inline = parseInlineTelegram(orderedMatch[3] ?? '');
+			appendLine(`${prefix}${inline.text}`, inline.entities.map((entity) => ({
+				...entity,
+				offset: entity.offset + prefix.length,
+			})));
+			if (index < lines.length - 1) {
+				output += '\n';
+			}
+			index += 1;
+			continue;
+		}
+
+		const inline = parseInlineTelegram(rawLine);
+		appendLine(inline.text, inline.entities);
+		if (index < lines.length - 1) {
+			output += '\n';
+		}
+		index += 1;
+	}
+
+	return {
+		text: output,
+		entities: sortTelegramEntities(entities.filter((entity) => entity.length > 0)),
+	};
+}
+
+function sliceTelegramRichText(rich: TelegramRichText, start: number, end: number): TelegramRichText {
+	const text = rich.text.slice(start, end);
+	const entities = rich.entities
+		.map((entity) => {
+			const entityStart = entity.offset;
+			const entityEnd = entity.offset + entity.length;
+			if (entityEnd <= start || entityStart >= end) {
+				return null;
+			}
+			const nextOffset = Math.max(entityStart, start) - start;
+			const nextEnd = Math.min(entityEnd, end) - start;
+			if (nextEnd <= nextOffset) {
+				return null;
+			}
+			return {
+				...entity,
+				offset: nextOffset,
+				length: nextEnd - nextOffset,
+			};
+		})
+		.filter((entity): entity is TelegramMessageEntity => Boolean(entity));
+	return {
+		text,
+		entities: sortTelegramEntities(entities),
+	};
+}
+
+function findTelegramSplitPoint(text: string, start: number, maxLength: number): number {
+	const target = Math.min(text.length, start + maxLength);
+	if (target >= text.length) {
+		return text.length;
+	}
+	const windowStart = Math.max(start + Math.floor(maxLength * 0.5), start + 1);
+	for (let index = target; index > windowStart; index -= 1) {
+		const char = text[index];
+		if (char === '\n' || char === ' ' || char === '\t') {
+			return adjustSplitEndExclusive(text, start, index);
 		}
 	}
-	let out = '';
-	let pos = 0;
-	for (const mark of filtered) {
-		if (mark.start > pos) {
-			out += escapeTelegramMarkdownV2(text.slice(pos, mark.start));
+	return adjustSplitEndExclusive(text, start, target);
+}
+
+/** Do not break between a UTF-16 high surrogate and its trailing low surrogate. */
+function adjustSplitEndExclusive(text: string, start: number, end: number): number {
+	let e = Math.min(Math.max(end, start), text.length);
+	while (e > start) {
+		const prev = text.charCodeAt(e - 1);
+		if (prev >= 0xd800 && prev <= 0xdbff && e < text.length) {
+			const next = text.charCodeAt(e);
+			if (next >= 0xdc00 && next <= 0xdfff) {
+				e -= 1;
+				continue;
+			}
 		}
-		const inner =
-			mark.open === '`'
-				? mark.content.replace(/[`\\]/g, (ch) => `\\${ch}`)
-				: escapeTelegramMarkdownV2(mark.content);
-		out += `${mark.open}${inner}${mark.close}`;
-		pos = mark.end;
+		break;
 	}
-	if (pos < text.length) {
-		out += escapeTelegramMarkdownV2(text.slice(pos));
+	return e <= start ? Math.min(start + 1, text.length) : e;
+}
+
+export function splitTelegramRichText(rich: TelegramRichText, maxLength: number): TelegramRichText[] {
+	const safeMaxLength = Math.max(1, Math.floor(maxLength));
+	if (rich.text.length <= safeMaxLength) {
+		return [rich];
 	}
-	return out;
+	const chunks: TelegramRichText[] = [];
+	let start = 0;
+	while (start < rich.text.length) {
+		const end = findTelegramSplitPoint(rich.text, start, safeMaxLength);
+		const chunk = sliceTelegramRichText(rich, start, end);
+		if (chunk.text) {
+			chunks.push(chunk);
+		}
+		start = end;
+		while (start < rich.text.length && /\s/.test(rich.text[start] ?? '')) {
+			start += 1;
+		}
+	}
+	return chunks.length > 0 ? chunks : [{ text: '', entities: [] }];
 }
 
 function renderSlackMrkdwn(text: string): string {
@@ -125,7 +445,7 @@ export function renderForPlatform(text: string, platform: BotPlatform): string {
 	const normalized = String(text ?? '').replace(/\r\n/g, '\n');
 	switch (platform) {
 		case 'telegram':
-			return renderTelegram(normalized);
+			return renderTelegramRichText(normalized).text;
 		case 'slack':
 			return renderSlackMrkdwn(normalized);
 		case 'discord':

--- a/main-src/bots/platforms/telegramAdapter.test.ts
+++ b/main-src/bots/platforms/telegramAdapter.test.ts
@@ -68,6 +68,7 @@ describe('TelegramBotAdapter', () => {
 	const tempDirs: string[] = [];
 
 	beforeEach(() => {
+		vi.useRealTimers();
 		setProxyMock.mockClear();
 		closeAllConnectionsMock.mockClear();
 		fromPartitionMock.mockClear();
@@ -181,5 +182,81 @@ describe('TelegramBotAdapter', () => {
 		expect(secondSerialized).toContain('name="document"');
 		expect(secondSerialized).toContain('filename="report.txt"');
 		expect(closeAllConnectionsMock).toHaveBeenCalled();
+	});
+
+	it('provides streamReply callbacks that send and edit progress messages', async () => {
+		vi.useFakeTimers();
+		let getUpdatesCalls = 0;
+		fetchMock.mockImplementation(async (url: string, options?: { signal?: AbortSignal; body?: string }) => {
+			if (url.endsWith('/getMe')) {
+				return jsonResponse(telegramOk({ username: 'async_bot' }));
+			}
+			if (url.endsWith('/getUpdates')) {
+				if (getUpdatesCalls === 0) {
+					getUpdatesCalls += 1;
+					return jsonResponse(
+						telegramOk([
+							{
+								update_id: 2,
+								message: {
+									message_id: 555,
+									text: 'stream please',
+									chat: { id: 10001, type: 'private' },
+									from: { id: 8, username: 'bob' },
+								},
+							},
+						])
+					);
+				}
+				return await abortablePending(options?.signal);
+			}
+			if (url.endsWith('/sendMessage')) {
+				return jsonResponse(telegramOk({ message_id: 777 }));
+			}
+			if (url.endsWith('/editMessageText')) {
+				return jsonResponse(telegramOk({ message_id: 777 }));
+			}
+			throw new Error(`Unexpected fetch URL: ${url}`);
+		});
+
+		const integration: BotIntegrationConfig = {
+			id: 'tg-stream',
+			name: 'Telegram',
+			platform: 'telegram',
+			telegram: {
+				botToken: 'secret-token',
+			},
+		};
+
+		const adapter = new TelegramBotAdapter(integration);
+		let resolveEnvelope: ((value: PlatformInboundEnvelope) => void) | null = null;
+		const envelopePromise = new Promise<PlatformInboundEnvelope>((resolve) => {
+			resolveEnvelope = resolve;
+		});
+
+		await adapter.start(async (envelope) => {
+			resolveEnvelope?.(envelope);
+		});
+		const envelope = await envelopePromise;
+		expect(envelope.streamReply).toBeTruthy();
+
+		await envelope.streamReply!.onStart();
+		await envelope.streamReply!.onDelta('正在打开页面');
+		await vi.advanceTimersByTimeAsync(1000);
+		await envelope.streamReply!.onToolStatus('Browser', 'running', '浏览器：navigate');
+		await vi.advanceTimersByTimeAsync(1000);
+		await envelope.streamReply!.onDone('最终完成');
+		await adapter.stop();
+
+		const sendMessageCalls = fetchMock.mock.calls.filter((call) => String(call[0]).endsWith('/sendMessage'));
+		const editCalls = fetchMock.mock.calls.filter((call) => String(call[0]).endsWith('/editMessageText'));
+		expect(sendMessageCalls.length).toBeGreaterThanOrEqual(1);
+		expect(editCalls.length).toBeGreaterThanOrEqual(1);
+
+		const firstSendBody = JSON.parse(String(sendMessageCalls[0]?.[1]?.body ?? '{}')) as Record<string, unknown>;
+		expect(String(firstSendBody.text ?? '')).toContain('处理中');
+
+		const lastEditBody = JSON.parse(String(editCalls.at(-1)?.[1]?.body ?? '{}')) as Record<string, unknown>;
+		expect(String(lastEditBody.text ?? '')).toContain('最终完成');
 	});
 });

--- a/main-src/bots/platforms/telegramAdapter.ts
+++ b/main-src/bots/platforms/telegramAdapter.ts
@@ -3,9 +3,18 @@ import FormData from 'form-data';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { BotIntegrationConfig } from '../../botSettingsTypes.js';
-import type { BotInboundAttachment, BotPlatformAdapter, PlatformMessageHandler } from './common.js';
-import { electronProxyRulesFromUrl, requestJson, resolveIntegrationProxyUrl, splitPlainText } from './common.js';
-import { renderForPlatform } from './platformMarkdown.js';
+import type {
+	BotInboundAttachment,
+	BotPlatformAdapter,
+	PlatformMessageHandler,
+	StreamReplyCallbacks,
+} from './common.js';
+import { electronProxyRulesFromUrl, requestJson, resolveIntegrationProxyUrl } from './common.js';
+import {
+	renderTelegramRichText,
+	splitTelegramRichText,
+	type TelegramRichText,
+} from './platformMarkdown.js';
 
 type TelegramUpdate = {
 	update_id: number;
@@ -40,6 +49,8 @@ type TelegramMessage = {
 };
 
 const DEDUP_TTL_MS = 10 * 60 * 1000;
+const TELEGRAM_STREAM_MAX_CHARS = 3500;
+const TELEGRAM_STREAM_EDIT_DEBOUNCE_MS = 900;
 
 export class TelegramBotAdapter implements BotPlatformAdapter {
 	readonly platform = 'telegram' as const;
@@ -205,6 +216,175 @@ export class TelegramBotAdapter implements BotPlatformAdapter {
 		}
 	}
 
+	private async sendTextReply(
+		message: TelegramMessage,
+		content: TelegramRichText,
+		options?: { replyToOriginal?: boolean }
+	): Promise<number> {
+		const payload: Record<string, unknown> = {
+			chat_id: message.chat.id,
+			text: content.text,
+		};
+		if (content.entities.length > 0) {
+			payload.entities = content.entities;
+		}
+		if (message.message_thread_id != null) {
+			payload.message_thread_id = message.message_thread_id;
+		}
+		if (options?.replyToOriginal !== false) {
+			payload.reply_to_message_id = message.message_id;
+		}
+		const result = await this.api<{ message_id?: number }>('sendMessage', payload);
+		return Number(result?.message_id ?? 0) || 0;
+	}
+
+	private async editTextMessage(
+		message: TelegramMessage,
+		targetMessageId: number,
+		content: TelegramRichText
+	): Promise<void> {
+		const payload: Record<string, unknown> = {
+			chat_id: message.chat.id,
+			message_id: targetMessageId,
+			text: content.text,
+		};
+		if (content.entities.length > 0) {
+			payload.entities = content.entities;
+		}
+		await this.api('editMessageText', payload);
+	}
+
+	private createStreamReply(message: TelegramMessage): StreamReplyCallbacks {
+		let streamMessageId: number | null = null;
+		let latestText = '';
+		let pendingText = '';
+		let flushTimer: ReturnType<typeof setTimeout> | null = null;
+		let lastFlushAt = 0;
+		const runningTools = new Map<string, string>();
+
+		const summarizeRunningTools = (): string => {
+			if (runningTools.size === 0) {
+				return '';
+			}
+			const items = Array.from(runningTools.entries())
+				.slice(-3)
+				.map(([name, detail]) => `- ${name}${detail ? `: ${detail}` : ''}`);
+			return ['进行中工具:', ...items].join('\n');
+		};
+
+		const buildStreamText = (fullText?: string): TelegramRichText => {
+			const base = String(fullText ?? latestText).trim();
+			const toolSummary = summarizeRunningTools();
+			const combined = base
+				? toolSummary
+					? `${base}\n\n${toolSummary}`
+					: base
+				: toolSummary || '处理中，请稍候...';
+			const rich = renderTelegramRichText(combined);
+			const chunks = splitTelegramRichText(rich, TELEGRAM_STREAM_MAX_CHARS);
+			if (chunks.length > 0 && chunks[0]) {
+				return chunks[0];
+			}
+			return { text: '处理中，请稍候...', entities: [] };
+		};
+
+		const flush = async (forceText?: string): Promise<void> => {
+			if (!streamMessageId) {
+				return;
+			}
+			const nextRich = buildStreamText(forceText);
+			if (!nextRich.text || nextRich.text === pendingText) {
+				return;
+			}
+			pendingText = nextRich.text;
+			lastFlushAt = Date.now();
+			await this.editTextMessage(message, streamMessageId, nextRich).catch(() => {});
+		};
+
+		const scheduleFlush = (): void => {
+			if (flushTimer) {
+				return;
+			}
+			const delay = Math.max(120, TELEGRAM_STREAM_EDIT_DEBOUNCE_MS - (Date.now() - lastFlushAt));
+			flushTimer = setTimeout(() => {
+				flushTimer = null;
+				void flush();
+			}, delay);
+		};
+
+		const clearFlushTimer = (): void => {
+			if (!flushTimer) {
+				return;
+			}
+			clearTimeout(flushTimer);
+			flushTimer = null;
+		};
+
+		return {
+			onStart: async () => {
+				const initial = renderTelegramRichText('处理中，请稍候...');
+				streamMessageId = await this.sendTextReply(message, initial);
+				pendingText = initial.text;
+				lastFlushAt = Date.now();
+			},
+			onDelta: async (fullText) => {
+				latestText = fullText;
+				if (!streamMessageId) {
+					return;
+				}
+				if (Date.now() - lastFlushAt >= TELEGRAM_STREAM_EDIT_DEBOUNCE_MS) {
+					clearFlushTimer();
+					await flush();
+					return;
+				}
+				scheduleFlush();
+			},
+			onToolStatus: (name, state, detail) => {
+				if (state === 'running') {
+					runningTools.set(name, String(detail ?? '').trim());
+				} else {
+					runningTools.delete(name);
+				}
+				if (streamMessageId) {
+					scheduleFlush();
+				}
+			},
+			onTodoUpdate: () => {
+				/* Telegram streaming keeps things lightweight; no-op for now. */
+			},
+			onDone: async (fullText) => {
+				clearFlushTimer();
+				runningTools.clear();
+				const renderedChunks = splitTelegramRichText(renderTelegramRichText(fullText), TELEGRAM_STREAM_MAX_CHARS);
+				if (!streamMessageId) {
+					for (const chunk of renderedChunks) {
+						await this.sendTextReply(message, chunk);
+					}
+					return;
+				}
+				if (renderedChunks.length === 0) {
+					await this.editTextMessage(message, streamMessageId, renderTelegramRichText('已完成。')).catch(() => {});
+					return;
+				}
+				await this.editTextMessage(message, streamMessageId, renderedChunks[0]!).catch(() => {});
+				for (const chunk of renderedChunks.slice(1)) {
+					await this.sendTextReply(message, chunk, { replyToOriginal: false }).catch(() => {});
+				}
+			},
+			onError: async (error) => {
+				clearFlushTimer();
+				const rendered = renderTelegramRichText(`❌ ${error}`);
+				if (!streamMessageId) {
+					await this.sendTextReply(message, rendered).catch(() => {});
+					return;
+				}
+				await this.editTextMessage(message, streamMessageId, rendered).catch(async () => {
+					await this.sendTextReply(message, rendered).catch(() => {});
+				});
+			},
+		};
+	}
+
 	async start(onMessage: PlatformMessageHandler): Promise<void> {
 		if (!this.token) {
 			return;
@@ -261,6 +441,7 @@ export class TelegramBotAdapter implements BotPlatformAdapter {
 						}
 						const threadReplyParams = message.message_thread_id ? { message_thread_id: message.message_thread_id } : {};
 						const threadKey = message.message_thread_id ? `${chatId}:${message.message_thread_id}` : chatId;
+						const streamReply = this.createStreamReply(message);
 						await onMessage({
 							conversationKey: threadKey,
 							messageId: String(message.message_id),
@@ -276,22 +457,13 @@ export class TelegramBotAdapter implements BotPlatformAdapter {
 								}).catch(() => {});
 							},
 							reply: async (text) => {
-								const rendered = renderForPlatform(text, 'telegram');
-								for (const chunk of splitPlainText(rendered, 3500)) {
-									await this.api('sendMessage', {
-										chat_id: message.chat.id,
-										text: chunk,
-										parse_mode: 'MarkdownV2',
-										reply_to_message_id: message.message_id,
-										...threadReplyParams,
-									}).catch(async () => {
-										await this.api('sendMessage', {
-											chat_id: message.chat.id,
-											text: chunk,
-											reply_to_message_id: message.message_id,
-											...threadReplyParams,
-										});
-									});
+								const rendered = splitTelegramRichText(renderTelegramRichText(text), TELEGRAM_STREAM_MAX_CHARS);
+								for (const [idx, chunk] of rendered.entries()) {
+									await this.sendTextReply(
+										message,
+										chunk,
+										{ replyToOriginal: idx === 0 }
+									);
 								}
 							},
 							replyImage: async (filePath) => {
@@ -300,6 +472,7 @@ export class TelegramBotAdapter implements BotPlatformAdapter {
 							replyFile: async (filePath) => {
 								await this.uploadReply('sendDocument', 'document', message, filePath);
 							},
+							streamReply,
 						});
 					}
 				} catch (error) {

--- a/main-src/browser/browserController.ts
+++ b/main-src/browser/browserController.ts
@@ -72,6 +72,31 @@ export type BrowserControlCommand =
 	  }
 	| {
 			commandId: string;
+			type: 'clickElement';
+			tabId?: string;
+			selector: string;
+			waitForLoad?: boolean;
+	  }
+	| {
+			commandId: string;
+			type: 'inputText';
+			tabId?: string;
+			selector: string;
+			text: string;
+			pressEnter?: boolean;
+			waitForLoad?: boolean;
+	  }
+	| {
+			commandId: string;
+			type: 'waitForSelector';
+			tabId?: string;
+			selector: string;
+			visible?: boolean;
+			waitForLoad?: boolean;
+			timeoutMs?: number;
+	  }
+	| {
+			commandId: string;
 			type: 'applyConfig';
 			config: BrowserSidebarConfigPayload;
 			defaultUserAgent?: string;

--- a/src/AgentRightSidebar.tsx
+++ b/src/AgentRightSidebar.tsx
@@ -99,6 +99,31 @@ type BrowserControlPayload =
 	  }
 	| {
 			commandId: string;
+			type: 'clickElement';
+			tabId?: string;
+			selector: string;
+			waitForLoad?: boolean;
+	  }
+	| {
+			commandId: string;
+			type: 'inputText';
+			tabId?: string;
+			selector: string;
+			text: string;
+			pressEnter?: boolean;
+			waitForLoad?: boolean;
+	  }
+	| {
+			commandId: string;
+			type: 'waitForSelector';
+			tabId?: string;
+			selector: string;
+			visible?: boolean;
+			waitForLoad?: boolean;
+			timeoutMs?: number;
+	  }
+	| {
+			commandId: string;
 			type: 'applyConfig';
 			config: Partial<BrowserSidebarSettingsConfig>;
 			defaultUserAgent?: string;
@@ -147,6 +172,28 @@ function isBrowserControlPayload(raw: unknown): raw is BrowserControlPayload {
 			return (
 				(obj.tabId === undefined || typeof obj.tabId === 'string') &&
 				(obj.waitForLoad === undefined || typeof obj.waitForLoad === 'boolean')
+			);
+		case 'clickElement':
+			return (
+				(obj.tabId === undefined || typeof obj.tabId === 'string') &&
+				typeof obj.selector === 'string' &&
+				(obj.waitForLoad === undefined || typeof obj.waitForLoad === 'boolean')
+			);
+		case 'inputText':
+			return (
+				(obj.tabId === undefined || typeof obj.tabId === 'string') &&
+				typeof obj.selector === 'string' &&
+				typeof obj.text === 'string' &&
+				(obj.pressEnter === undefined || typeof obj.pressEnter === 'boolean') &&
+				(obj.waitForLoad === undefined || typeof obj.waitForLoad === 'boolean')
+			);
+		case 'waitForSelector':
+			return (
+				(obj.tabId === undefined || typeof obj.tabId === 'string') &&
+				typeof obj.selector === 'string' &&
+				(obj.visible === undefined || typeof obj.visible === 'boolean') &&
+				(obj.waitForLoad === undefined || typeof obj.waitForLoad === 'boolean') &&
+				(obj.timeoutMs === undefined || typeof obj.timeoutMs === 'number')
 			);
 		case 'applyConfig':
 			return Boolean(obj.config && typeof obj.config === 'object');
@@ -1203,6 +1250,314 @@ const AgentRightSidebarBrowserPanel = memo(function AgentRightSidebarBrowserPane
 		[]
 	);
 
+	const clickElementInWebview = useCallback(
+		async (
+			node: AsyncShellWebviewElement,
+			options: { selector: string }
+		): Promise<Record<string, unknown>> => {
+			const script = `
+				(() => {
+					const args = ${JSON.stringify({ selector: options.selector })};
+					const target = document.querySelector(args.selector);
+					if (!target) {
+						return {
+							ok: false,
+							error: 'Selector did not match any element.',
+						};
+					}
+					if (!(target instanceof HTMLElement)) {
+						return {
+							ok: false,
+							error: 'Matched node is not an HTMLElement.',
+						};
+					}
+					target.scrollIntoView({ block: 'center', inline: 'center', behavior: 'instant' });
+					target.focus?.();
+					const rect = target.getBoundingClientRect();
+					const beforeUrl = location.href;
+					const beforeTitle = document.title || '';
+					if (typeof target.click === 'function') {
+						target.click();
+					} else {
+						target.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
+					}
+					return {
+						ok: true,
+						selector: args.selector,
+						tagName: target.tagName.toLowerCase(),
+						text: String(target.innerText || target.textContent || '').trim().slice(0, 500),
+						href: target instanceof HTMLAnchorElement ? target.href : '',
+						x: Math.round(rect.left + rect.width / 2),
+						y: Math.round(rect.top + rect.height / 2),
+						urlBefore: beforeUrl,
+						titleBefore: beforeTitle,
+						urlAfter: location.href,
+						titleAfter: document.title || '',
+					};
+				})()
+			`;
+			const result = await node.executeJavaScript<Record<string, unknown>>(script, true);
+			if (result?.ok === false) {
+				throw new Error(String(result.error ?? 'Failed to click element.'));
+			}
+			return {
+				url: String(result?.urlAfter ?? safeGetWebviewUrl(node)),
+				title: String(result?.titleAfter ?? ''),
+				selector: String(result?.selector ?? options.selector),
+				tagName: String(result?.tagName ?? ''),
+				text: String(result?.text ?? ''),
+				href: String(result?.href ?? ''),
+				clickPoint: {
+					x: Number(result?.x ?? 0) || 0,
+					y: Number(result?.y ?? 0) || 0,
+				},
+				urlBefore: String(result?.urlBefore ?? ''),
+				urlAfter: String(result?.urlAfter ?? safeGetWebviewUrl(node)),
+			};
+		},
+		[]
+	);
+
+	const inputTextInWebview = useCallback(
+		async (
+			node: AsyncShellWebviewElement,
+			options: { selector: string; text: string; pressEnter?: boolean }
+		): Promise<Record<string, unknown>> => {
+			const script = `
+				(() => {
+					const args = ${JSON.stringify({
+						selector: options.selector,
+						text: options.text,
+						pressEnter: options.pressEnter === true,
+					})};
+					const target = document.querySelector(args.selector);
+					if (!target) {
+						return {
+							ok: false,
+							error: 'Selector did not match any element.',
+						};
+					}
+					if (!(target instanceof HTMLElement)) {
+						return {
+							ok: false,
+							error: 'Matched node is not an HTMLElement.',
+						};
+					}
+					const dispatchInput = (el) => {
+						el.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }));
+						el.dispatchEvent(new Event('change', { bubbles: true, cancelable: true }));
+					};
+					const setNativeValue = (el, value) => {
+						const proto =
+							el instanceof HTMLTextAreaElement
+								? HTMLTextAreaElement.prototype
+								: el instanceof HTMLInputElement
+									? HTMLInputElement.prototype
+									: el instanceof HTMLSelectElement
+										? HTMLSelectElement.prototype
+										: null;
+						const descriptor = proto ? Object.getOwnPropertyDescriptor(proto, 'value') : null;
+						if (descriptor?.set) {
+							descriptor.set.call(el, value);
+						} else {
+							el.value = value;
+						}
+					};
+					target.scrollIntoView({ block: 'center', inline: 'center', behavior: 'instant' });
+					target.focus?.();
+					let mode = 'unknown';
+					if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement || target instanceof HTMLSelectElement) {
+						setNativeValue(target, args.text);
+						dispatchInput(target);
+						mode = target instanceof HTMLTextAreaElement ? 'textarea' : target instanceof HTMLSelectElement ? 'select' : 'input';
+					} else if (target.isContentEditable) {
+						target.textContent = args.text;
+						dispatchInput(target);
+						mode = 'contenteditable';
+					} else if ('value' in target) {
+						try {
+							target.value = args.text;
+							dispatchInput(target);
+							mode = 'value-property';
+						} catch {
+							target.textContent = args.text;
+							dispatchInput(target);
+							mode = 'textContent';
+						}
+					} else {
+						target.textContent = args.text;
+						dispatchInput(target);
+						mode = 'textContent';
+					}
+					if (args.pressEnter) {
+						const keyboardInit = {
+							key: 'Enter',
+							code: 'Enter',
+							keyCode: 13,
+							which: 13,
+							bubbles: true,
+							cancelable: true,
+						};
+						target.dispatchEvent(new KeyboardEvent('keydown', keyboardInit));
+						target.dispatchEvent(new KeyboardEvent('keypress', keyboardInit));
+						target.dispatchEvent(new KeyboardEvent('keyup', keyboardInit));
+						const form = target.closest('form');
+						if (form instanceof HTMLFormElement) {
+							if (typeof form.requestSubmit === 'function') {
+								form.requestSubmit();
+							} else {
+								form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+							}
+						}
+					}
+					const value =
+						target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement || target instanceof HTMLSelectElement
+							? target.value
+							: target.isContentEditable
+								? String(target.textContent || '')
+								: 'value' in target
+									? String(target.value ?? '')
+									: String(target.textContent || '');
+					return {
+						ok: true,
+						selector: args.selector,
+						mode,
+						tagName: target.tagName.toLowerCase(),
+						value,
+						pressEnter: args.pressEnter,
+						url: location.href,
+						title: document.title || '',
+					};
+				})()
+			`;
+			const result = await node.executeJavaScript<Record<string, unknown>>(script, true);
+			if (result?.ok === false) {
+				throw new Error(String(result.error ?? 'Failed to input text.'));
+			}
+			return {
+				url: String(result?.url ?? safeGetWebviewUrl(node)),
+				title: String(result?.title ?? ''),
+				selector: String(result?.selector ?? options.selector),
+				mode: String(result?.mode ?? ''),
+				tagName: String(result?.tagName ?? ''),
+				value: String(result?.value ?? options.text),
+				pressEnter: result?.pressEnter === true,
+			};
+		},
+		[]
+	);
+
+	const waitForSelectorInWebview = useCallback(
+		async (
+			node: AsyncShellWebviewElement,
+			options: { selector: string; visible?: boolean; timeoutMs?: number }
+		): Promise<Record<string, unknown>> => {
+			const timeoutMs = Math.min(Math.max(500, Math.floor(options.timeoutMs ?? 20_000)), 60_000);
+			const script = `
+				(() => {
+					const args = ${JSON.stringify({
+						selector: options.selector,
+						visible: options.visible === true,
+						timeoutMs,
+					})};
+					const root = document.documentElement || document.body;
+					if (!root) {
+						return Promise.resolve({
+							ok: false,
+							error: 'Document root is unavailable.',
+						});
+					}
+					const isVisible = (el) => {
+						if (!(el instanceof HTMLElement)) {
+							return false;
+						}
+						const style = window.getComputedStyle(el);
+						if (!style || style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') {
+							return false;
+						}
+						const rect = el.getBoundingClientRect();
+						return rect.width > 0 && rect.height > 0;
+					};
+					const snapshot = (el) => {
+						const rect = el instanceof HTMLElement ? el.getBoundingClientRect() : { width: 0, height: 0 };
+						return {
+							ok: true,
+							selector: args.selector,
+							tagName: el instanceof Element ? el.tagName.toLowerCase() : '',
+							text: el instanceof Element ? String(el.innerText || el.textContent || '').trim().slice(0, 500) : '',
+							visible: isVisible(el),
+							url: location.href,
+							title: document.title || '',
+							width: Math.round(rect.width || 0),
+							height: Math.round(rect.height || 0),
+						};
+					};
+					const findMatch = () => {
+						const el = document.querySelector(args.selector);
+						if (!el) {
+							return null;
+						}
+						if (args.visible && !isVisible(el)) {
+							return null;
+						}
+						return el;
+					};
+					const immediate = findMatch();
+					if (immediate) {
+						return Promise.resolve(snapshot(immediate));
+					}
+					return new Promise((resolve) => {
+						const observer = new MutationObserver(() => {
+							const match = findMatch();
+							if (!match) {
+								return;
+							}
+							cleanup();
+							resolve(snapshot(match));
+						});
+						const cleanup = () => {
+							window.clearTimeout(timer);
+							observer.disconnect();
+						};
+						const timer = window.setTimeout(() => {
+							cleanup();
+							resolve({
+								ok: false,
+								error: args.visible
+									? 'Timed out waiting for a visible element matching the selector.'
+									: 'Timed out waiting for an element matching the selector.',
+							});
+						}, args.timeoutMs);
+						observer.observe(root, {
+							childList: true,
+							subtree: true,
+							attributes: true,
+							attributeFilter: ['class', 'style', 'hidden', 'aria-hidden'],
+						});
+					});
+				})()
+			`;
+			const result = await node.executeJavaScript<Record<string, unknown>>(script, true);
+			if (result?.ok === false) {
+				throw new Error(String(result.error ?? 'Failed while waiting for selector.'));
+			}
+			return {
+				url: String(result?.url ?? safeGetWebviewUrl(node)),
+				title: String(result?.title ?? ''),
+				selector: String(result?.selector ?? options.selector),
+				tagName: String(result?.tagName ?? ''),
+				text: String(result?.text ?? ''),
+				visible: result?.visible === true,
+				size: {
+					width: Number(result?.width ?? 0) || 0,
+					height: Number(result?.height ?? 0) || 0,
+				},
+				timeoutMs,
+			};
+		},
+		[]
+	);
+
 	const captureWebviewScreenshot = useCallback(async (node: AsyncShellWebviewElement): Promise<Record<string, unknown>> => {
 		const image = await node.capturePage();
 		const size = image.getSize();
@@ -1565,7 +1920,13 @@ const AgentRightSidebarBrowserPanel = memo(function AgentRightSidebarBrowserPane
 					? command.tabId
 					: activeTabIdRef.current;
 			if (!targetTabId) {
-				if (command.type === 'readPage' || command.type === 'screenshotPage') {
+				if (
+					command.type === 'readPage' ||
+					command.type === 'screenshotPage' ||
+					command.type === 'clickElement' ||
+					command.type === 'inputText' ||
+					command.type === 'waitForSelector'
+				) {
 					await notifyBrowserCommandResult(shell, {
 						commandId: command.commandId,
 						ok: false,
@@ -1581,7 +1942,13 @@ const AgentRightSidebarBrowserPanel = memo(function AgentRightSidebarBrowserPane
 				return;
 			}
 			setActiveTabId(targetTabId);
-			if (command.type === 'readPage' || command.type === 'screenshotPage') {
+			if (
+				command.type === 'readPage' ||
+				command.type === 'screenshotPage' ||
+				command.type === 'clickElement' ||
+				command.type === 'inputText' ||
+				command.type === 'waitForSelector'
+			) {
 				try {
 					const node = await waitForWebviewNode(targetTabId);
 					if (command.waitForLoad !== false) {
@@ -1592,6 +1959,45 @@ const AgentRightSidebarBrowserPanel = memo(function AgentRightSidebarBrowserPane
 							selector: command.selector,
 							includeHtml: command.includeHtml,
 							maxChars: command.maxChars,
+						});
+						await notifyBrowserCommandResult(shell, {
+							commandId: command.commandId,
+							ok: true,
+							result,
+						});
+					} else if (command.type === 'clickElement') {
+						const result = await clickElementInWebview(node, {
+							selector: command.selector,
+						});
+						if (command.waitForLoad !== false) {
+							await new Promise((resolve) => window.setTimeout(resolve, 60));
+							await waitForWebviewSettled(node, targetTabId);
+						}
+						await notifyBrowserCommandResult(shell, {
+							commandId: command.commandId,
+							ok: true,
+							result,
+						});
+					} else if (command.type === 'inputText') {
+						const result = await inputTextInWebview(node, {
+							selector: command.selector,
+							text: command.text,
+							pressEnter: command.pressEnter,
+						});
+						if (command.waitForLoad !== false && command.pressEnter) {
+							await new Promise((resolve) => window.setTimeout(resolve, 60));
+							await waitForWebviewSettled(node, targetTabId);
+						}
+						await notifyBrowserCommandResult(shell, {
+							commandId: command.commandId,
+							ok: true,
+							result,
+						});
+					} else if (command.type === 'waitForSelector') {
+						const result = await waitForSelectorInWebview(node, {
+							selector: command.selector,
+							visible: command.visible,
+							timeoutMs: command.timeoutMs,
 						});
 						await notifyBrowserCommandResult(shell, {
 							commandId: command.commandId,
@@ -1635,13 +2041,16 @@ const AgentRightSidebarBrowserPanel = memo(function AgentRightSidebarBrowserPane
 	}, [
 		applyBrowserConfigLocally,
 		captureWebviewScreenshot,
+		clickElementInWebview,
 		closeTab,
+		inputTextInWebview,
 		navigateTab,
 		onCommandHandled,
 		openInNewTab,
 		pendingCommand,
 		readPageFromWebview,
 		shell,
+		waitForSelectorInWebview,
 		waitForWebviewNode,
 		waitForWebviewSettled,
 	]);

--- a/src/agentStructuredMessage.test.ts
+++ b/src/agentStructuredMessage.test.ts
@@ -322,19 +322,36 @@ describe('extractBotReplyText', () => {
 		expect(extractBotReplyText(outerRaw)).toBe('Main text.');
 	});
 
+	it('returns a short summary instead of raw JSON for tool-only bot replies', () => {
+		const outerRaw = stringifyAgentAssistantPayload({
+			_asyncAssistant: 1,
+			v: 1,
+			parts: [
+				{
+					type: 'tool',
+					toolUseId: 'call_session',
+					name: 'get_async_session',
+					args: {},
+					result: '{"workspace":"demo"}',
+					success: true,
+				},
+			],
+		});
+		expect(extractBotReplyText(outerRaw)).toBe('已读取当前 Async 会话信息。');
+	});
+
 	it('returns raw input for invalid structured message', () => {
 		const malformed = '{"_asyncAssistant":1,"v":1,"parts":"not-an-array"}';
 		expect(extractBotReplyText(malformed)).toBe(malformed);
 	});
 
-	it('returns raw input when structured message has empty parts', () => {
+	it('returns empty string when structured message has empty parts', () => {
 		const raw = stringifyAgentAssistantPayload({
 			_asyncAssistant: 1,
 			v: 1,
 			parts: [],
 		});
-		// No text, no tool results → falls through to return raw
-		expect(extractBotReplyText(raw)).toBe(raw);
+		expect(extractBotReplyText(raw)).toBe('');
 	});
 });
 

--- a/src/agentStructuredMessage.ts
+++ b/src/agentStructuredMessage.ts
@@ -249,6 +249,55 @@ function stripBotTaskResultMetadata(result: string): string {
 	return i > 0 ? lines.slice(i).join('\n') : result;
 }
 
+function summarizeBotToolOnlyReply(parts: AgentAssistantPart[]): string {
+	const toolParts = parts.filter((part): part is AgentAssistantToolPart => part.type === 'tool');
+	if (toolParts.length === 0) {
+		return '';
+	}
+	return toolParts
+		.map((part) => {
+			const ok = part.success === true;
+			switch (part.name) {
+				case 'get_async_session':
+					return ok ? '已读取当前 Async 会话信息。' : '读取当前 Async 会话信息失败。';
+				case 'switch_workspace':
+					return ok ? part.result.trim() || '已切换工作区。' : `切换工作区失败：${part.result.trim()}`;
+				case 'switch_model':
+					return ok ? part.result.trim() || '已切换模型。' : `切换模型失败：${part.result.trim()}`;
+				case 'new_async_thread':
+					return ok ? part.result.trim() || '已创建新的内部线程。' : `创建内部线程失败：${part.result.trim()}`;
+				case 'send_local_attachment':
+					return ok ? part.result.trim() || '已发送附件给用户。' : `发送附件失败：${part.result.trim()}`;
+				case 'pause_for_qr_login':
+					return ok ? '已发送二维码登录截图，正在等待用户扫码。' : `二维码登录等待失败：${part.result.trim()}`;
+				case 'Browser': {
+					const action = String(part.args.action ?? '').trim();
+					return ok
+						? action
+							? `已执行浏览器操作：${action}。`
+							: '已执行浏览器操作。'
+						: action
+							? `浏览器操作失败：${action}。`
+							: '浏览器操作失败。';
+				}
+				case 'BrowserCapture': {
+					const action = String(part.args.action ?? '').trim();
+					return ok
+						? action
+							? `已执行浏览器抓包操作：${action}。`
+							: '已执行浏览器抓包操作。'
+						: action
+							? `浏览器抓包操作失败：${action}。`
+							: '浏览器抓包操作失败。';
+				}
+				default:
+					return ok ? `已执行工具：${part.name}。` : `工具执行失败：${part.name}。`;
+			}
+		})
+		.join('\n')
+		.trim();
+}
+
 /**
  * 从机器人 orchestrator 返回的结构化 JSON 中提取对外展示的纯文本/markdown。
  *
@@ -292,7 +341,12 @@ export function extractBotReplyText(raw: string): string {
 	const outerText = outerTexts.join('').trim();
 	if (outerText) return outerText;
 
-	return raw;
+	const toolOnlySummary = summarizeBotToolOnlyReply(payload.parts);
+	if (toolOnlySummary) {
+		return toolOnlySummary;
+	}
+
+	return '';
 }
 
 function collectBotScreenshotPathsFromPayload(payload: AgentAssistantPayload, out: string[]): void {


### PR DESCRIPTION
Summary

This branch adds a BrowserCapture HTTP tool for the agent and wires browser controller support for capture flows. The editor menubar is adjusted back to the agent layout and the AgentRightSidebar gains related UI.

Telegram bot integration is updated with a fuller markdown pipeline aligned with entity based message sending plus new tests for markdown and the Telegram adapter.

Bot runtime and controller changes improve how streamed replies are shown when the model emits structured JSON. Tool only assistant payloads now produce short user facing summaries instead of raw JSON and partial structured streams show a loading style placeholder instead of leaking JSON. extractBotReplyText behavior for empty or tool only structured messages is covered by tests.

Files touched span agent tools and executor browser controller bot runtime and platform adapters plus structured message helpers and sidebar UI.