### PR TITLE
feat: Anthropic deferred tools, turn tool-result budget, and chat turn-focus UX

### DIFF
--- a/main-src/agent/agentLoop.ts
+++ b/main-src/agent/agentLoop.ts
@@ -16,19 +16,20 @@
 import OpenAI from 'openai';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import Anthropic from '@anthropic-ai/sdk';
-import type { MessageParam, ContentBlockParam, ToolResultBlockParam } from '@anthropic-ai/sdk/resources/messages';
-import type { ChatMessage } from '../threadStore.js';
+import type { MessageParam, ContentBlockParam } from '@anthropic-ai/sdk/resources/messages';
+import type { ChatMessage, DeferredToolState } from '../threadStore.js';
 import type { ShellSettings, ModelRequestParadigm, ThinkingLevel } from '../settingsStore.js';
 import {
 	assembleAgentToolPool,
 	assembleVisibleAgentToolPool,
 	filterMcpToolsByDenyPrefixes,
+	isDeferredAgentTool,
 } from './agentToolPool.js';
 import type { TurnTokenUsage } from '../llm/types.js';
 import { llmSdkResponseHeadTimeoutMs } from '../llm/sdkResponseHeadTimeoutMs.js';
 import { withLlmTransportRetry } from '../llm/llmTransportRetry.js';
 import { formatLlmSdkError } from '../llm/formatLlmSdkError.js';
-import { composeSystem, temperatureForMode } from '../llm/modePrompts.js';
+import { composeSystem, composeSystemSections, temperatureForMode } from '../llm/modePrompts.js';
 import {
 	anthropicEffectiveMaxTokens,
 	anthropicEffectiveTemperature,
@@ -40,6 +41,7 @@ import {
 	buildAnthropicSystemForApi,
 	isAnthropicPromptCachingEnabled,
 } from '../llm/anthropicPromptCache.js';
+import type { AnthropicToolResultBlock, AnthropicToolSchema } from '../llm/anthropicBeta.js';
 import type { ComposerMode } from '../llm/composerMode.js';
 import {
 	agentToolsForComposerMode,
@@ -78,7 +80,8 @@ import {
 } from './structuredAssistantToApi.js';
 import type { MistakeLimitContext, MistakeLimitDecision } from './mistakeLimitGate.js';
 import { resolveStreamTimeouts, createStreamTimeoutManager } from '../llm/streamTimeouts.js';
-import { persistLargeToolResultIfNeeded } from './toolResultPersistence.js';
+import { applyTurnToolResultBudget, normalizeToolResultReplacementState, type ToolResultReplacementState } from './toolResultBudget.js';
+import { analyzeToolContext, shouldEnableAnthropicNativeDefer } from './toolContextAnalysis.js';
 
 export type { MistakeLimitContext, MistakeLimitDecision } from './mistakeLimitGate.js';
 
@@ -205,6 +208,7 @@ export type AgentLoopOptions = {
 	/** OpenAI 兼容：提供商级代理 */
 	requestProxyUrl?: string;
 	maxOutputTokens: number;
+	contextWindowTokens?: number;
 	signal: AbortSignal;
 	/** 与主界面 Composer 模式一致；Plan 仅注册只读工具 */
 	composerMode: ComposerMode;
@@ -220,10 +224,16 @@ export type AgentLoopOptions = {
 			execCtx: ToolExecutionContext
 		) => Promise<ToolResult> | ToolResult
 	>;
-	/** 线程级延迟工具发现状态（当前主要用于动态 MCP 工具）。 */
+	/** 线程级延迟工具发现状态（优先于旧的 discoveredDeferredToolNames 传递）。 */
+	deferredToolState?: DeferredToolState;
+	/** 兼容旧调用方：若未提供 deferredToolState，则退回使用此字段。 */
 	discoveredDeferredToolNames?: string[];
 	/** 当 ToolSearch 加载了新工具后回调，用于把状态持久化到线程。 */
+	onDeferredToolStateChange?: (state: DeferredToolState) => void;
+	/** 兼容旧调用方：若设置，会在 deferred state 更新后同步回调 discoveredToolNames。 */
 	onDiscoveredDeferredToolsChange?: (names: string[]) => void;
+	toolResultReplacementState?: ToolResultReplacementState;
+	onToolResultReplacementStateChange?: (state: ToolResultReplacementState) => void;
 	/** 在 executeTool 之前调用；用于 shell 写入等需用户确认的闸门 */
 	beforeExecuteTool?: (call: ToolCall) => Promise<BeforeExecuteToolResult>;
 	thinkingLevel?: ThinkingLevel;
@@ -332,16 +342,56 @@ function agentToolDefsForLoop(
 	});
 }
 
+function normalizeToolNameList(values: Iterable<string>): string[] {
+	return [...new Set(Array.from(values).map((value) => String(value ?? '').trim()).filter(Boolean))].sort((a, b) =>
+		a.localeCompare(b)
+	);
+}
+
+function normalizeDeferredToolStateForLoop(
+	state?: DeferredToolState | null,
+	discoveredDeferredToolNames?: string[]
+): DeferredToolState {
+	return {
+		discoveredToolNames: normalizeToolNameList([
+			...(state?.discoveredToolNames ?? []),
+			...(discoveredDeferredToolNames ?? []),
+		]),
+		...(state?.providerLoadedToolNames
+			? {
+					providerLoadedToolNames: {
+						...(state.providerLoadedToolNames.anthropic?.length
+							? { anthropic: normalizeToolNameList(state.providerLoadedToolNames.anthropic) }
+							: {}),
+						...(state.providerLoadedToolNames.openai?.length
+							? { openai: normalizeToolNameList(state.providerLoadedToolNames.openai) }
+							: {}),
+					},
+				}
+			: {}),
+	};
+}
+
+function emitDeferredToolStateChange(
+	options: AgentLoopOptions,
+	state: DeferredToolState
+): void {
+	options.onDeferredToolStateChange?.(state);
+	options.onDiscoveredDeferredToolsChange?.(state.discoveredToolNames);
+}
+
 function visibleAgentToolDefsForLoop(
 	composerMode: ComposerMode,
 	settings: ShellSettings,
 	discoveredDeferredToolNames: Iterable<string>,
-	override?: AgentToolDef[]
+	override?: AgentToolDef[],
+	nativeDeferEnabled?: boolean
 ): AgentToolDef[] {
 	return assembleVisibleAgentToolPool(composerMode, {
 		mcpToolDenyPrefixes: settings.mcpToolDenyPrefixes,
 		discoveredDeferredToolNames,
 		override,
+		nativeDeferEnabled,
 	});
 }
 
@@ -361,14 +411,20 @@ function appendMcpToolsSystemHint(
 	if (n === 0) {
 		return systemContent;
 	}
-	return [
-		systemContent,
-		'',
+	const hint = [
 		`## MCP tools (${n})`,
 		'Additional tools from configured Model Context Protocol servers use names prefixed `mcp__`.',
 		'Most MCP tools are loaded on demand. Use `ToolSearch` to discover and load the relevant MCP tool before calling it directly.',
 		'Use `ListMcpResourcesTool` / `ReadMcpResourceTool` to browse MCP resources when needed.',
 		'Use them when the user needs integrations beyond the built-in workspace tools (e.g. web, APIs, databases). Follow each tool\'s description and parameter schema.',
+	].join('\n');
+	if (!systemContent.trim()) {
+		return hint;
+	}
+	return [
+		systemContent,
+		'',
+		hint,
 	].join('\n');
 }
 
@@ -592,7 +648,11 @@ async function runOpenAILoop(
 		settings
 	);
 	const temperature = temperatureForMode(options.composerMode);
-	const discoveredDeferredToolNames = new Set(options.discoveredDeferredToolNames ?? []);
+	let deferredToolState = normalizeDeferredToolStateForLoop(
+		options.deferredToolState,
+		options.discoveredDeferredToolNames
+	);
+	const discoveredDeferredToolNames = new Set(deferredToolState.discoveredToolNames);
 	const markDeferredToolsDiscovered = (names: string[]): string[] => {
 		const added: string[] = [];
 		for (const name of names) {
@@ -604,9 +664,18 @@ async function runOpenAILoop(
 			added.push(trimmed);
 		}
 		if (added.length > 0) {
-			options.onDiscoveredDeferredToolsChange?.(
-				[...discoveredDeferredToolNames].sort((a, b) => a.localeCompare(b))
-			);
+			deferredToolState = normalizeDeferredToolStateForLoop({
+				...deferredToolState,
+				discoveredToolNames: [...discoveredDeferredToolNames],
+				providerLoadedToolNames: {
+					...(deferredToolState.providerLoadedToolNames ?? {}),
+					openai: normalizeToolNameList([
+						...(deferredToolState.providerLoadedToolNames?.openai ?? []),
+						...added,
+					]),
+				},
+			});
+			emitDeferredToolStateChange(options, deferredToolState);
 		}
 		return added;
 	};
@@ -619,6 +688,7 @@ async function runOpenAILoop(
 			discoveredDeferredToolNames,
 			options.toolPoolOverride
 		);
+	const resolveToolDefsByName = () => new Map(resolveFullToolPool().map((tool) => [tool.name, tool] as const));
 	const mergedCustomToolHandlers = {
 		ToolSearch: createToolSearchToolHandler({
 			resolveFullToolPool,
@@ -637,14 +707,47 @@ async function runOpenAILoop(
 	const mistakeLimitEnabled = options.mistakeLimitEnabled !== false;
 	const threshold = options.maxConsecutiveMistakes ?? DEFAULT_MAX_CONSECUTIVE_MISTAKES;
 	let consecutiveToolFailures = 0;
+	let toolResultReplacementState = normalizeToolResultReplacementState(
+		options.toolResultReplacementState
+	);
 
 	const MAX_OUTPUT_RECOVERY_LIMIT = 3;
 	let outputRecoveryCount = 0;
 
 	type TurnTc = { id: string; name: string; arguments: string };
+	type OpenAIToolExecution = {
+		call: TurnTc;
+		args: Record<string, unknown>;
+		result: ToolResult;
+	};
 
 	const toolDeltaBatcher = createToolInputDeltaBatcher((p) => handlers.onToolInputDelta?.(p));
 	const maxToolArgChars = maxStreamingToolArgChars();
+	const toolExecCtx: ToolExecutionContext = {
+		delegateExecutionDepth: options.delegateExecutionDepth ?? 0,
+		workspaceRoot: options.workspaceRoot ?? null,
+		workspaceLspManager: options.workspaceLspManager ?? null,
+		threadId: options.threadId ?? null,
+		hostWebContentsId: options.hostWebContentsId ?? null,
+		signal: options.signal,
+		teamToolRoleScope: options.teamToolRoleScope,
+		customToolHandlers: mergedCustomToolHandlers,
+	};
+	const resolveAnthropicApiTools = (): AnthropicToolSchema[] => {
+		const visibleToolPool = resolveVisibleToolPool();
+		if (!nativeAnthropicDeferEnabled) {
+			return toAnthropicTools(visibleToolPool);
+		}
+		const deferToolNames = new Set(
+			resolveFullToolPool()
+				.filter((tool) => isDeferredAgentTool(tool) && !discoveredDeferredToolNames.has(tool.name))
+				.map((tool) => tool.name)
+		);
+		return toAnthropicTools(visibleToolPool, {
+			deferToolNames,
+			includeExperimentalBetaFields: nativeAnthropicDeferEnabled,
+		});
+	};
 
 	async function handleMistakeLimitBeforeRound(): Promise<boolean> {
 		if (!mistakeLimitEnabled || consecutiveToolFailures < threshold) {
@@ -674,16 +777,18 @@ async function runOpenAILoop(
 		return false;
 	}
 
-	async function runOneOpenAITool(tc: TurnTc): Promise<OpenAI.Chat.ChatCompletionToolMessageParam> {
+	async function runOneOpenAITool(tc: TurnTc): Promise<OpenAIToolExecution> {
 		let args: Record<string, unknown>;
 		try {
 			args = JSON.parse(tc.arguments || '{}');
 		} catch (parseErr) {
 			const msg = `工具参数 JSON 无效：${parseErr instanceof Error ? parseErr.message : String(parseErr)}。请提供合法的 JSON。`;
 			if (mistakeLimitEnabled) consecutiveToolFailures++;
-			structured.pushTool(tc.id, tc.name, {}, msg, false);
-			handlers.onToolResult(tc.name, msg, false, tc.id);
-			return { role: 'tool', tool_call_id: tc.id, content: msg };
+			return {
+				call: tc,
+				args: {},
+				result: { toolCallId: tc.id, name: tc.name, content: msg, isError: true },
+			};
 		}
 
 		const toolCall: ToolCall = { id: tc.id, name: tc.name, arguments: args };
@@ -708,51 +813,34 @@ async function runOpenAILoop(
 		if (!gate.proceed) {
 			const msg = gate.rejectionMessage;
 			if (mistakeLimitEnabled) consecutiveToolFailures++;
-			structured.pushTool(tc.id, tc.name, args, msg, false);
-			handlers.onToolResult(tc.name, msg, false, tc.id);
-			return { role: 'tool', tool_call_id: tc.id, content: msg };
+			return {
+				call: tc,
+				args,
+				result: { toolCallId: tc.id, name: tc.name, content: msg, isError: true },
+			};
 		}
 
 		handlers.onToolProgress?.({ name: tc.name, phase: 'executing' });
 		const execStart = Date.now();
 		console.log(`[AgentLoop] tool=${tc.name} — executeTool start`);
-		const result = await executeTool(toolCall, options.toolHooks, {
-			delegateExecutionDepth: options.delegateExecutionDepth ?? 0,
-			workspaceRoot: options.workspaceRoot ?? null,
-			workspaceLspManager: options.workspaceLspManager ?? null,
-			threadId: options.threadId ?? null,
-			hostWebContentsId: options.hostWebContentsId ?? null,
-			signal: options.signal,
-			teamToolRoleScope: options.teamToolRoleScope,
-			customToolHandlers: mergedCustomToolHandlers,
-		});
-		const persistedResult = await persistLargeToolResultIfNeeded(result, {
-			delegateExecutionDepth: options.delegateExecutionDepth ?? 0,
-			workspaceRoot: options.workspaceRoot ?? null,
-			workspaceLspManager: options.workspaceLspManager ?? null,
-			threadId: options.threadId ?? null,
-			hostWebContentsId: options.hostWebContentsId ?? null,
-			signal: options.signal,
-			teamToolRoleScope: options.teamToolRoleScope,
-			customToolHandlers: mergedCustomToolHandlers,
-		});
-		console.log(`[AgentLoop] tool=${tc.name} — executeTool done (${Date.now() - execStart}ms, error=${persistedResult.isError})`);
+		const result = await executeTool(toolCall, options.toolHooks, toolExecCtx);
+		console.log(`[AgentLoop] tool=${tc.name} — executeTool done (${Date.now() - execStart}ms, error=${result.isError})`);
 		if (mistakeLimitEnabled) {
-			if (persistedResult.isError) {
+			if (result.isError) {
 				consecutiveToolFailures++;
 			} else {
 				consecutiveToolFailures = 0;
 			}
 		}
 
-		structured.pushTool(tc.id, tc.name, args, persistedResult.content, !persistedResult.isError);
-		handlers.onToolResult(tc.name, persistedResult.content, !persistedResult.isError, tc.id);
-
-		return { role: 'tool', tool_call_id: tc.id, content: persistedResult.content };
+		return { call: tc, args, result };
 	}
 
-	async function flushOpenAIToolsInOrder(turnToolCalls: TurnTc[]): Promise<void> {
+	async function flushOpenAIToolsInOrder(
+		turnToolCalls: TurnTc[]
+	): Promise<OpenAI.Chat.ChatCompletionToolMessageParam[]> {
 		const withNames = turnToolCalls.filter((tc) => tc.name);
+		const executed: OpenAIToolExecution[] = [];
 		let i = 0;
 		while (i < withNames.length) {
 			const cur = withNames[i]!;
@@ -766,16 +854,46 @@ async function runOpenAILoop(
 					batch.map((b) => () => runOneOpenAITool(b)),
 					MAX_TOOL_CONCURRENCY
 				);
-				for (const msg of outs) {
-					conversation.push(msg);
-				}
+				executed.push(...outs);
 				i = j;
 			} else {
-				const msg = await runOneOpenAITool(cur);
-				conversation.push(msg);
+				executed.push(await runOneOpenAITool(cur));
 				i++;
 			}
 		}
+		if (executed.length === 0) {
+			return [];
+		}
+		const budgeted = await applyTurnToolResultBudget(
+			executed.map((item) => item.result),
+			resolveToolDefsByName(),
+			toolResultReplacementState,
+			toolExecCtx
+		);
+		toolResultReplacementState = budgeted.state;
+		options.onToolResultReplacementStateChange?.(toolResultReplacementState);
+		return executed.map((item, index) => {
+			const adjusted = budgeted.results[index]!;
+			structured.pushTool(
+				item.call.id,
+				item.call.name,
+				item.args,
+				adjusted.content,
+				!adjusted.isError,
+				adjusted.structuredContent
+			);
+			handlers.onToolResult(
+				item.call.name,
+				adjusted.content,
+				!adjusted.isError,
+				item.call.id
+			);
+			return {
+				role: 'tool',
+				tool_call_id: item.call.id,
+				content: adjusted.content,
+			};
+		});
 	}
 
 	const streamTimeoutConfig = resolveStreamTimeouts(settings);
@@ -979,7 +1097,8 @@ async function runOpenAILoop(
 
 		console.log(`[AgentLoop] round ${round} — executing ${turnToolCalls.filter(tc => tc.name).length} tool(s)`);
 		const toolsStart = Date.now();
-		await flushOpenAIToolsInOrder(turnToolCalls);
+		const toolMessages = await flushOpenAIToolsInOrder(turnToolCalls);
+		conversation.push(...toolMessages);
 		console.log(`[AgentLoop] round ${round} — tools done (${Date.now() - toolsStart}ms)`);
 
 		if (maxRounds != null && round === maxRounds - 1) {
@@ -1053,23 +1172,43 @@ async function runAnthropicLoop(
 		})
 	);
 	const storedSystem = threadMessages.find((m) => m.role === 'system');
-	const systemText = appendMcpToolsSystemHint(
-		prependProviderIdentitySystemPrompt(
-			settings,
-			composeSystem(storedSystem?.content, options.composerMode, options.agentSystemAppend)
-		),
-		options.composerMode,
-		settings
-	);
 	const model = options.requestModelId.trim();
 	if (!model) { handlers.onError('模型请求名称为空。'); return; }
 	const anthropicPromptCaching = isAnthropicPromptCachingEnabled(model);
-	const system = buildAnthropicSystemForApi(systemText, anthropicPromptCaching);
+	const systemSectionsBase = composeSystemSections(
+		storedSystem?.content,
+		options.composerMode,
+		options.agentSystemAppend
+	);
+	const staticSystemText = prependProviderIdentitySystemPrompt(
+		settings,
+		systemSectionsBase.staticText
+	);
+	const dynamicSystemText = appendMcpToolsSystemHint(
+		systemSectionsBase.dynamicText,
+		options.composerMode,
+		settings
+	);
+	const system = buildAnthropicSystemForApi(
+		{
+			staticText: staticSystemText,
+			dynamicText: dynamicSystemText,
+			fullText: [staticSystemText, dynamicSystemText].filter(Boolean).join('\n\n---\n'),
+		},
+		anthropicPromptCaching
+	);
 	let conversation: MessageParam[] = normalizeAnthropicMessagesForApi(threadToAnthropic(threadMessages));
 	conversation = repairAnthropicToolPairing(conversation);
 	conversation = mergeAdjacentAnthropicUserMessages(conversation);
 	if (conversation.length === 0) { handlers.onError('没有可发送的对话消息。'); return; }
-	const discoveredDeferredToolNames = new Set(options.discoveredDeferredToolNames ?? []);
+	let deferredToolState = normalizeDeferredToolStateForLoop(
+		options.deferredToolState,
+		options.discoveredDeferredToolNames
+	);
+	const discoveredDeferredToolNames = new Set(deferredToolState.discoveredToolNames);
+	let toolResultReplacementState = normalizeToolResultReplacementState(
+		options.toolResultReplacementState
+	);
 	const markDeferredToolsDiscovered = (names: string[]): string[] => {
 		const added: string[] = [];
 		for (const name of names) {
@@ -1081,25 +1220,79 @@ async function runAnthropicLoop(
 			added.push(trimmed);
 		}
 		if (added.length > 0) {
-			options.onDiscoveredDeferredToolsChange?.(
-				[...discoveredDeferredToolNames].sort((a, b) => a.localeCompare(b))
-			);
+			deferredToolState = normalizeDeferredToolStateForLoop({
+				...deferredToolState,
+				discoveredToolNames: [...discoveredDeferredToolNames],
+				providerLoadedToolNames: {
+					...(deferredToolState.providerLoadedToolNames ?? {}),
+					anthropic: normalizeToolNameList([
+						...(deferredToolState.providerLoadedToolNames?.anthropic ?? []),
+						...added,
+					]),
+				},
+			});
+			emitDeferredToolStateChange(options, deferredToolState);
 		}
 		return added;
 	};
 	const resolveFullToolPool = () =>
 		agentToolDefsForLoop(options.composerMode, settings, options.toolPoolOverride);
+	const resolveToolDefsByName = () => new Map(resolveFullToolPool().map((tool) => [tool.name, tool] as const));
+	const countAnthropicDeferredToolTokensExact = async (
+		tools: AgentToolDef[]
+	): Promise<number | null> => {
+		if (tools.length === 0) {
+			return 0;
+		}
+		try {
+			const response = await client.messages.countTokens({
+				model,
+				messages: [{ role: 'user', content: '' }],
+				tools: toAnthropicTools(tools) as unknown as Anthropic.Messages.MessageCountTokensTool[],
+			});
+			const baseline = await client.messages.countTokens({
+				model,
+				messages: [{ role: 'user', content: '' }],
+			});
+			return Math.max(0, response.input_tokens - baseline.input_tokens);
+		} catch {
+			return null;
+		}
+	};
+	const initialFullToolPool = resolveFullToolPool();
+	const initialDeferredToolPool = initialFullToolPool.filter((tool) => isDeferredAgentTool(tool));
+	const initialVisibleToolPool = visibleAgentToolDefsForLoop(
+		options.composerMode,
+		settings,
+		discoveredDeferredToolNames,
+		options.toolPoolOverride
+	);
+	const toolContextAnalysis = await analyzeToolContext({
+		provider: 'anthropic',
+		fullToolPool: initialFullToolPool,
+		visibleToolPool: initialVisibleToolPool,
+		deferredToolPool: initialDeferredToolPool,
+		exactDeferredTokenCounter: countAnthropicDeferredToolTokensExact,
+	});
+	const nativeAnthropicDeferEnabled = shouldEnableAnthropicNativeDefer({
+		model,
+		baseURL,
+		contextWindowTokens: options.contextWindowTokens,
+		analysis: toolContextAnalysis,
+	});
 	const resolveVisibleToolPool = () =>
 		visibleAgentToolDefsForLoop(
 			options.composerMode,
 			settings,
 			discoveredDeferredToolNames,
-			options.toolPoolOverride
+			options.toolPoolOverride,
+			nativeAnthropicDeferEnabled
 		);
 	const mergedCustomToolHandlers = {
 		ToolSearch: createToolSearchToolHandler({
 			resolveFullToolPool,
 			discoverTools: markDeferredToolsDiscovered,
+			nativeAnthropicToolReference: nativeAnthropicDeferEnabled,
 		}),
 		...(options.customToolHandlers ?? {}),
 	};
@@ -1117,7 +1310,22 @@ async function runAnthropicLoop(
 	let outputRecoveryCountA = 0;
 
 	type TurnTu = { id: string; name: string; input: string };
+	type AnthropicToolExecution = {
+		call: TurnTu;
+		args: Record<string, unknown>;
+		result: ToolResult;
+	};
 	const maxToolArgChars = maxStreamingToolArgChars();
+	const toolExecCtx: ToolExecutionContext = {
+		delegateExecutionDepth: options.delegateExecutionDepth ?? 0,
+		workspaceRoot: options.workspaceRoot ?? null,
+		workspaceLspManager: options.workspaceLspManager ?? null,
+		threadId: options.threadId ?? null,
+		hostWebContentsId: options.hostWebContentsId ?? null,
+		signal: options.signal,
+		teamToolRoleScope: options.teamToolRoleScope,
+		customToolHandlers: mergedCustomToolHandlers,
+	};
 
 	async function handleMistakeLimitBeforeRoundAnthropic(): Promise<boolean> {
 		if (!mistakeLimitEnabled || consecutiveToolFailures < threshold) {
@@ -1147,16 +1355,18 @@ async function runAnthropicLoop(
 		return false;
 	}
 
-	async function runOneAnthropicTool(tu: TurnTu): Promise<ToolResultBlockParam> {
+	async function runOneAnthropicTool(tu: TurnTu): Promise<AnthropicToolExecution> {
 		let args: Record<string, unknown>;
 		try {
 			args = JSON.parse(tu.input || '{}');
 		} catch (parseErr) {
 			const msg = `工具参数 JSON 无效：${parseErr instanceof Error ? parseErr.message : String(parseErr)}。请提供合法的 JSON。`;
 			if (mistakeLimitEnabled) consecutiveToolFailures++;
-			structured.pushTool(tu.id, tu.name, {}, msg, false);
-			handlers.onToolResult(tu.name, msg, false, tu.id);
-			return { type: 'tool_result', tool_use_id: tu.id, content: msg, is_error: true };
+			return {
+				call: tu,
+				args: {},
+				result: { toolCallId: tu.id, name: tu.name, content: msg, isError: true },
+			};
 		}
 
 		const toolCall: ToolCall = { id: tu.id, name: tu.name, arguments: args };
@@ -1181,56 +1391,31 @@ async function runAnthropicLoop(
 		if (!gate.proceed) {
 			const msg = gate.rejectionMessage;
 			if (mistakeLimitEnabled) consecutiveToolFailures++;
-			structured.pushTool(tu.id, tu.name, args, msg, false);
-			handlers.onToolResult(tu.name, msg, false, tu.id);
-			return { type: 'tool_result', tool_use_id: tu.id, content: msg, is_error: true };
+			return {
+				call: tu,
+				args,
+				result: { toolCallId: tu.id, name: tu.name, content: msg, isError: true },
+			};
 		}
 
 		handlers.onToolProgress?.({ name: tu.name, phase: 'executing' });
 		const execStart = Date.now();
 		console.log(`[AgentLoop/A] tool=${tu.name} — executeTool start`);
-		const result = await executeTool(toolCall, options.toolHooks, {
-			delegateExecutionDepth: options.delegateExecutionDepth ?? 0,
-			workspaceRoot: options.workspaceRoot ?? null,
-			workspaceLspManager: options.workspaceLspManager ?? null,
-			threadId: options.threadId ?? null,
-			hostWebContentsId: options.hostWebContentsId ?? null,
-			signal: options.signal,
-			teamToolRoleScope: options.teamToolRoleScope,
-			customToolHandlers: mergedCustomToolHandlers,
-		});
-		const persistedResult = await persistLargeToolResultIfNeeded(result, {
-			delegateExecutionDepth: options.delegateExecutionDepth ?? 0,
-			workspaceRoot: options.workspaceRoot ?? null,
-			workspaceLspManager: options.workspaceLspManager ?? null,
-			threadId: options.threadId ?? null,
-			hostWebContentsId: options.hostWebContentsId ?? null,
-			signal: options.signal,
-			teamToolRoleScope: options.teamToolRoleScope,
-			customToolHandlers: mergedCustomToolHandlers,
-		});
-		console.log(`[AgentLoop/A] tool=${tu.name} — executeTool done (${Date.now() - execStart}ms, error=${persistedResult.isError})`);
+		const result = await executeTool(toolCall, options.toolHooks, toolExecCtx);
+		console.log(`[AgentLoop/A] tool=${tu.name} — executeTool done (${Date.now() - execStart}ms, error=${result.isError})`);
 		if (mistakeLimitEnabled) {
-			if (persistedResult.isError) {
+			if (result.isError) {
 				consecutiveToolFailures++;
 			} else {
 				consecutiveToolFailures = 0;
 			}
 		}
 
-		structured.pushTool(tu.id, tu.name, args, persistedResult.content, !persistedResult.isError);
-		handlers.onToolResult(tu.name, persistedResult.content, !persistedResult.isError, tu.id);
-
-		return {
-			type: 'tool_result',
-			tool_use_id: tu.id,
-			content: persistedResult.content,
-			is_error: persistedResult.isError,
-		};
+		return { call: tu, args, result };
 	}
 
-	async function flushAnthropicToolsInOrder(turnToolUses: TurnTu[]): Promise<ToolResultBlockParam[]> {
-		const out: ToolResultBlockParam[] = [];
+	async function flushAnthropicToolsInOrder(turnToolUses: TurnTu[]): Promise<AnthropicToolResultBlock[]> {
+		const executed: AnthropicToolExecution[] = [];
 		let i = 0;
 		while (i < turnToolUses.length) {
 			const cur = turnToolUses[i]!;
@@ -1244,14 +1429,47 @@ async function runAnthropicLoop(
 					batch.map((b) => () => runOneAnthropicTool(b)),
 					MAX_TOOL_CONCURRENCY
 				);
-				out.push(...batchResults);
+				executed.push(...batchResults);
 				i = j;
 			} else {
-				out.push(await runOneAnthropicTool(cur));
+				executed.push(await runOneAnthropicTool(cur));
 				i++;
 			}
 		}
-		return out;
+		if (executed.length === 0) {
+			return [];
+		}
+		const budgeted = await applyTurnToolResultBudget(
+			executed.map((item) => item.result),
+			resolveToolDefsByName(),
+			toolResultReplacementState,
+			toolExecCtx
+		);
+		toolResultReplacementState = budgeted.state;
+		options.onToolResultReplacementStateChange?.(toolResultReplacementState);
+		return executed.map((item, index) => {
+			const adjusted = budgeted.results[index]!;
+			structured.pushTool(
+				item.call.id,
+				item.call.name,
+				item.args,
+				adjusted.content,
+				!adjusted.isError,
+				adjusted.structuredContent
+			);
+			handlers.onToolResult(
+				item.call.name,
+				adjusted.content,
+				!adjusted.isError,
+				item.call.id
+			);
+			return {
+				type: 'tool_result',
+				tool_use_id: item.call.id,
+				content: adjusted.structuredContent ?? adjusted.content,
+				is_error: adjusted.isError,
+			};
+		});
 	}
 
 	const toolDeltaBatcherA = createToolInputDeltaBatcher((p) => handlers.onToolInputDelta?.(p));
@@ -1276,7 +1494,7 @@ async function runAnthropicLoop(
 
 		console.log(`[AgentLoop/A] round ${round} — starting LLM call`);
 		const roundStartAtA = Date.now();
-		const tools = toAnthropicTools(resolveVisibleToolPool());
+		const tools = resolveAnthropicApiTools();
 		let turnText = '';
 		let turnThinking = '';
 		let turnThinkingSignature = '';

--- a/main-src/agent/agentToolPool.ts
+++ b/main-src/agent/agentToolPool.ts
@@ -8,6 +8,16 @@ export function isDeferredAgentToolName(name: string): boolean {
 	return name.startsWith('mcp__');
 }
 
+export function isDeferredAgentTool(tool: AgentToolDef): boolean {
+	if (tool.alwaysLoad === true) {
+		return false;
+	}
+	if (tool.shouldDefer === true) {
+		return true;
+	}
+	return isDeferredAgentToolName(tool.name);
+}
+
 function modeForBaseTools(
 	composerMode: ComposerMode
 ): 'agent' | 'plan' | 'team' {
@@ -53,7 +63,7 @@ export function assembleAgentToolPool(
 }
 
 export function getDeferredAgentToolDefs(fullPool: AgentToolDef[]): AgentToolDef[] {
-	return fullPool.filter((tool) => isDeferredAgentToolName(tool.name));
+	return fullPool.filter((tool) => isDeferredAgentTool(tool));
 }
 
 export function assembleVisibleAgentToolPool(
@@ -62,6 +72,7 @@ export function assembleVisibleAgentToolPool(
 		mcpToolDenyPrefixes?: string[];
 		discoveredDeferredToolNames?: Iterable<string>;
 		override?: AgentToolDef[];
+		nativeDeferEnabled?: boolean;
 	}
 ): AgentToolDef[] {
 	const fullPool =
@@ -76,11 +87,29 @@ export function assembleVisibleAgentToolPool(
 
 	const deferred = getDeferredAgentToolDefs(fullPool);
 	const discovered = new Set(options?.discoveredDeferredToolNames ?? []);
+	if (options?.nativeDeferEnabled) {
+		if (deferred.length === 0) {
+			return fullPool.filter((tool) => tool.name !== TOOL_SEARCH_TOOL_NAME);
+		}
+		const searchTool = toolSearchDef();
+		if (!searchTool || fullPool.some((tool) => tool.name === TOOL_SEARCH_TOOL_NAME)) {
+			return fullPool;
+		}
+		const firstDeferredIndex = fullPool.findIndex((tool) => isDeferredAgentTool(tool));
+		if (firstDeferredIndex === -1) {
+			return [...fullPool, searchTool];
+		}
+		return [
+			...fullPool.slice(0, firstDeferredIndex),
+			searchTool,
+			...fullPool.slice(firstDeferredIndex),
+		];
+	}
 	const visible = fullPool.filter((tool) => {
 		if (tool.name === TOOL_SEARCH_TOOL_NAME) {
 			return false;
 		}
-		return !isDeferredAgentToolName(tool.name) || discovered.has(tool.name);
+		return !isDeferredAgentTool(tool) || discovered.has(tool.name);
 	});
 
 	if (deferred.length === 0) {
@@ -91,7 +120,7 @@ export function assembleVisibleAgentToolPool(
 	if (!searchTool || visible.some((tool) => tool.name === TOOL_SEARCH_TOOL_NAME)) {
 		return visible;
 	}
-	const firstDeferredIndex = visible.findIndex((tool) => isDeferredAgentToolName(tool.name));
+	const firstDeferredIndex = visible.findIndex((tool) => isDeferredAgentTool(tool));
 	if (firstDeferredIndex === -1) {
 		return [...visible, searchTool];
 	}

--- a/main-src/agent/agentTools.ts
+++ b/main-src/agent/agentTools.ts
@@ -3,11 +3,19 @@
  * 每个工具包含名称、描述和 JSON Schema 参数，供 OpenAI / Anthropic / Gemini 的 tool calling 使用。
  */
 
-import { buildCachedAnthropicTools, buildCachedOpenAITools } from './toolSchemaCache.js';
+import type { AnthropicToolResultContent, AnthropicToolSchema } from '../llm/anthropicBeta.js';
+import { buildAnthropicToolSchemas, buildOpenAIToolSchemas } from './toolSchemaCache.js';
 
 export type AgentToolDef = {
 	name: string;
 	description: string;
+	shouldDefer?: boolean;
+	alwaysLoad?: boolean;
+	maxResultSizeChars?: number;
+	strict?: boolean;
+	eagerInputStreaming?: boolean;
+	isMcp?: boolean;
+	schemaCacheKey?: string;
 	parameters: {
 		type: 'object';
 		properties: Record<string, Record<string, unknown>>;
@@ -25,6 +33,7 @@ export type ToolResult = {
 	toolCallId: string;
 	name: string;
 	content: string;
+	structuredContent?: AnthropicToolResultContent;
 	isError: boolean;
 };
 
@@ -803,9 +812,15 @@ export const AGENT_TOOLS: AgentToolDef[] = [
 ];
 
 export function toOpenAITools(defs: AgentToolDef[]) {
-	return buildCachedOpenAITools(defs);
+	return buildOpenAIToolSchemas(defs);
 }
 
-export function toAnthropicTools(defs: AgentToolDef[]) {
-	return buildCachedAnthropicTools(defs);
+export function toAnthropicTools(
+	defs: AgentToolDef[],
+	options?: {
+		deferToolNames?: Iterable<string>;
+		includeExperimentalBetaFields?: boolean;
+	}
+): AnthropicToolSchema[] {
+	return buildAnthropicToolSchemas(defs, options);
 }

--- a/main-src/agent/managedSubagents.ts
+++ b/main-src/agent/managedSubagents.ts
@@ -325,9 +325,12 @@ async function runManagedAgent(runtime: ManagedAgentRuntime): Promise<void> {
 	runtime.lastError = null;
 	const matchedSubagent = findConfiguredSubagent(runtime.settings, runtime.subagentType);
 	const subAppend = buildSubagentSystemAppend(runtime.settings, runtime.subagentType);
-	const baseToolDefs = assembleAgentToolPool(runtime.runProfile === 'explore' ? 'plan' : runtime.options.composerMode, {
-		mcpToolDenyPrefixes: runtime.settings.mcpToolDenyPrefixes,
-	}).filter((tool) => tool.name !== 'Agent' && tool.name !== 'Task');
+	const inheritedExploreToolDefs =
+		runtime.runProfile === 'explore'
+			? assembleAgentToolPool('plan', {
+					mcpToolDenyPrefixes: runtime.settings.mcpToolDenyPrefixes,
+				})
+			: undefined;
 
 	const runPromise = (async () => {
 		let output = '';
@@ -481,7 +484,7 @@ async function runManagedAgent(runtime: ManagedAgentRuntime): Promise<void> {
 					...runtime.options,
 					signal: abortController.signal,
 					composerMode: runtime.runProfile === 'explore' ? 'plan' : runtime.options.composerMode,
-					toolPoolOverride: baseToolDefs,
+					...(inheritedExploreToolDefs ? { toolPoolOverride: inheritedExploreToolDefs } : {}),
 					customToolHandlers,
 					delegateExecutionDepth: 1,
 					toolHooks:

--- a/main-src/agent/structuredAssistantBuilder.ts
+++ b/main-src/agent/structuredAssistantBuilder.ts
@@ -3,6 +3,7 @@ import type {
 	AgentAssistantPayload,
 	AgentAssistantToolPart,
 } from '../../src/agentStructuredMessage.js';
+import type { AnthropicToolResultContent } from '../llm/anthropicBeta.js';
 import { stringifyAgentAssistantPayload } from '../../src/agentStructuredMessage.js';
 
 /**
@@ -27,6 +28,7 @@ export class StructuredAssistantBuilder {
 		args: Record<string, unknown>,
 		result: string,
 		success: boolean,
+		resultStructured?: AnthropicToolResultContent,
 		nest?: { subParent?: string; subDepth?: number }
 	): void {
 		const tool: AgentAssistantToolPart = {
@@ -35,6 +37,7 @@ export class StructuredAssistantBuilder {
 			name,
 			args,
 			result,
+			...(resultStructured ? { resultStructured } : {}),
 			success,
 		};
 		if (nest?.subParent != null) {

--- a/main-src/agent/structuredAssistantToApi.test.ts
+++ b/main-src/agent/structuredAssistantToApi.test.ts
@@ -53,7 +53,7 @@ describe('structuredAssistantToApi', () => {
 		expect(String((oa[0] as { content?: unknown }).content)).toContain('<tool_call');
 	});
 
-	it('Anthropic: tool-only payload falls back to legacy XML string', () => {
+	it('Anthropic: tool-only payload expands to assistant + user tool_result blocks', () => {
 		const raw = stringifyAgentAssistantPayload({
 			_asyncAssistant: 1,
 			v: 1,
@@ -70,8 +70,9 @@ describe('structuredAssistantToApi', () => {
 		});
 		const p = parseAgentAssistantPayload(raw)!;
 		const am = expandStructuredAssistantPayloadToAnthropic(p);
-		expect(am).toHaveLength(1);
+		expect(am).toHaveLength(2);
 		expect(am[0]!.role).toBe('assistant');
-		expect(typeof (am[0] as { content: unknown }).content).toBe('string');
+		expect(Array.isArray((am[0] as { content: unknown }).content)).toBe(true);
+		expect(am[1]!.role).toBe('user');
 	});
 });

--- a/main-src/agent/structuredAssistantToApi.ts
+++ b/main-src/agent/structuredAssistantToApi.ts
@@ -9,12 +9,13 @@
  */
 
 import type OpenAI from 'openai';
-import type { ContentBlockParam, MessageParam, ToolResultBlockParam } from '@anthropic-ai/sdk/resources/messages';
+import type { ContentBlockParam, MessageParam } from '@anthropic-ai/sdk/resources/messages';
 import type {
 	AgentAssistantPart,
 	AgentAssistantPayload,
 	AgentAssistantToolPart,
 } from '../../src/agentStructuredMessage.js';
+import type { AnthropicToolResultBlock } from '../llm/anthropicBeta.js';
 import { structuredToLegacyAgentXml } from '../../src/agentStructuredMessage.js';
 
 export type OAIMsg = OpenAI.Chat.Completions.ChatCompletionMessageParam;
@@ -85,10 +86,10 @@ function expandAnthropicNativeParts(parts: AgentAssistantPart[]): MessageParam[]
 				blocks.push({ type: 'tool_use', id: t.toolUseId, name: t.name, input: t.args });
 			}
 			out.push({ role: 'assistant', content: blocks });
-			const toolResults: ToolResultBlockParam[] = tools.map((t) => ({
+			const toolResults: AnthropicToolResultBlock[] = tools.map((t) => ({
 				type: 'tool_result',
 				tool_use_id: t.toolUseId,
-				content: t.result,
+				content: t.resultStructured ?? t.result,
 				is_error: !t.success,
 			}));
 			out.push({ role: 'user', content: toolResults });
@@ -101,11 +102,5 @@ function expandAnthropicNativeParts(parts: AgentAssistantPart[]): MessageParam[]
 
 /** 单条结构化助手 → 若干条 Anthropic MessageParam；收尾为 tool_result user 时回退 XML。 */
 export function expandStructuredAssistantPayloadToAnthropic(p: AgentAssistantPayload): MessageParam[] {
-	const native = expandAnthropicNativeParts(p.parts);
-	if (native.length === 0) return [];
-	const last = native[native.length - 1]!;
-	if (last.role === 'user') {
-		return [{ role: 'assistant', content: structuredToLegacyAgentXml(p) }];
-	}
-	return native;
+	return expandAnthropicNativeParts(p.parts);
 }

--- a/main-src/agent/teamOrchestrator.ts
+++ b/main-src/agent/teamOrchestrator.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import type { ChatMessage, TeamSessionSnapshot } from '../threadStore.js';
+import type { ChatMessage, DeferredToolState, TeamSessionSnapshot } from '../threadStore.js';
 import type { ShellSettings, TeamRoleType } from '../settingsStore.js';
 import type { WorkspaceLspManager } from '../lsp/workspaceLspManager.js';
 import { runAgentLoop, type AgentLoopHandlers, type AgentLoopOptions } from './agentLoop.js';
@@ -322,8 +322,12 @@ export type TeamOrchestratorInput = {
 	workspaceLspManager?: WorkspaceLspManager | null;
 	hostWebContentsId?: number | null;
 	toolHooks?: ToolExecutionHooks;
-	discoveredDeferredToolNames?: string[];
-	onDiscoveredDeferredToolsChange?: (names: string[]) => void;
+	deferredToolState?: DeferredToolState;
+	onDeferredToolStateChange?: (state: DeferredToolState) => void;
+	toolResultReplacementState?: import('./toolResultBudget.js').ToolResultReplacementState;
+	onToolResultReplacementStateChange?: (
+		state: import('./toolResultBudget.js').ToolResultReplacementState
+	) => void;
 	emit: (evt: TeamEmit) => void;
 	onDone: (fullText: string, usage?: { inputTokens?: number; outputTokens?: number; cacheReadTokens?: number; cacheWriteTokens?: number }, teamSnapshot?: TeamSessionSnapshot) => void;
 	onError: (message: string) => void;
@@ -773,12 +777,19 @@ async function llmPlanTasks(params: {
 	thinkingLevel?: TeamOrchestratorInput['thinkingLevel'];
 	workspaceRoot?: string | null;
 	workspaceLspManager?: WorkspaceLspManager | null;
+	hostWebContentsId?: number | null;
 	toolHooks?: ToolExecutionHooks;
+	deferredToolState?: DeferredToolState;
+	onDeferredToolStateChange?: (state: DeferredToolState) => void;
+	toolResultReplacementState?: import('./toolResultBudget.js').ToolResultReplacementState;
+	onToolResultReplacementStateChange?: (
+		state: import('./toolResultBudget.js').ToolResultReplacementState
+	) => void;
 	emit: (evt: TeamEmit) => void;
 }): Promise<{ tasks: LLMPlannedTask[]; planSummary: string; mode: LeadPlanMode; clarificationAnswers: string[] }> {
 	const {
 		settings, threadId, teamLead, specialists, plannerTools, messages, modelSelection, resolvedModel,
-		signal, thinkingLevel, workspaceRoot, workspaceLspManager, toolHooks, emit,
+		signal, thinkingLevel, workspaceRoot, workspaceLspManager, hostWebContentsId, toolHooks, deferredToolState, onDeferredToolStateChange, toolResultReplacementState, onToolResultReplacementStateChange, emit,
 	} = params;
 	const hasCjk = messages.some((message) => /[\u3400-\u9fff]/.test(String(message.content ?? '')));
 	const availableRoles = specialists.map((s) => `- ${s.assignmentKey}: ${s.name}`).join('\n');
@@ -838,6 +849,9 @@ async function llmPlanTasks(params: {
 		requestBaseURL: resolvedModel.baseURL,
 		requestProxyUrl: resolvedModel.proxyUrl,
 		maxOutputTokens: resolvedModel.maxOutputTokens,
+		...(resolvedModel.contextWindowTokens != null
+			? { contextWindowTokens: resolvedModel.contextWindowTokens }
+			: {}),
 		signal,
 		composerMode: 'agent',
 		toolPoolOverride: plannerTools,
@@ -848,8 +862,10 @@ async function llmPlanTasks(params: {
 		hostWebContentsId: params.hostWebContentsId ?? null,
 		threadId,
 		toolHooks,
-		discoveredDeferredToolNames,
-		onDiscoveredDeferredToolsChange,
+		deferredToolState,
+		onDeferredToolStateChange,
+		toolResultReplacementState,
+		onToolResultReplacementStateChange,
 		teamToolRoleScope: teamLeadScope,
 	};
 
@@ -863,6 +879,7 @@ async function llmPlanTasks(params: {
 			options.requestBaseURL = resolved.baseURL;
 			options.requestProxyUrl = resolved.proxyUrl;
 			options.maxOutputTokens = resolved.maxOutputTokens;
+			options.contextWindowTokens = resolved.contextWindowTokens;
 		}
 	}
 
@@ -1149,14 +1166,21 @@ async function runPreflightReviewerAgent(params: {
 	thinkingLevel?: TeamOrchestratorInput['thinkingLevel'];
 	workspaceRoot?: string | null;
 	workspaceLspManager?: WorkspaceLspManager | null;
+	hostWebContentsId?: number | null;
 	toolHooks?: ToolExecutionHooks;
 	baseTools: AgentToolDef[];
+	deferredToolState?: DeferredToolState;
+	onDeferredToolStateChange?: (state: DeferredToolState) => void;
+	toolResultReplacementState?: import('./toolResultBudget.js').ToolResultReplacementState;
+	onToolResultReplacementStateChange?: (
+		state: import('./toolResultBudget.js').ToolResultReplacementState
+	) => void;
 	emit: (evt: TeamEmit) => void;
 }): Promise<{ verdict: 'ok' | 'needs_clarification'; summary: string }> {
 	const {
 		settings, threadId, reviewer, plannedTasks, userRequest, planSummary, specialists,
 		modelSelection, resolvedModel,
-		signal, thinkingLevel, workspaceRoot, workspaceLspManager, toolHooks, baseTools, emit,
+		signal, thinkingLevel, workspaceRoot, workspaceLspManager, hostWebContentsId, toolHooks, baseTools, deferredToolState, onDeferredToolStateChange, toolResultReplacementState, onToolResultReplacementStateChange, emit,
 	} = params;
 
 	const messages: ChatMessage[] = [
@@ -1188,6 +1212,9 @@ async function runPreflightReviewerAgent(params: {
 		requestBaseURL: resolvedModel.baseURL,
 		requestProxyUrl: resolvedModel.proxyUrl,
 		maxOutputTokens: resolvedModel.maxOutputTokens,
+		...(resolvedModel.contextWindowTokens != null
+			? { contextWindowTokens: resolvedModel.contextWindowTokens }
+			: {}),
 		signal,
 		composerMode: 'agent',
 		toolPoolOverride: specializedTools,
@@ -1198,8 +1225,10 @@ async function runPreflightReviewerAgent(params: {
 		hostWebContentsId: params.hostWebContentsId ?? null,
 		threadId,
 		toolHooks,
-		discoveredDeferredToolNames,
-		onDiscoveredDeferredToolsChange,
+		deferredToolState,
+		onDeferredToolStateChange,
+		toolResultReplacementState,
+		onToolResultReplacementStateChange,
 		teamToolRoleScope: teamRoleScope,
 	};
 
@@ -1213,6 +1242,7 @@ async function runPreflightReviewerAgent(params: {
 			options.requestBaseURL = resolved.baseURL;
 			options.requestProxyUrl = resolved.proxyUrl;
 			options.maxOutputTokens = resolved.maxOutputTokens;
+			options.contextWindowTokens = resolved.contextWindowTokens;
 		}
 	}
 
@@ -1308,13 +1338,20 @@ async function runReviewerAgent(params: {
 	thinkingLevel?: TeamOrchestratorInput['thinkingLevel'];
 	workspaceRoot?: string | null;
 	workspaceLspManager?: WorkspaceLspManager | null;
+	hostWebContentsId?: number | null;
 	toolHooks?: ToolExecutionHooks;
 	baseTools: AgentToolDef[];
+	deferredToolState?: DeferredToolState;
+	onDeferredToolStateChange?: (state: DeferredToolState) => void;
+	toolResultReplacementState?: import('./toolResultBudget.js').ToolResultReplacementState;
+	onToolResultReplacementStateChange?: (
+		state: import('./toolResultBudget.js').ToolResultReplacementState
+	) => void;
 	emit: (evt: TeamEmit) => void;
 }): Promise<{ verdict: 'approved' | 'revision_needed'; summary: string }> {
 	const {
 		settings, threadId, reviewer, completedTasks, userRequest, planSummary, modelSelection, resolvedModel,
-		signal, thinkingLevel, workspaceRoot, workspaceLspManager, toolHooks, baseTools, emit,
+		signal, thinkingLevel, workspaceRoot, workspaceLspManager, hostWebContentsId, toolHooks, baseTools, deferredToolState, onDeferredToolStateChange, toolResultReplacementState, onToolResultReplacementStateChange, emit,
 	} = params;
 
 	const reviewMessages: ChatMessage[] = [
@@ -1342,6 +1379,9 @@ async function runReviewerAgent(params: {
 		requestBaseURL: resolvedModel.baseURL,
 		requestProxyUrl: resolvedModel.proxyUrl,
 		maxOutputTokens: resolvedModel.maxOutputTokens,
+		...(resolvedModel.contextWindowTokens != null
+			? { contextWindowTokens: resolvedModel.contextWindowTokens }
+			: {}),
 		signal,
 		composerMode: 'agent',
 		toolPoolOverride: specializedTools,
@@ -1352,8 +1392,10 @@ async function runReviewerAgent(params: {
 		hostWebContentsId: params.hostWebContentsId ?? null,
 		threadId,
 		toolHooks,
-		discoveredDeferredToolNames,
-		onDiscoveredDeferredToolsChange,
+		deferredToolState,
+		onDeferredToolStateChange,
+		toolResultReplacementState,
+		onToolResultReplacementStateChange,
 		teamToolRoleScope: teamRoleScope,
 	};
 
@@ -1367,6 +1409,7 @@ async function runReviewerAgent(params: {
 			options.requestBaseURL = resolved.baseURL;
 			options.requestProxyUrl = resolved.proxyUrl;
 			options.maxOutputTokens = resolved.maxOutputTokens;
+			options.contextWindowTokens = resolved.contextWindowTokens;
 		}
 	}
 
@@ -1474,9 +1517,16 @@ async function runOneSpecialist(params: {
 	thinkingLevel?: TeamOrchestratorInput['thinkingLevel'];
 	workspaceRoot?: string | null;
 	workspaceLspManager?: WorkspaceLspManager | null;
+	hostWebContentsId?: number | null;
 	toolHooks?: ToolExecutionHooks;
 	baseTools: AgentToolDef[];
 	threadId: string;
+	deferredToolState?: DeferredToolState;
+	onDeferredToolStateChange?: (state: DeferredToolState) => void;
+	toolResultReplacementState?: import('./toolResultBudget.js').ToolResultReplacementState;
+	onToolResultReplacementStateChange?: (
+		state: import('./toolResultBudget.js').ToolResultReplacementState
+	) => void;
 	pullPeerMailboxMessages?: () => Promise<ChatMessage[]>;
 	handlePeerRequest?: (request: TeamPeerRequest) => Promise<string>;
 	handlePeerReply?: (reply: TeamPeerReply) => void;
@@ -1485,8 +1535,8 @@ async function runOneSpecialist(params: {
 	const {
 		settings, task, expert, userRequest, planSummary, completedTasksById, allTasks,
 		modelSelection, resolvedModel,
-		signal, thinkingLevel, workspaceRoot, workspaceLspManager, toolHooks, baseTools,
-		threadId, pullPeerMailboxMessages, handlePeerRequest, handlePeerReply, emit,
+		signal, thinkingLevel, workspaceRoot, workspaceLspManager, hostWebContentsId, toolHooks, baseTools,
+		threadId, deferredToolState, onDeferredToolStateChange, toolResultReplacementState, onToolResultReplacementStateChange, pullPeerMailboxMessages, handlePeerRequest, handlePeerReply, emit,
 	} = params;
 
 	const subMessages: ChatMessage[] = [
@@ -1516,6 +1566,9 @@ async function runOneSpecialist(params: {
 		requestBaseURL: resolvedModel.baseURL,
 		requestProxyUrl: resolvedModel.proxyUrl,
 		maxOutputTokens: resolvedModel.maxOutputTokens,
+		...(resolvedModel.contextWindowTokens != null
+			? { contextWindowTokens: resolvedModel.contextWindowTokens }
+			: {}),
 		signal,
 		composerMode: 'agent',
 		toolPoolOverride: specializedToolPool,
@@ -1526,8 +1579,10 @@ async function runOneSpecialist(params: {
 		hostWebContentsId: params.hostWebContentsId ?? null,
 		threadId,
 		toolHooks,
-		discoveredDeferredToolNames,
-		onDiscoveredDeferredToolsChange,
+		deferredToolState,
+		onDeferredToolStateChange,
+		toolResultReplacementState,
+		onToolResultReplacementStateChange,
 		teamToolRoleScope: teamRoleScope,
 		beforeRoundMessages: pullPeerMailboxMessages,
 	};
@@ -1603,6 +1658,7 @@ async function runOneSpecialist(params: {
 				options.requestBaseURL = resolvedOverride.baseURL;
 				options.requestProxyUrl = resolvedOverride.proxyUrl;
 				options.maxOutputTokens = resolvedOverride.maxOutputTokens;
+				options.contextWindowTokens = resolvedOverride.contextWindowTokens;
 			}
 		}
 		setTeamEscalationRuntime(teamRoleScope.teamTaskId, {
@@ -1763,7 +1819,7 @@ export async function runTeamSession(input: TeamOrchestratorInput): Promise<void
 	const {
 		settings, threadId, messages, modelSelection, resolvedModel,
 		agentSystemAppend, signal, thinkingLevel, workspaceRoot, workspaceLspManager,
-		toolHooks, discoveredDeferredToolNames, onDiscoveredDeferredToolsChange, emit, onDone, onError,
+		hostWebContentsId, toolHooks, deferredToolState, onDeferredToolStateChange, toolResultReplacementState, onToolResultReplacementStateChange, emit, onDone, onError,
 	} = input;
 
 	try {
@@ -1816,7 +1872,7 @@ export async function runTeamSession(input: TeamOrchestratorInput): Promise<void
 			try {
 				const planResult = await llmPlanTasks({
 					settings, threadId, teamLead, specialists, plannerTools, messages: planningMessages, modelSelection,
-					resolvedModel, signal, thinkingLevel, workspaceRoot, workspaceLspManager, toolHooks, emit,
+					resolvedModel, signal, thinkingLevel, workspaceRoot, workspaceLspManager, hostWebContentsId, toolHooks, deferredToolState, onDeferredToolStateChange, toolResultReplacementState, onToolResultReplacementStateChange, emit,
 				});
 				if (planResult.clarificationAnswers.length > 0) {
 					const propagated = applyTeamClarificationAnswers(
@@ -1905,7 +1961,7 @@ export async function runTeamSession(input: TeamOrchestratorInput): Promise<void
 						settings, threadId, reviewer: resolvedExperts.planReviewer, plannedTasks,
 						userRequest: effectiveUserText, planSummary, specialists,
 						modelSelection, resolvedModel, signal, thinkingLevel,
-						workspaceRoot, workspaceLspManager, toolHooks, baseTools: baseTeamTools, emit,
+						workspaceRoot, workspaceLspManager, hostWebContentsId, toolHooks, baseTools: baseTeamTools, deferredToolState, onDeferredToolStateChange, toolResultReplacementState, onToolResultReplacementStateChange, emit,
 					});
 					preflightSummary = preflight.summary;
 					preflightVerdict = preflight.verdict;
@@ -2173,9 +2229,13 @@ export async function runTeamSession(input: TeamOrchestratorInput): Promise<void
 							settings, task, expert, userRequest: effectiveUserText, planSummary, completedTasksById,
 							allTasks: plannedTasks,
 							modelSelection, resolvedModel,
-							signal, thinkingLevel, workspaceRoot, workspaceLspManager, toolHooks,
+							signal, thinkingLevel, workspaceRoot, workspaceLspManager, hostWebContentsId, toolHooks,
 							baseTools: baseTeamTools,
 							threadId,
+							deferredToolState,
+							onDeferredToolStateChange,
+							toolResultReplacementState,
+							onToolResultReplacementStateChange,
 							pullPeerMailboxMessages: () => pullPeerMailboxMessages(task),
 							handlePeerRequest: (request) => waitForRunningPeerReply(task, request),
 							handlePeerReply: (reply) => {
@@ -2231,7 +2291,7 @@ export async function runTeamSession(input: TeamOrchestratorInput): Promise<void
 					try {
 						const revisedPlan = await llmPlanTasks({
 							settings, threadId, teamLead, specialists, plannerTools, messages: planningMessages, modelSelection,
-							resolvedModel, signal, thinkingLevel, workspaceRoot, workspaceLspManager, toolHooks, emit,
+							resolvedModel, signal, thinkingLevel, workspaceRoot, workspaceLspManager, hostWebContentsId, toolHooks, deferredToolState, onDeferredToolStateChange, toolResultReplacementState, onToolResultReplacementStateChange, emit,
 						});
 						if (revisedPlan.clarificationAnswers.length > 0) {
 							const propagated = applyTeamClarificationAnswers(
@@ -2348,7 +2408,7 @@ export async function runTeamSession(input: TeamOrchestratorInput): Promise<void
 			review = await runReviewerAgent({
 				settings, threadId, reviewer: resolvedExperts.deliveryReviewer, completedTasks: completed,
 				userRequest: effectiveUserText, planSummary, modelSelection, resolvedModel, signal, thinkingLevel,
-				workspaceRoot, workspaceLspManager, toolHooks, baseTools: baseTeamTools, emit,
+				workspaceRoot, workspaceLspManager, hostWebContentsId, toolHooks, baseTools: baseTeamTools, deferredToolState, onDeferredToolStateChange, toolResultReplacementState, onToolResultReplacementStateChange, emit,
 			});
 		} else {
 			const failed = completed.filter((t) => t.status === 'failed' || t.status === 'revision');

--- a/main-src/agent/toolContextAnalysis.ts
+++ b/main-src/agent/toolContextAnalysis.ts
@@ -1,0 +1,142 @@
+import { URL } from 'node:url';
+import type { AgentToolDef } from './agentTools.js';
+import { buildAnthropicToolSchemas, buildOpenAIToolSchemas } from './toolSchemaCache.js';
+
+export type ToolContextAnalysis = {
+	fullToolCount: number;
+	visibleToolCount: number;
+	deferredToolCount: number;
+	fullSchemaChars: number;
+	visibleSchemaChars: number;
+	deferredSchemaChars: number;
+	fullSchemaTokens: number;
+	visibleSchemaTokens: number;
+	deferredSchemaTokens: number;
+	usedExactTokenCount: boolean;
+};
+
+export const DEFAULT_NATIVE_DEFER_THRESHOLD_RATIO = 0.1;
+
+function isEnvTruthy(value: string | undefined): boolean {
+	if (value == null) {
+		return false;
+	}
+	const normalized = value.trim().toLowerCase();
+	return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
+}
+
+function isEnvFalsy(value: string | undefined): boolean {
+	if (value == null) {
+		return false;
+	}
+	const normalized = value.trim().toLowerCase();
+	return normalized === '0' || normalized === 'false' || normalized === 'no' || normalized === 'off';
+}
+
+function stableEstimateTokens(chars: number): number {
+	return Math.ceil(chars / 4);
+}
+
+function stableToolSchemaChars(
+	provider: 'openai' | 'anthropic',
+	tools: AgentToolDef[]
+): number {
+	if (tools.length === 0) {
+		return 0;
+	}
+	const schemas =
+		provider === 'anthropic'
+			? buildAnthropicToolSchemas(tools)
+			: buildOpenAIToolSchemas(tools);
+	return JSON.stringify(schemas).length;
+}
+
+export async function analyzeToolContext(options: {
+	provider: 'openai' | 'anthropic';
+	fullToolPool: AgentToolDef[];
+	visibleToolPool: AgentToolDef[];
+	deferredToolPool: AgentToolDef[];
+	exactDeferredTokenCounter?: (tools: AgentToolDef[]) => Promise<number | null>;
+}): Promise<ToolContextAnalysis> {
+	const fullSchemaChars = stableToolSchemaChars(options.provider, options.fullToolPool);
+	const visibleSchemaChars = stableToolSchemaChars(options.provider, options.visibleToolPool);
+	const deferredSchemaChars = stableToolSchemaChars(options.provider, options.deferredToolPool);
+	const exactDeferredTokens =
+		options.exactDeferredTokenCounter && options.deferredToolPool.length > 0
+			? await options.exactDeferredTokenCounter(options.deferredToolPool)
+			: null;
+	const deferredSchemaTokens =
+		exactDeferredTokens != null
+			? exactDeferredTokens
+			: stableEstimateTokens(deferredSchemaChars);
+	return {
+		fullToolCount: options.fullToolPool.length,
+		visibleToolCount: options.visibleToolPool.length,
+		deferredToolCount: options.deferredToolPool.length,
+		fullSchemaChars,
+		visibleSchemaChars,
+		deferredSchemaChars,
+		fullSchemaTokens: stableEstimateTokens(fullSchemaChars),
+		visibleSchemaTokens: stableEstimateTokens(visibleSchemaChars),
+		deferredSchemaTokens,
+		usedExactTokenCount: exactDeferredTokens != null,
+	};
+}
+
+export function modelSupportsAnthropicToolReference(model: string): boolean {
+	return !/haiku/i.test(model);
+}
+
+function isAnthropicFirstPartyHost(baseURL?: string): boolean {
+	const raw = String(baseURL ?? '').trim();
+	if (!raw) {
+		return true;
+	}
+	try {
+		const host = new URL(raw).hostname.toLowerCase();
+		return host === 'api.anthropic.com' || host.endsWith('.anthropic.com');
+	} catch {
+		return false;
+	}
+}
+
+export function providerSupportsAnthropicNativeDefer(baseURL?: string): boolean {
+	if (isEnvTruthy(process.env.ASYNC_ANTHROPIC_NATIVE_DEFER)) {
+		return true;
+	}
+	if (isEnvFalsy(process.env.ASYNC_ANTHROPIC_NATIVE_DEFER)) {
+		return false;
+	}
+	return isAnthropicFirstPartyHost(baseURL);
+}
+
+export function resolveNativeDeferThresholdRatio(): number {
+	const raw = Number(process.env.ASYNC_NATIVE_DEFER_THRESHOLD_RATIO ?? DEFAULT_NATIVE_DEFER_THRESHOLD_RATIO);
+	if (!Number.isFinite(raw) || raw < 0) {
+		return DEFAULT_NATIVE_DEFER_THRESHOLD_RATIO;
+	}
+	return raw;
+}
+
+export function shouldEnableAnthropicNativeDefer(options: {
+	model: string;
+	baseURL?: string;
+	contextWindowTokens?: number;
+	analysis: ToolContextAnalysis;
+}): boolean {
+	if (!providerSupportsAnthropicNativeDefer(options.baseURL)) {
+		return false;
+	}
+	if (!modelSupportsAnthropicToolReference(options.model)) {
+		return false;
+	}
+	const contextWindowTokens = Number(options.contextWindowTokens ?? 0);
+	if (!Number.isFinite(contextWindowTokens) || contextWindowTokens <= 0) {
+		return options.analysis.deferredToolCount > 0;
+	}
+	return (
+		options.analysis.deferredToolCount > 0 &&
+		options.analysis.deferredSchemaTokens >=
+			Math.ceil(contextWindowTokens * resolveNativeDeferThresholdRatio())
+	);
+}

--- a/main-src/agent/toolResultBudget.ts
+++ b/main-src/agent/toolResultBudget.ts
@@ -1,0 +1,144 @@
+import type { AgentToolDef, ToolResult } from './agentTools.js';
+import { maxResultSizeCharsForTool, persistToolResultToDisk } from './toolResultPersistence.js';
+import type { ToolExecutionContext } from './toolExecutor.js';
+
+export type ToolResultReplacementRecord = {
+	toolUseId: string;
+	toolName: string;
+	replacement: string;
+	originalSize: number;
+};
+
+export type ToolResultReplacementState = {
+	seenToolUseIds: string[];
+	replacements: ToolResultReplacementRecord[];
+};
+
+type BudgetCandidate = {
+	index: number;
+	result: ToolResult;
+	toolDef: AgentToolDef | null;
+	size: number;
+};
+
+const DEFAULT_TURN_RESULT_BUDGET_CHARS = 200_000;
+
+function normalizeUnique(values: Iterable<string>): string[] {
+	return [...new Set(Array.from(values).map((value) => String(value ?? '').trim()).filter(Boolean))].sort((a, b) =>
+		a.localeCompare(b)
+	);
+}
+
+export function normalizeToolResultReplacementState(
+	state?: ToolResultReplacementState | null
+): ToolResultReplacementState {
+	const replacementMap = new Map<string, ToolResultReplacementRecord>();
+	for (const record of state?.replacements ?? []) {
+		const toolUseId = String(record?.toolUseId ?? '').trim();
+		if (!toolUseId) {
+			continue;
+		}
+		replacementMap.set(toolUseId, {
+			toolUseId,
+			toolName: String(record.toolName ?? '').trim(),
+			replacement: String(record.replacement ?? ''),
+			originalSize: Math.max(0, Math.floor(Number(record.originalSize ?? 0) || 0)),
+		});
+	}
+	return {
+		seenToolUseIds: normalizeUnique(state?.seenToolUseIds ?? []),
+		replacements: [...replacementMap.values()].sort((a, b) => a.toolUseId.localeCompare(b.toolUseId)),
+	};
+}
+
+export function resolveTurnToolResultBudgetChars(): number {
+	const raw = Number(process.env.ASYNC_TOOL_RESULT_BUDGET_CHARS ?? DEFAULT_TURN_RESULT_BUDGET_CHARS);
+	if (!Number.isFinite(raw) || raw <= 0) {
+		return DEFAULT_TURN_RESULT_BUDGET_CHARS;
+	}
+	return Math.floor(raw);
+}
+
+export async function applyTurnToolResultBudget(
+	results: ToolResult[],
+	toolDefsByName: Map<string, AgentToolDef>,
+	state: ToolResultReplacementState,
+	execCtx: ToolExecutionContext
+): Promise<{
+	results: ToolResult[];
+	state: ToolResultReplacementState;
+}> {
+	const normalizedState = normalizeToolResultReplacementState(state);
+	const seenIds = new Set(normalizedState.seenToolUseIds);
+	const replacementsById = new Map(
+		normalizedState.replacements.map((record) => [record.toolUseId, record] as const)
+	);
+	const adjusted = results.map((result) => ({ ...result }));
+	const freshCandidates: BudgetCandidate[] = [];
+	let totalChars = 0;
+
+	for (let index = 0; index < adjusted.length; index++) {
+		const result = adjusted[index]!;
+		const replacement = replacementsById.get(result.toolCallId);
+		if (replacement) {
+			result.content = replacement.replacement;
+			result.structuredContent = undefined;
+			totalChars += result.content.length;
+			continue;
+		}
+		totalChars += result.content.length;
+		if (seenIds.has(result.toolCallId)) {
+			continue;
+		}
+		const toolDef = toolDefsByName.get(result.name) ?? null;
+		const threshold = maxResultSizeCharsForTool(result.name, toolDef);
+		if (threshold == null || result.content.length <= threshold) {
+			continue;
+		}
+		freshCandidates.push({
+			index,
+			result,
+			toolDef,
+			size: result.content.length,
+		});
+	}
+
+	const limit = resolveTurnToolResultBudgetChars();
+	if (totalChars > limit && freshCandidates.length > 0) {
+		const sorted = [...freshCandidates].sort((a, b) => b.size - a.size || a.index - b.index);
+		for (const candidate of sorted) {
+			if (totalChars <= limit) {
+				break;
+			}
+			try {
+				const persisted = await persistToolResultToDisk(candidate.result, execCtx);
+				adjusted[candidate.index] = {
+					...candidate.result,
+					content: persisted.content,
+					structuredContent: undefined,
+				};
+				totalChars = totalChars - candidate.size + persisted.content.length;
+				replacementsById.set(candidate.result.toolCallId, {
+					toolUseId: candidate.result.toolCallId,
+					toolName: candidate.result.name,
+					replacement: persisted.content,
+					originalSize: persisted.originalSize,
+				});
+			} catch {
+				/* keep original content when persistence fails */
+			}
+		}
+	}
+
+	for (const result of adjusted) {
+		seenIds.add(result.toolCallId);
+	}
+
+	return {
+		results: adjusted,
+		state: {
+			seenToolUseIds: normalizeUnique(seenIds),
+			replacements: [...replacementsById.values()].sort((a, b) => a.toolUseId.localeCompare(b.toolUseId)),
+		},
+	};
+}

--- a/main-src/agent/toolResultPersistence.ts
+++ b/main-src/agent/toolResultPersistence.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import type { ToolResult } from './agentTools.js';
+import type { AgentToolDef, ToolResult } from './agentTools.js';
 import type { ToolExecutionContext } from './toolExecutor.js';
 
 const PERSIST_PREVIEW_CHARS = 4000;
@@ -13,19 +13,32 @@ function sanitizePathPart(raw: string): string {
 	return raw.replace(/[^a-zA-Z0-9_.-]+/g, '_').slice(0, 80) || 'item';
 }
 
-function persistenceThresholdForTool(name: string): number | null {
-	if (name === 'Read') return null;
-	if (name === 'Bash') return BASH_THRESHOLD_CHARS;
-	if (name === 'Grep') return SEARCH_THRESHOLD_CHARS;
-	if (name === 'Browser' || name === 'BrowserCapture') return BASH_THRESHOLD_CHARS;
-	if (name.startsWith('mcp__')) return DEFAULT_THRESHOLD_CHARS;
-	if (name === 'ReadMcpResourceTool' || name === 'ListMcpResourcesTool' || name === 'LSP') {
+export function maxResultSizeCharsForTool(
+	toolName: string,
+	toolDef?: AgentToolDef | null
+): number | null {
+	if (typeof toolDef?.maxResultSizeChars === 'number') {
+		if (!Number.isFinite(toolDef.maxResultSizeChars)) {
+			return null;
+		}
+		return Math.max(0, Math.floor(toolDef.maxResultSizeChars));
+	}
+	if (toolName === 'Read') return null;
+	if (toolName === 'Bash') return BASH_THRESHOLD_CHARS;
+	if (toolName === 'Grep') return SEARCH_THRESHOLD_CHARS;
+	if (toolName === 'Browser' || toolName === 'BrowserCapture') return BASH_THRESHOLD_CHARS;
+	if (toolName.startsWith('mcp__')) return DEFAULT_THRESHOLD_CHARS;
+	if (toolName === 'ReadMcpResourceTool' || toolName === 'ListMcpResourcesTool' || toolName === 'LSP') {
 		return DEFAULT_THRESHOLD_CHARS;
 	}
 	return null;
 }
 
-function buildPersistenceTarget(execCtx: ToolExecutionContext, toolUseId: string, toolName: string): {
+function buildPersistenceTarget(
+	execCtx: ToolExecutionContext,
+	toolUseId: string,
+	toolName: string
+): {
 	fullPath: string;
 	displayPath: string;
 } {
@@ -38,14 +51,19 @@ function buildPersistenceTarget(execCtx: ToolExecutionContext, toolUseId: string
 			displayPath: relPath,
 		};
 	}
-	const tmpPath = path.join(os.tmpdir(), 'async-tool-results', sanitizePathPart(execCtx.threadId ?? 'thread'), fileName);
+	const tmpPath = path.join(
+		os.tmpdir(),
+		'async-tool-results',
+		sanitizePathPart(execCtx.threadId ?? 'thread'),
+		fileName
+	);
 	return {
 		fullPath: tmpPath,
 		displayPath: tmpPath,
 	};
 }
 
-function buildPersistedPreviewMessage(
+export function buildPersistedPreviewMessage(
 	toolName: string,
 	displayPath: string,
 	originalContent: string
@@ -64,22 +82,38 @@ function buildPersistedPreviewMessage(
 	].join('\n');
 }
 
-export async function persistLargeToolResultIfNeeded(
+export async function persistToolResultToDisk(
 	result: ToolResult,
 	execCtx: ToolExecutionContext
+): Promise<{
+	content: string;
+	originalSize: number;
+}> {
+	const target = buildPersistenceTarget(execCtx, result.toolCallId, result.name);
+	await fs.promises.mkdir(path.dirname(target.fullPath), { recursive: true });
+	await fs.promises.writeFile(target.fullPath, result.content, 'utf8');
+	return {
+		content: buildPersistedPreviewMessage(result.name, target.displayPath, result.content),
+		originalSize: result.content.length,
+	};
+}
+
+export async function persistLargeToolResultIfNeeded(
+	result: ToolResult,
+	execCtx: ToolExecutionContext,
+	toolDef?: AgentToolDef | null
 ): Promise<ToolResult> {
-	const threshold = persistenceThresholdForTool(result.name);
+	const threshold = maxResultSizeCharsForTool(result.name, toolDef);
 	if (!Number.isFinite(threshold) || threshold === null || result.content.length <= threshold) {
 		return result;
 	}
 
-	const target = buildPersistenceTarget(execCtx, result.toolCallId, result.name);
 	try {
-		await fs.promises.mkdir(path.dirname(target.fullPath), { recursive: true });
-		await fs.promises.writeFile(target.fullPath, result.content, 'utf8');
+		const persisted = await persistToolResultToDisk(result, execCtx);
 		return {
 			...result,
-			content: buildPersistedPreviewMessage(result.name, target.displayPath, result.content),
+			content: persisted.content,
+			structuredContent: undefined,
 		};
 	} catch {
 		const fallbackPreview =
@@ -89,6 +123,7 @@ export async function persistLargeToolResultIfNeeded(
 		return {
 			...result,
 			content: fallbackPreview,
+			structuredContent: undefined,
 		};
 	}
 }

--- a/main-src/agent/toolSchemaCache.ts
+++ b/main-src/agent/toolSchemaCache.ts
@@ -1,24 +1,22 @@
+import type { AnthropicToolSchema } from '../llm/anthropicBeta.js';
 import type { AgentToolDef } from './agentTools.js';
 
 const MAX_SCHEMA_CACHE_ENTRIES = 64;
 
-type OpenAIToolSchema = {
+export type OpenAIToolSchema = {
 	type: 'function';
 	function: {
 		name: string;
 		description: string;
 		parameters: Record<string, unknown>;
+		strict?: boolean;
 	};
 };
 
-type AnthropicToolSchema = {
-	name: string;
-	description: string;
-	input_schema: Record<string, unknown>;
-};
+type AnthropicToolBaseSchema = Omit<AnthropicToolSchema, 'defer_loading' | 'cache_control'>;
 
 const openAiToolSchemaCache = new Map<string, OpenAIToolSchema[]>();
-const anthropicToolSchemaCache = new Map<string, AnthropicToolSchema[]>();
+const anthropicToolSchemaCache = new Map<string, AnthropicToolBaseSchema[]>();
 
 function cacheSet<T>(cache: Map<string, T>, key: string, value: T): T {
 	if (cache.has(key)) {
@@ -51,57 +49,85 @@ function normalizeUnknown(value: unknown, parentKey = ''): unknown {
 	return Object.fromEntries(entries.map(([key, item]) => [key, normalizeUnknown(item, key)]));
 }
 
-function normalizeAgentToolDef(def: AgentToolDef): AgentToolDef {
+function normalizeAgentToolDef(
+	def: AgentToolDef,
+	provider: 'openai' | 'anthropic'
+): Record<string, unknown> {
 	return {
 		name: def.name,
 		description: def.description,
-		parameters: normalizeUnknown(def.parameters) as AgentToolDef['parameters'],
+		parameters: normalizeUnknown(def.parameters),
+		strict: def.strict === true,
+		eagerInputStreaming: provider === 'anthropic' && def.eagerInputStreaming === true,
+		schemaCacheKey: def.schemaCacheKey?.trim() || null,
 	};
 }
 
-function normalizeToolDefs(defs: AgentToolDef[]): AgentToolDef[] {
-	return defs.map(normalizeAgentToolDef);
+function toolDefsSignature(
+	defs: AgentToolDef[],
+	provider: 'openai' | 'anthropic'
+): string {
+	return JSON.stringify(defs.map((def) => normalizeAgentToolDef(def, provider)));
 }
 
-function toolDefsSignature(defs: AgentToolDef[]): string {
-	return JSON.stringify(normalizeToolDefs(defs));
-}
-
-export function buildCachedOpenAITools(defs: AgentToolDef[]): OpenAIToolSchema[] {
-	const signature = toolDefsSignature(defs);
+function buildOpenAIToolBaseSchemas(defs: AgentToolDef[]): OpenAIToolSchema[] {
+	const signature = toolDefsSignature(defs, 'openai');
 	const cached = openAiToolSchemaCache.get(signature);
 	if (cached) {
 		return cached;
 	}
-	const normalized = normalizeToolDefs(defs);
 	return cacheSet(
 		openAiToolSchemaCache,
 		signature,
-		normalized.map((def) => ({
+		defs.map((def) => ({
 			type: 'function' as const,
 			function: {
 				name: def.name,
 				description: def.description,
-				parameters: def.parameters as Record<string, unknown>,
+				parameters: normalizeUnknown(def.parameters) as Record<string, unknown>,
+				...(def.strict === true ? { strict: true } : {}),
 			},
 		}))
 	);
 }
 
-export function buildCachedAnthropicTools(defs: AgentToolDef[]): AnthropicToolSchema[] {
-	const signature = toolDefsSignature(defs);
+function buildAnthropicToolBaseSchemas(defs: AgentToolDef[]): AnthropicToolBaseSchema[] {
+	const signature = toolDefsSignature(defs, 'anthropic');
 	const cached = anthropicToolSchemaCache.get(signature);
 	if (cached) {
 		return cached;
 	}
-	const normalized = normalizeToolDefs(defs);
 	return cacheSet(
 		anthropicToolSchemaCache,
 		signature,
-		normalized.map((def) => ({
+		defs.map((def) => ({
 			name: def.name,
 			description: def.description,
-			input_schema: def.parameters as Record<string, unknown>,
+			input_schema: normalizeUnknown(def.parameters) as Record<string, unknown>,
+			...(def.strict === true ? { strict: true } : {}),
+			...(def.eagerInputStreaming === true ? { eager_input_streaming: true } : {}),
 		}))
+	);
+}
+
+export function buildOpenAIToolSchemas(defs: AgentToolDef[]): OpenAIToolSchema[] {
+	return buildOpenAIToolBaseSchemas(defs);
+}
+
+export function buildAnthropicToolSchemas(
+	defs: AgentToolDef[],
+	options?: {
+		deferToolNames?: Iterable<string>;
+		includeExperimentalBetaFields?: boolean;
+	}
+): AnthropicToolSchema[] {
+	const base = buildAnthropicToolBaseSchemas(defs);
+	const deferNames = new Set(options?.deferToolNames ?? []);
+	const includeExperimental = options?.includeExperimentalBetaFields !== false;
+	if (!includeExperimental || deferNames.size === 0) {
+		return base;
+	}
+	return base.map((schema) =>
+		deferNames.has(schema.name) ? { ...schema, defer_loading: true } : schema
 	);
 }

--- a/main-src/agent/toolSearchTool.ts
+++ b/main-src/agent/toolSearchTool.ts
@@ -1,5 +1,6 @@
 import type { AgentToolDef, ToolCall, ToolResult } from './agentTools.js';
 import { isDeferredAgentToolName } from './agentToolPool.js';
+import type { AnthropicToolResultContent } from '../llm/anthropicBeta.js';
 
 export const TOOL_SEARCH_TOOL_NAME = 'ToolSearch';
 
@@ -9,6 +10,7 @@ const MAX_RESULT_LIMIT = 12;
 export type ToolSearchRuntime = {
 	resolveFullToolPool: () => AgentToolDef[];
 	discoverTools: (names: string[]) => string[];
+	nativeAnthropicToolReference?: boolean;
 };
 
 type SearchableToolSummary = {
@@ -96,6 +98,19 @@ export async function executeToolSearchTool(
 		.slice(0, limit);
 	const matched = ranked.map((item) => item.tool);
 	const newlyLoaded = runtime.discoverTools(matched.map((tool) => tool.name));
+	const structuredContent: AnthropicToolResultContent | undefined =
+		runtime.nativeAnthropicToolReference && matched.length > 0
+			? [
+					{
+						type: 'text',
+						text: `Loaded ${matched.length} deferred tool${matched.length === 1 ? '' : 's'} for the next assistant turn.`,
+					},
+					...matched.map((tool) => ({
+						type: 'tool_reference' as const,
+						tool_name: tool.name,
+					})),
+				]
+			: undefined;
 
 	const content =
 		matched.length === 0
@@ -131,6 +146,7 @@ export async function executeToolSearchTool(
 		toolCallId: call.id,
 		name: call.name,
 		content,
+		...(structuredContent ? { structuredContent } : {}),
 		isError: false,
 	};
 }

--- a/main-src/ipc/register.ts
+++ b/main-src/ipc/register.ts
@@ -90,8 +90,10 @@ import {
 	getExecutedPlanFileKeys,
 	markPlanFileExecuted,
 	incrementThreadAgentToolCallCount,
-	getDiscoveredDeferredToolNames,
-	saveDiscoveredDeferredToolNames,
+	getDeferredToolState,
+	saveDeferredToolState,
+	getToolResultReplacementState,
+	saveToolResultReplacementState,
 	saveTeamSession,
 	getAgentSession,
 	type ChatMessage,
@@ -382,6 +384,9 @@ function resolveManagedAgentLoopOptions(
 		requestBaseURL: resolved.baseURL,
 		requestProxyUrl: resolved.proxyUrl,
 		maxOutputTokens: resolved.maxOutputTokens,
+		...(resolved.contextWindowTokens != null
+			? { contextWindowTokens: resolved.contextWindowTokens }
+			: {}),
 		composerMode: 'agent',
 		thinkingLevel,
 		workspaceRoot,
@@ -735,9 +740,12 @@ function runChatStream(
 						workspaceRoot,
 						workspaceLspManager,
 						hostWebContentsId: win.webContents.id,
-						discoveredDeferredToolNames: getDiscoveredDeferredToolNames(threadId),
-						onDiscoveredDeferredToolsChange: (names: string[]) =>
-							saveDiscoveredDeferredToolNames(threadId, names),
+						deferredToolState: getDeferredToolState(threadId),
+						onDeferredToolStateChange: (state) =>
+							saveDeferredToolState(threadId, state),
+						toolResultReplacementState: getToolResultReplacementState(threadId),
+						onToolResultReplacementStateChange: (state) =>
+							saveToolResultReplacementState(threadId, state),
 						emit: (evt) => send(evt),
 						onDone: (full, usage, teamSnapshot) => {
 							updateLastAssistant(threadId, full);
@@ -796,7 +804,8 @@ function runChatStream(
 					mistakeLimitWaiters
 				);
 			const ag = getSettings().agent;
-			const discoveredDeferredTools = getDiscoveredDeferredToolNames(threadId);
+			const deferredToolState = getDeferredToolState(threadId);
+			const toolResultReplacementState = getToolResultReplacementState(threadId);
 			const customToolHandlers = {
 					request_user_input: createRequestUserInputToolHandler({
 						threadId,
@@ -814,6 +823,9 @@ function runChatStream(
 					requestBaseURL: resolved.baseURL,
 					requestProxyUrl: resolved.proxyUrl,
 					maxOutputTokens: resolved.maxOutputTokens,
+					...(resolved.contextWindowTokens != null
+						? { contextWindowTokens: resolved.contextWindowTokens }
+						: {}),
 					signal: ac.signal,
 					composerMode: mode,
 					thinkingLevel,
@@ -825,9 +837,12 @@ function runChatStream(
 					workspaceRoot,
 					workspaceLspManager,
 					hostWebContentsId: win.webContents.id,
-					discoveredDeferredToolNames: discoveredDeferredTools,
-					onDiscoveredDeferredToolsChange: (names: string[]) =>
-						saveDiscoveredDeferredToolNames(threadId, names),
+					deferredToolState,
+					onDeferredToolStateChange: (state) =>
+						saveDeferredToolState(threadId, state),
+					toolResultReplacementState,
+					onToolResultReplacementStateChange: (state) =>
+						saveToolResultReplacementState(threadId, state),
 				};
 			try {
 				setDelegateContext(
@@ -884,6 +899,9 @@ function runChatStream(
 						requestBaseURL: resolved.baseURL,
 						requestProxyUrl: resolved.proxyUrl,
 						maxOutputTokens: resolved.maxOutputTokens,
+						...(resolved.contextWindowTokens != null
+							? { contextWindowTokens: resolved.contextWindowTokens }
+							: {}),
 						signal: ac.signal,
 						composerMode: mode,
 						thinkingLevel,
@@ -896,9 +914,12 @@ function runChatStream(
 						workspaceLspManager,
 						threadId,
 						hostWebContentsId: win.webContents.id,
-						discoveredDeferredToolNames: discoveredDeferredTools,
-						onDiscoveredDeferredToolsChange: (names: string[]) =>
-							saveDiscoveredDeferredToolNames(threadId, names),
+						deferredToolState,
+						onDeferredToolStateChange: (state) =>
+							saveDeferredToolState(threadId, state),
+						toolResultReplacementState,
+						onToolResultReplacementStateChange: (state) =>
+							saveToolResultReplacementState(threadId, state),
 						toolHooks: {
 							beforeWrite: ({ path, previousContent }) => {
 								const snapshots = agentRevertSnapshotsByThread.get(threadId);
@@ -2587,6 +2608,11 @@ export function registerIpc(): void {
 		if (!options) {
 			return { ok: false as const, error: 'no-model' };
 		}
+		options.deferredToolState = getDeferredToolState(threadId);
+		options.onDeferredToolStateChange = (state) => saveDeferredToolState(threadId, state);
+		options.toolResultReplacementState = getToolResultReplacementState(threadId);
+		options.onToolResultReplacementStateChange = (state) =>
+			saveToolResultReplacementState(threadId, state);
 		const send = (evt: import('../agent/managedSubagents.js').ManagedAgentUiEvent) =>
 			event.sender.send('async-shell:chat', evt);
 		const result = await sendInputToManagedAgent({
@@ -2636,6 +2662,11 @@ export function registerIpc(): void {
 		if (!options) {
 			return { ok: false as const, error: 'no-model' };
 		}
+		options.deferredToolState = getDeferredToolState(threadId);
+		options.onDeferredToolStateChange = (state) => saveDeferredToolState(threadId, state);
+		options.toolResultReplacementState = getToolResultReplacementState(threadId);
+		options.onToolResultReplacementStateChange = (state) =>
+			saveToolResultReplacementState(threadId, state);
 		const send = (evt: import('../agent/managedSubagents.js').ManagedAgentUiEvent) =>
 			event.sender.send('async-shell:chat', evt);
 		const result = await resumeManagedAgent({

--- a/main-src/llm/anthropicAdapter.ts
+++ b/main-src/llm/anthropicAdapter.ts
@@ -2,7 +2,7 @@ import Anthropic from '@anthropic-ai/sdk';
 import type { MessageParam } from '@anthropic-ai/sdk/resources/messages';
 import type { ChatMessage } from '../threadStore.js';
 import type { ShellSettings } from '../settingsStore.js';
-import { composeSystem, temperatureForMode } from './modePrompts.js';
+import { composeSystemSections, temperatureForMode } from './modePrompts.js';
 import type { StreamHandlers, TurnTokenUsage, UnifiedChatOptions } from './types.js';
 import {
 	anthropicEffectiveMaxTokens,
@@ -71,17 +71,25 @@ export async function streamAnthropic(
 	);
 
 	const storedSystem = messages.find((m) => m.role === 'system');
-	const systemText = prependProviderIdentitySystemPrompt(
-		settings,
-		composeSystem(storedSystem?.content, options.mode, options.agentSystemAppend)
-	);
 	const model = options.requestModelId.trim();
 	if (!model) {
 		handlers.onError('模型请求名称为空。请在 Models 中编辑该模型的「请求名称」。');
 		return;
 	}
 	const promptCaching = isAnthropicPromptCachingEnabled(model);
-	const system = buildAnthropicSystemForApi(systemText, promptCaching);
+	const systemSections = composeSystemSections(
+		storedSystem?.content,
+		options.mode,
+		options.agentSystemAppend
+	);
+	const system = buildAnthropicSystemForApi(
+		{
+			...systemSections,
+			staticText: prependProviderIdentitySystemPrompt(settings, systemSections.staticText),
+			fullText: prependProviderIdentitySystemPrompt(settings, systemSections.fullText),
+		},
+		promptCaching
+	);
 	const anthropicMessages = addAnthropicCacheBreakpoints(
 		toAnthropicMessages(messages),
 		promptCaching,

--- a/main-src/llm/anthropicBeta.ts
+++ b/main-src/llm/anthropicBeta.ts
@@ -1,0 +1,44 @@
+import type {
+	ImageBlockParam,
+	TextBlockParam,
+	Tool,
+	ToolResultBlockParam,
+} from '@anthropic-ai/sdk/resources/messages';
+
+export type AnthropicCacheControl = { type: 'ephemeral' };
+
+export type AnthropicToolReferenceBlock = {
+	type: 'tool_reference';
+	tool_name: string;
+};
+
+export type AnthropicToolResultContentBlock =
+	| TextBlockParam
+	| ImageBlockParam
+	| AnthropicToolReferenceBlock;
+
+export type AnthropicToolResultContent =
+	| string
+	| AnthropicToolResultContentBlock[];
+
+export type AnthropicToolResultBlock = Omit<ToolResultBlockParam, 'content'> & {
+	content?: AnthropicToolResultContent;
+};
+
+export type AnthropicToolSchema = Tool & {
+	strict?: boolean;
+	defer_loading?: boolean;
+	eager_input_streaming?: boolean;
+	cache_control?: AnthropicCacheControl | null;
+};
+
+export function isAnthropicToolReferenceBlock(
+	value: unknown
+): value is AnthropicToolReferenceBlock {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		(value as { type?: unknown }).type === 'tool_reference' &&
+		typeof (value as { tool_name?: unknown }).tool_name === 'string'
+	);
+}

--- a/main-src/llm/anthropicPromptCache.ts
+++ b/main-src/llm/anthropicPromptCache.ts
@@ -9,6 +9,7 @@
  */
 
 import type { ContentBlockParam, MessageParam, TextBlockParam } from '@anthropic-ai/sdk/resources/messages';
+import type { SystemPromptSections } from './modePrompts.js';
 
 export type AnthropicCacheControl = { type: 'ephemeral' };
 
@@ -38,22 +39,36 @@ export function isAnthropicPromptCachingEnabled(model: string): boolean {
  * 对齐 `buildSystemPromptBlocks`：启用缓存时把 system 设为单块可缓存文本；关闭时保持普通 string 以减小请求体差异。
  */
 export function buildAnthropicSystemForApi(
-	systemText: string,
+	systemInput: string | SystemPromptSections,
 	enableCaching: boolean
 ): string | TextBlockParam[] {
+	const systemSections =
+		typeof systemInput === 'string'
+			? { staticText: systemInput, dynamicText: '', fullText: systemInput }
+			: systemInput;
+	const staticText = systemSections.staticText.trim();
+	const dynamicText = systemSections.dynamicText.trim();
 	if (!enableCaching) {
-		return systemText;
+		return systemSections.fullText;
 	}
-	if (!systemText) {
-		return systemText;
+	if (!staticText && !dynamicText) {
+		return systemSections.fullText;
 	}
-	return [
-		{
+	const blocks: TextBlockParam[] = [];
+	if (staticText) {
+		blocks.push({
 			type: 'text',
-			text: systemText,
+			text: staticText,
 			cache_control: getAnthropicCacheControl(),
-		},
-	];
+		});
+	}
+	if (dynamicText) {
+		blocks.push({
+			type: 'text',
+			text: dynamicText,
+		});
+	}
+	return blocks;
 }
 
 function withCacheOnLastUserContentBlock(blocks: ContentBlockParam[]): ContentBlockParam[] {

--- a/main-src/llm/modePrompts.ts
+++ b/main-src/llm/modePrompts.ts
@@ -1,5 +1,11 @@
 import type { ComposerMode } from './composerMode.js';
 
+export type SystemPromptSections = {
+	staticText: string;
+	dynamicText: string;
+	fullText: string;
+};
+
 function modeBlock(mode: ComposerMode): string {
 	switch (mode) {
 		case 'ask':
@@ -201,6 +207,23 @@ export function composeSystem(baseSystem: string | undefined, mode: ComposerMode
 		core += `\n\n---\n${extra}`;
 	}
 	return core;
+}
+
+export function composeSystemSections(
+	baseSystem: string | undefined,
+	mode: ComposerMode,
+	agentAppend?: string
+): SystemPromptSections {
+	const base = (baseSystem ?? '').trim();
+	const block = modeBlock(mode);
+	const staticText = (!base ? block : `${base}\n\n---\n${block}`).trim();
+	const dynamicText = (agentAppend ?? '').trim();
+	const fullText = dynamicText ? `${staticText}\n\n---\n${dynamicText}` : staticText;
+	return {
+		staticText,
+		dynamicText,
+		fullText,
+	};
 }
 
 export function temperatureForMode(mode: ComposerMode): number {

--- a/main-src/mcp/mcpManager.ts
+++ b/main-src/mcp/mcpManager.ts
@@ -30,6 +30,9 @@ function mcpToolToAgentTool(tool: McpToolWithSource): AgentToolDef {
 	return {
 		name: buildMcpToolName(tool.serverId, tool.name),
 		description: tool.description ?? `MCP tool: ${tool.name} (from ${tool.serverName})`,
+		shouldDefer: true,
+		isMcp: true,
+		schemaCacheKey: `${tool.serverId}:${tool.name}`,
 		parameters: {
 			type: 'object',
 			properties: (tool.inputSchema.properties ?? {}) as Record<string, Record<string, unknown>>,

--- a/main-src/threadStore.ts
+++ b/main-src/threadStore.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'node:crypto';
 import { resolveAsyncDataDir } from './dataDir.js';
 import { appendSuffixToStructuredAssistant, isStructuredAssistantMessage } from '../src/agentStructuredMessage.js';
 import type { AgentSessionSnapshot } from '../src/agentSessionTypes.js';
+import type { ToolResultReplacementState } from './agent/toolResultBudget.js';
 
 export type ChatMessage = {
 	role: 'user' | 'assistant' | 'system';
@@ -45,6 +46,14 @@ export type TeamSessionSnapshot = {
 	reviewVerdict: 'approved' | 'revision_needed' | null;
 };
 
+export type DeferredToolState = {
+	discoveredToolNames: string[];
+	providerLoadedToolNames?: {
+		anthropic?: string[];
+		openai?: string[];
+	};
+};
+
 export type ThreadRecord = {
 	id: string;
 	title: string;
@@ -60,8 +69,10 @@ export type ThreadRecord = {
 	agentToolCallsCompleted?: number;
 	/** 上次记忆抽取完成时的 `agentToolCallsCompleted`，用于计算间隔内工具调用数 */
 	memoryExtractionToolBaseline?: number;
-	/** 线程中已通过 ToolSearch 加载过的延迟工具名（当前主要是 MCP 动态工具）。 */
+	/** 线程中已通过 ToolSearch 加载过的延迟工具状态（兼容旧字段懒升级）。 */
+	deferredToolState?: DeferredToolState;
 	discoveredDeferredToolNames?: string[];
+	toolResultReplacementState?: ToolResultReplacementState;
 	plan?: ThreadPlan;
 	executedPlanFileKeys?: string[];
 	teamSession?: TeamSessionSnapshot;
@@ -531,25 +542,131 @@ export function incrementThreadAgentToolCallCount(threadId: string): void {
 	save();
 }
 
-export function getDiscoveredDeferredToolNames(threadId: string): string[] {
-	const thread = getThread(threadId);
-	if (!thread?.discoveredDeferredToolNames) {
-		return [];
-	}
-	return [...new Set(thread.discoveredDeferredToolNames.map((item) => String(item).trim()).filter(Boolean))];
+function normalizeToolNameList(values: Iterable<string>): string[] {
+	return [...new Set(Array.from(values).map((item) => String(item).trim()).filter(Boolean))].sort((a, b) =>
+		a.localeCompare(b)
+	);
 }
 
-export function saveDiscoveredDeferredToolNames(threadId: string, names: string[]): void {
+function normalizeDeferredToolState(
+	state?: DeferredToolState | null,
+	legacyNames?: string[] | null
+): DeferredToolState {
+	const discovered = normalizeToolNameList([
+		...(state?.discoveredToolNames ?? []),
+		...(legacyNames ?? []),
+	]);
+	const providerLoadedToolNames =
+		state?.providerLoadedToolNames
+			? {
+					...(state.providerLoadedToolNames.anthropic?.length
+						? { anthropic: normalizeToolNameList(state.providerLoadedToolNames.anthropic) }
+						: {}),
+					...(state.providerLoadedToolNames.openai?.length
+						? { openai: normalizeToolNameList(state.providerLoadedToolNames.openai) }
+						: {}),
+				}
+			: undefined;
+	return {
+		discoveredToolNames: discovered,
+		...(providerLoadedToolNames && Object.keys(providerLoadedToolNames).length > 0
+			? { providerLoadedToolNames }
+			: {}),
+	};
+}
+
+function upgradeThreadDeferredState(thread: ThreadRecord): DeferredToolState {
+	const normalized = normalizeDeferredToolState(
+		thread.deferredToolState,
+		thread.discoveredDeferredToolNames
+	);
+	thread.deferredToolState = normalized;
+	if (thread.discoveredDeferredToolNames) {
+		delete thread.discoveredDeferredToolNames;
+	}
+	return normalized;
+}
+
+export function getDeferredToolState(threadId: string): DeferredToolState {
+	const thread = getThread(threadId);
+	if (!thread) {
+		return { discoveredToolNames: [] };
+	}
+	return upgradeThreadDeferredState(thread);
+}
+
+export function saveDeferredToolState(threadId: string, state: DeferredToolState): void {
 	const thread = getThread(threadId);
 	if (!thread) {
 		return;
 	}
-	const normalized = [...new Set(names.map((item) => String(item).trim()).filter(Boolean))].sort((a, b) =>
-		a.localeCompare(b)
-	);
-	thread.discoveredDeferredToolNames = normalized;
+	thread.deferredToolState = normalizeDeferredToolState(state);
+	if (thread.discoveredDeferredToolNames) {
+		delete thread.discoveredDeferredToolNames;
+	}
 	thread.updatedAt = Date.now();
 	save();
+}
+
+export function getDiscoveredDeferredToolNames(threadId: string): string[] {
+	return getDeferredToolState(threadId).discoveredToolNames;
+}
+
+export function saveDiscoveredDeferredToolNames(threadId: string, names: string[]): void {
+	const current = getDeferredToolState(threadId);
+	saveDeferredToolState(threadId, {
+		...current,
+		discoveredToolNames: names,
+	});
+}
+
+export function getToolResultReplacementState(threadId: string): ToolResultReplacementState {
+	const thread = getThread(threadId);
+	if (!thread?.toolResultReplacementState) {
+		return { seenToolUseIds: [], replacements: [] };
+	}
+	return {
+		seenToolUseIds: normalizeToolNameList(thread.toolResultReplacementState.seenToolUseIds ?? []),
+		replacements: [...(thread.toolResultReplacementState.replacements ?? [])]
+			.map((record) => ({
+				toolUseId: String(record.toolUseId ?? '').trim(),
+				toolName: String(record.toolName ?? '').trim(),
+				replacement: String(record.replacement ?? ''),
+				originalSize: Math.max(0, Math.floor(Number(record.originalSize ?? 0) || 0)),
+			}))
+			.filter((record) => record.toolUseId.length > 0)
+			.sort((a, b) => a.toolUseId.localeCompare(b.toolUseId)),
+	};
+}
+
+export function saveToolResultReplacementState(
+	threadId: string,
+	state: ToolResultReplacementState
+): void {
+	const thread = getThread(threadId);
+	if (!thread) {
+		return;
+	}
+	thread.toolResultReplacementState = getToolResultReplacementStateFromInput(state);
+	thread.updatedAt = Date.now();
+	save();
+}
+
+function getToolResultReplacementStateFromInput(
+	state: ToolResultReplacementState
+): ToolResultReplacementState {
+	return {
+		seenToolUseIds: normalizeToolNameList(state.seenToolUseIds ?? []),
+		replacements: [...(state.replacements ?? [])]
+			.map((record) => ({
+				toolUseId: String(record.toolUseId ?? '').trim(),
+				toolName: String(record.toolName ?? '').trim(),
+				replacement: String(record.replacement ?? ''),
+				originalSize: Math.max(0, Math.floor(Number(record.originalSize ?? 0) || 0)),
+			}))
+			.filter((record) => record.toolUseId.length > 0)
+			.sort((a, b) => a.toolUseId.localeCompare(b.toolUseId)),
+	};
 }
 
 export function saveMemoryExtractedMessageCount(threadId: string, count: number): void {

--- a/src/AgentChatPanel.tsx
+++ b/src/AgentChatPanel.tsx
@@ -36,6 +36,11 @@ import {
 	segmentAssistantContentUnified,
 } from './agentChatSegments';
 import { computeMergedAgentFileChanges } from './agentFileChangesCompute';
+import {
+	computeLatestTurnFocusSpacerPx,
+	findLatestTurnFocusUserIndex,
+	findStickyUserIndexForViewport,
+} from './agentTurnFocus';
 import { useAppShellGitFiles, useAppShellGitMeta } from './app/appShellContexts';
 import { userMessageToSegments, type ComposerSegment } from './composerSegments';
 import type { WizardPending } from './hooks/useWizardPending';
@@ -336,6 +341,8 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 	const trackGapPx = isEditorRail ? 20 : 22;
 	const messageRowHeightsRef = useRef<Map<number, number>>(new Map());
 	const [messageStartIndex, setMessageStartIndex] = useState(0);
+	const [latestTurnFocusSpacerPx, setLatestTurnFocusSpacerPx] = useState(0);
+	const [stickyUserIndex, setStickyUserIndex] = useState<number | null>(null);
 	const messagesTopSentinelRef = useRef<HTMLDivElement | null>(null);
 	const pendingPrependScrollRef = useRef<{ prevScrollHeight: number } | null>(null);
 	const prevDisplayMessagesLenRef = useRef(displayMessages.length);
@@ -348,6 +355,10 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 
 	const len = displayMessages.length;
 	const allHistoryRendered = messageStartIndex <= 0;
+	const latestTurnFocusUserIndex = useMemo(
+		() => findLatestTurnFocusUserIndex(displayMessages, composerMode),
+		[displayMessages, composerMode]
+	);
 	const lastDisplayedMessage = len > 0 ? displayMessages[len - 1] : undefined;
 	const lastMessageLayoutSig = useMemo(
 		() =>
@@ -499,6 +510,115 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 			viewport.scrollTop += delta;
 		}
 	}, [messageStartIndex, displayMessages.length]);
+
+	useLayoutEffect(() => {
+		if (!hasConversation || latestTurnFocusUserIndex == null) {
+			setLatestTurnFocusSpacerPx((prev) => (prev === 0 ? prev : 0));
+			return;
+		}
+		const viewport = messagesViewportRef.current;
+		if (!viewport) {
+			return;
+		}
+		const viewportStyle = window.getComputedStyle(viewport);
+		const topPadding = Number.parseFloat(viewportStyle.paddingTop || '0') || 0;
+		const bottomPadding = Number.parseFloat(viewportStyle.paddingBottom || '0') || 0;
+		const activeRowHeight = Math.max(0, getRowHeightForBudget(latestTurnFocusUserIndex));
+		let belowContentHeight = 0;
+		for (let i = latestTurnFocusUserIndex + 1; i < len; i++) {
+			belowContentHeight += Math.max(0, getRowHeightForBudget(i));
+			belowContentHeight += trackGapPx;
+		}
+		const baseSpacer = computeLatestTurnFocusSpacerPx({
+			viewportHeight: viewport.clientHeight,
+			topPadding,
+			bottomPadding,
+			activeRowHeight,
+			belowContentHeight,
+		});
+		const nextSpacer = baseSpacer > 0 ? Math.max(0, baseSpacer - trackGapPx) : 0;
+		setLatestTurnFocusSpacerPx((prev) => (Math.abs(prev - nextSpacer) <= 1 ? prev : nextSpacer));
+	}, [
+		hasConversation,
+		latestTurnFocusUserIndex,
+		len,
+		lastMessageLayoutSig,
+		conversationRenderKey,
+		getRowHeightForBudget,
+		trackGapPx,
+		messagesViewportRef,
+	]);
+
+	useLayoutEffect(() => {
+		if (!hasConversation || composerMode === 'team') {
+			setStickyUserIndex((prev) => (prev == null ? prev : null));
+			return;
+		}
+		const viewport = messagesViewportRef.current;
+		const track = messagesTrackRef.current;
+		if (!viewport || !track) {
+			return;
+		}
+		const syncStickyUserIndex = () => {
+			const viewportRect = viewport.getBoundingClientRect();
+			const viewportStyle = window.getComputedStyle(viewport);
+			const stickyTopPx = viewportRect.top + (Number.parseFloat(viewportStyle.paddingTop || '0') || 0);
+			const renderedRowTops = Array.from(
+				track.querySelectorAll<HTMLElement>('.ref-msg-row-measure[data-msg-index]')
+			)
+				.map((row) => {
+					const raw = row.dataset.msgIndex;
+					const index = raw ? Number(raw) : Number.NaN;
+					return {
+						index,
+						top: row.getBoundingClientRect().top - stickyTopPx,
+					};
+				})
+				.filter((row) => Number.isFinite(row.index));
+			const nextStickyIndex = findStickyUserIndexForViewport({
+				displayMessages,
+				renderedRowTops,
+				stickyTopPx: 0,
+			});
+			const resolvedStickyIndex =
+				nextStickyIndex === latestTurnFocusUserIndex ? null : nextStickyIndex;
+			setStickyUserIndex((prev) => (prev === resolvedStickyIndex ? prev : resolvedStickyIndex));
+		};
+		let rafId = 0;
+		const scheduleSyncStickyUserIndex = () => {
+			if (rafId !== 0) {
+				return;
+			}
+			rafId = window.requestAnimationFrame(() => {
+				rafId = 0;
+				syncStickyUserIndex();
+			});
+		};
+		scheduleSyncStickyUserIndex();
+		viewport.addEventListener('scroll', scheduleSyncStickyUserIndex, { passive: true });
+		const resizeObserver = new ResizeObserver(() => {
+			scheduleSyncStickyUserIndex();
+		});
+		resizeObserver.observe(track);
+		return () => {
+			viewport.removeEventListener('scroll', scheduleSyncStickyUserIndex);
+			resizeObserver.disconnect();
+			if (rafId !== 0) {
+				window.cancelAnimationFrame(rafId);
+			}
+		};
+	}, [
+		hasConversation,
+		composerMode,
+		conversationRenderKey,
+		lastMessageLayoutSig,
+		latestTurnFocusSpacerPx,
+		latestTurnFocusUserIndex,
+		displayMessages,
+		messageStartIndex,
+		messagesViewportRef,
+		messagesTrackRef,
+	]);
 
 	const messageNodeAtIndex = (i: number): ReactNode => {
 			const m = displayMessages[i];
@@ -725,7 +845,7 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 		const nodes: ReactNode[] = [];
 		const convoKey = conversationRenderKey;
 		for (let i = messageStartIndex; i < displayMessages.length; i++) {
-			const isStickyUserRow = displayMessages[i]?.role === 'user';
+			const isStickyUserRow = i === stickyUserIndex;
 			nodes.push(
 				<div
 					key={`row-${convoKey}-${i}`}
@@ -743,6 +863,16 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 					`[perf] renderChatMessageList: ${elapsed.toFixed(1)}ms, slice=${nodes.length}/${displayMessages.length}, awaiting=${awaitingReply}`
 				);
 			}
+		}
+		if (latestTurnFocusSpacerPx > 0) {
+			nodes.push(
+				<div
+					key={`row-${convoKey}-turn-focus-tail`}
+					className="ref-messages-tail-spacer"
+					style={{ height: `${latestTurnFocusSpacerPx}px` }}
+					aria-hidden
+				/>
+			);
 		}
 		return nodes;
 	};

--- a/src/agentStructuredMessage.ts
+++ b/src/agentStructuredMessage.ts
@@ -2,6 +2,8 @@
  * Agent 助手消息的结构化持久化格式，磁盘存 JSON；发 API 时再展开为原有 XML 协议。
  */
 
+import type { AnthropicToolResultContent } from '../main-src/llm/anthropicBeta.js';
+
 export type AgentAssistantTextPart = { type: 'text'; text: string };
 
 export type AgentAssistantToolPart = {
@@ -10,6 +12,7 @@ export type AgentAssistantToolPart = {
 	name: string;
 	args: Record<string, unknown>;
 	result: string;
+	resultStructured?: AnthropicToolResultContent;
 	success: boolean;
 	subParent?: string;
 	subDepth?: number;
@@ -25,6 +28,35 @@ export type AgentAssistantPayload = {
 
 function escapeToolResultForMarker(raw: string): string {
 	return raw.split('</tool_result>').join('</tool\u200c_result>');
+}
+
+function isValidStructuredToolResultContent(value: unknown): value is AnthropicToolResultContent {
+	if (typeof value === 'string') {
+		return true;
+	}
+	if (!Array.isArray(value)) {
+		return false;
+	}
+	for (const item of value) {
+		if (!item || typeof item !== 'object' || Array.isArray(item)) {
+			return false;
+		}
+		const block = item as Record<string, unknown>;
+		if (block.type === 'text') {
+			if (typeof block.text !== 'string') return false;
+			continue;
+		}
+		if (block.type === 'tool_reference') {
+			if (typeof block.tool_name !== 'string') return false;
+			continue;
+		}
+		if (block.type === 'image') {
+			if (!block.source || typeof block.source !== 'object') return false;
+			continue;
+		}
+		return false;
+	}
+	return true;
 }
 
 /** 与 agentLoop / App 写入 tool_result 标记时一致 */
@@ -67,6 +99,9 @@ export function parseAgentAssistantPayload(raw: string): AgentAssistantPayload |
 				if (typeof pt.toolUseId !== 'string' || typeof pt.name !== 'string') return null;
 				if (!pt.args || typeof pt.args !== 'object' || Array.isArray(pt.args)) return null;
 				if (typeof pt.result !== 'string' || typeof pt.success !== 'boolean') return null;
+				if (pt.resultStructured !== undefined && !isValidStructuredToolResultContent(pt.resultStructured)) {
+					return null;
+				}
 				if (pt.subParent !== undefined && typeof pt.subParent !== 'string') return null;
 				if (pt.subDepth !== undefined && typeof pt.subDepth !== 'number') return null;
 			} else {

--- a/src/agentTurnFocus.test.ts
+++ b/src/agentTurnFocus.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	computeLatestTurnFocusSpacerPx,
+	findLatestTurnFocusUserIndex,
+	findStickyUserIndexForViewport,
+} from './agentTurnFocus';
+import type { ChatMessage } from './threadTypes';
+
+describe('agentTurnFocus', () => {
+	it('targets the latest user turn only when there is earlier replied history', () => {
+		const displayMessages: ChatMessage[] = [
+			{ role: 'user', content: '第一轮提问' },
+			{ role: 'assistant', content: '第一轮回复' },
+			{ role: 'user', content: '第二轮提问' },
+			{ role: 'assistant', content: '流式中' },
+		];
+
+		expect(findLatestTurnFocusUserIndex(displayMessages, 'agent')).toBe(2);
+	});
+
+	it('keeps turn focus on the latest user message even after a short assistant reply finishes', () => {
+		expect(
+			findLatestTurnFocusUserIndex(
+				[
+					{ role: 'user', content: '第一轮提问' },
+					{ role: 'assistant', content: '第一轮回复' },
+					{ role: 'user', content: '第二轮提问' },
+					{ role: 'assistant', content: '短回复' },
+				],
+				'agent'
+			)
+		).toBe(2);
+	});
+
+	it('does not enable turn focus for the first turn or team bootstrapping', () => {
+		expect(
+			findLatestTurnFocusUserIndex(
+				[
+					{ role: 'user', content: '第一条消息' },
+					{ role: 'assistant', content: '流式中' },
+				],
+				'ask'
+			)
+		).toBeNull();
+
+		expect(
+			findLatestTurnFocusUserIndex(
+				[
+					{ role: 'user', content: 'team 消息' },
+					{ role: 'assistant', content: '流式中' },
+				],
+				'team'
+			)
+		).toBeNull();
+
+		expect(
+			findLatestTurnFocusUserIndex(
+				[
+					{ role: 'user', content: '普通提问' },
+					{ role: 'assistant', content: '普通回复' },
+				],
+				'agent'
+			)
+		).toBeNull();
+	});
+
+	it('computes only the spacer needed to pull the active user turn to the top', () => {
+		const spacer = computeLatestTurnFocusSpacerPx({
+			viewportHeight: 600,
+			topPadding: 8,
+			bottomPadding: 100,
+			activeRowHeight: 70,
+			belowContentHeight: 72,
+		});
+
+		expect(spacer).toBe(350);
+	});
+
+	it('returns zero when the last user row already fills the available viewport height', () => {
+		const spacer = computeLatestTurnFocusSpacerPx({
+			viewportHeight: 600,
+			topPadding: 8,
+			bottomPadding: 100,
+			activeRowHeight: 420,
+			belowContentHeight: 100,
+		});
+
+		expect(spacer).toBe(0);
+	});
+
+	it('picks the nearest user message that has crossed the sticky top boundary', () => {
+		const displayMessages: ChatMessage[] = [
+			{ role: 'user', content: 'u1' },
+			{ role: 'assistant', content: 'a1' },
+			{ role: 'user', content: 'u2' },
+			{ role: 'assistant', content: 'a2' },
+			{ role: 'user', content: 'u3' },
+		];
+
+		expect(
+			findStickyUserIndexForViewport({
+				displayMessages,
+				renderedRowTops: [
+					{ index: 0, top: -220 },
+					{ index: 1, top: -120 },
+					{ index: 2, top: -16 },
+					{ index: 3, top: 96 },
+					{ index: 4, top: 240 },
+				],
+				stickyTopPx: 0,
+			})
+		).toBe(2);
+	});
+
+	it('does not activate sticky state before any user bubble reaches the top edge', () => {
+		const displayMessages: ChatMessage[] = [
+			{ role: 'user', content: 'u1' },
+			{ role: 'assistant', content: 'a1' },
+			{ role: 'user', content: 'u2' },
+		];
+
+		expect(
+			findStickyUserIndexForViewport({
+				displayMessages,
+				renderedRowTops: [
+					{ index: 0, top: 24 },
+					{ index: 1, top: 120 },
+					{ index: 2, top: 256 },
+				],
+				stickyTopPx: 0,
+			})
+		).toBeNull();
+	});
+});

--- a/src/agentTurnFocus.ts
+++ b/src/agentTurnFocus.ts
@@ -1,0 +1,72 @@
+import type { ComposerMode } from './ComposerPlusMenu';
+import type { ChatMessage } from './threadTypes';
+
+export const STICKY_USER_SNAP_PX = 12;
+
+export function findLatestTurnFocusUserIndex(
+	displayMessages: ChatMessage[],
+	composerMode: ComposerMode
+): number | null {
+	if (composerMode === 'team' || displayMessages.length === 0) {
+		return null;
+	}
+	let userIndex = -1;
+	for (let i = displayMessages.length - 1; i >= 0; i--) {
+		if (displayMessages[i]?.role === 'user') {
+			userIndex = i;
+			break;
+		}
+	}
+	if (userIndex < 0) {
+		return null;
+	}
+	const hasEarlierAssistant = displayMessages
+		.slice(0, userIndex)
+		.some((message) => message.role === 'assistant');
+	return hasEarlierAssistant ? userIndex : null;
+}
+
+export function computeLatestTurnFocusSpacerPx(params: {
+	viewportHeight: number;
+	topPadding: number;
+	bottomPadding: number;
+	activeRowHeight: number;
+	belowContentHeight: number;
+}): number {
+	const { viewportHeight, topPadding, bottomPadding, activeRowHeight, belowContentHeight } = params;
+	if (viewportHeight <= 0) {
+		return 0;
+	}
+	return Math.max(
+		0,
+		Math.ceil(
+			viewportHeight -
+				Math.max(0, topPadding) -
+				Math.max(0, bottomPadding) -
+				Math.max(0, activeRowHeight) -
+				Math.max(0, belowContentHeight)
+		)
+	);
+}
+
+export function findStickyUserIndexForViewport(params: {
+	displayMessages: ChatMessage[];
+	renderedRowTops: Array<{ index: number; top: number }>;
+	stickyTopPx: number;
+}): number | null {
+	const { displayMessages, renderedRowTops, stickyTopPx } = params;
+	let candidate: number | null = null;
+	for (const row of renderedRowTops) {
+		if (displayMessages[row.index]?.role !== 'user') {
+			continue;
+		}
+		if (row.top <= stickyTopPx + STICKY_USER_SNAP_PX) {
+			candidate = row.index;
+			continue;
+		}
+		if (candidate != null) {
+			break;
+		}
+	}
+	return candidate;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -3291,6 +3291,12 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 	flex-shrink: 0;
 }
 
+.ref-messages-tail-spacer {
+	width: 100%;
+	flex-shrink: 0;
+	pointer-events: none;
+}
+
 /* ??????/????????????????????????? */
 .ref-msg-slot {
 	display: flex;
@@ -3335,7 +3341,7 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 	/* �?.ref-msg-user 同圆角：否则父级方角会在气泡左下/右下露出更深的楔�?*/
 	border-radius: 18px;
 	overflow: hidden;
-	background: var(--void-bg-0);
+	/*background: var(--void-bg-0);*/
 	box-shadow:
 		0 1px 0 rgba(255, 255, 255, 0.04),
 		0 18px 32px -12px rgba(0, 0, 0, 0.65);
@@ -3343,7 +3349,7 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 
 /* ?????????????? */
 .ref-center--chat .ref-msg-sticky-user-wrap {
-	background: var(--void-bg-0);
+	/*background: var(--void-bg-0);*/
 }
 
 /* ?? sticky ????????? diff ???? */

--- a/src/styles/mac-codex.css
+++ b/src/styles/mac-codex.css
@@ -813,9 +813,15 @@
 }
 
 :root[data-ui-style='mac-codex'] .ref-msg-sticky-user-wrap {
-	background: transparent;
-	box-shadow: none;
-	border-radius: 22px;
+	/*background: linear-gradient(*/
+	/*	180deg,*/
+	/*	color-mix(in srgb, var(--surface-panel-bg-strong) 98%, transparent) 0%,*/
+	/*	color-mix(in srgb, var(--surface-panel-bg) 96%, transparent) 100%*/
+	/*);*/
+	/*backdrop-filter: saturate(180%) blur(14px);*/
+	/*-webkit-backdrop-filter: saturate(180%) blur(14px);*/
+	/*box-shadow: var(--shadow-floating), var(--void-shadow-soft);*/
+	/*border-radius: 22px;*/
 }
 
 :root[data-ui-style='mac-codex'] .ref-msg-user {


### PR DESCRIPTION
﻿## Summary

This branch ships two related improvements: Anthropic-native deferred tool execution with tighter turn budgeting and persistence, plus a chat UI refinement that keeps the active user turn readable while streaming long assistant replies.

## Anthropic agent runtime (`c1c69fa`)

- **Deferred tools**: Model-driven deferral via `defer_loading` / `tool_reference`-style flows so tools are not fully materialized until needed.
- **Context analysis**: New `toolContextAnalysis` to decide what context is required before expanding tool payloads.
- **Turn budgeting**: New `toolResultBudget` to cap tool-result volume per turn while keeping the loop stable.
- **Wiring**: Updates across `agentLoop`, orchestration, structured assistant → API mapping, Anthropic adapter/beta headers, prompt cache behavior, MCP manager hooks, IPC registration, and thread persistence for oversized tool results.

## Chat UX (`07b64bd`)

- **Turn focus**: Adds `agentTurnFocus` helpers and integrates them into `AgentChatPanel` to compute a tail spacer so the latest user bubble can align with the viewport during replies.
- **Sticky user rows**: Sticky state is derived from measured row positions during scroll/resize instead of treating every user row as sticky.
- **Styles**: Adds `ref-messages-tail-spacer` and adjusts sticky user wrap styling in `index.css` / `mac-codex.css` for cleaner overlap.
- **Tests**: Vitest coverage for focus/spacer/sticky selection logic.

## How to test

- Run the existing Vitest suite (including `src/agentTurnFocus.test.ts` and agent API mapping tests touched by this branch).
- Manually verify long assistant streams: latest user message stays visually anchored; scrolling earlier user turns still behaves sensibly outside team mode.
