### PR TITLE
Settings: remove placeholder nav, collapsible slash commands, portal toasts

### DIFF
--- a/main-src/ipc/register.ts
+++ b/main-src/ipc/register.ts
@@ -1504,19 +1504,13 @@ export function registerIpc(): void {
 		'team',
 		'bots',
 		'agents',
-		'tab',
 		'models',
-		'cloud',
 		'plugins',
 		'rules',
 		'tools',
-		'hooks',
 		'indexing',
 		'autoUpdate',
 		'browser',
-		'network',
-		'beta',
-		'dev',
 	]);
 
 	ipcMain.handle('app:requestOpenSettings', async (event, payload: unknown) => {

--- a/src/SettingsAgentPanel.tsx
+++ b/src/SettingsAgentPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useI18n } from './i18n';
 import type { AppLocale } from './i18n';
 import type {
@@ -67,6 +67,8 @@ function IconTrash({ className }: { className?: string }) {
 function BadgeLike({ text }: { text: string }) {
 	return <span className="ref-settings-plugins-badge">{text}</span>;
 }
+
+const SLASH_HELP_COLLAPSED_ITEMS = 8;
 
 /** Generic drag-to-reorder for a list of {id} items */
 function useDragReorder<T extends { id: string }>(items: T[], onReorder: (next: T[]) => void) {
@@ -292,6 +294,64 @@ export function SettingsAgentPanel({
 	};
 	const cmdsDrag = useDragReorder(editableCommands, (next) => patch({ commands: [...next, ...pluginCommands] }));
 	const slashCmdHelpRows = useMemo(() => buildSlashCommandListRows(commands, t), [commands, t]);
+	const [slashHelpExpanded, setSlashHelpExpanded] = useState(false);
+	const slashHelpListRef = useRef<HTMLUListElement | null>(null);
+	const [slashHelpHeights, setSlashHelpHeights] = useState({ collapsed: 0, expanded: 0 });
+	const shouldCollapseSlashHelp = slashCmdHelpRows.length > SLASH_HELP_COLLAPSED_ITEMS;
+
+	useLayoutEffect(() => {
+		if (!shouldCollapseSlashHelp && slashHelpExpanded) {
+			setSlashHelpExpanded(false);
+		}
+	}, [shouldCollapseSlashHelp, slashHelpExpanded]);
+
+	useLayoutEffect(() => {
+		const listEl = slashHelpListRef.current;
+		if (!listEl) {
+			return;
+		}
+
+		let frame = 0;
+		const measure = () => {
+			const items = Array.from(listEl.children) as HTMLElement[];
+			const expanded = Math.ceil(listEl.scrollHeight);
+			let collapsed = expanded;
+			if (shouldCollapseSlashHelp && items.length > 0) {
+				const lastVisibleIndex = Math.min(SLASH_HELP_COLLAPSED_ITEMS, items.length) - 1;
+				const lastVisibleItem = items[lastVisibleIndex];
+				if (lastVisibleItem) {
+					collapsed = Math.ceil(lastVisibleItem.offsetTop + lastVisibleItem.offsetHeight);
+				}
+			}
+			setSlashHelpHeights((prev) =>
+				prev.collapsed === collapsed && prev.expanded === expanded ? prev : { collapsed, expanded }
+			);
+		};
+		const scheduleMeasure = () => {
+			cancelAnimationFrame(frame);
+			frame = requestAnimationFrame(measure);
+		};
+
+		scheduleMeasure();
+
+		const resizeObserver = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(scheduleMeasure) : null;
+		resizeObserver?.observe(listEl);
+		window.addEventListener('resize', scheduleMeasure);
+
+		return () => {
+			cancelAnimationFrame(frame);
+			resizeObserver?.disconnect();
+			window.removeEventListener('resize', scheduleMeasure);
+		};
+	}, [shouldCollapseSlashHelp, slashCmdHelpRows]);
+
+	const slashHelpVisibleHeight =
+		shouldCollapseSlashHelp && slashHelpHeights.expanded > 0
+			? slashHelpExpanded
+				? slashHelpHeights.expanded
+				: slashHelpHeights.collapsed
+			: null;
+	const hiddenSlashCount = Math.max(0, slashCmdHelpRows.length - SLASH_HELP_COLLAPSED_ITEMS);
 
 	const renderOriginBadge = (origin?: AgentItemOrigin) => {
 		const o = origin ?? 'user';
@@ -862,27 +922,50 @@ export function SettingsAgentPanel({
 				<p className="ref-settings-agent-section-desc">{t('agentSettings.cmdDesc')}</p>
 				<div className="ref-settings-agent-slash-help" aria-label={t('agentSettings.cmdSlashListAria')}>
 					<h3 className="ref-settings-agent-subheading">{t('agentSettings.cmdSlashListTitle')}</h3>
-					<ul className="ref-settings-agent-slash-help-list">
-						{slashCmdHelpRows.map((row, i) => (
-							<li key={`${row.label}-${i}`} className="ref-settings-agent-slash-help-item">
-								<div className="ref-settings-agent-slash-help-row">
-									<code className="ref-settings-agent-slash-help-code">{row.label}</code>
-									<span
-										className={`ref-settings-agent-slash-help-badge ${row.source !== 'builtin' ? 'ref-settings-agent-slash-help-badge--user' : ''}`}
-									>
-										{row.source === 'builtin'
-											? t('slashCmd.helpBuiltin')
-											: row.source === 'plugin'
-												? t('slashCmd.helpPlugin')
-												: t('slashCmd.helpUser')}
-									</span>
-								</div>
-								{row.description ? (
-									<p className="ref-settings-agent-slash-help-desc">{row.description}</p>
-								) : null}
-							</li>
-						))}
-					</ul>
+					<div
+						className={`ref-settings-agent-slash-help-list-shell ${shouldCollapseSlashHelp ? (slashHelpExpanded ? 'is-expanded' : 'is-collapsed') : 'is-static'}`}
+						style={slashHelpVisibleHeight ? { maxHeight: `${slashHelpVisibleHeight}px` } : undefined}
+					>
+						<ul id="ref-settings-agent-slash-help-list" ref={slashHelpListRef} className="ref-settings-agent-slash-help-list">
+							{slashCmdHelpRows.map((row, i) => (
+								<li key={`${row.label}-${i}`} className="ref-settings-agent-slash-help-item">
+									<div className="ref-settings-agent-slash-help-row">
+										<code className="ref-settings-agent-slash-help-code">{row.label}</code>
+										<span
+											className={`ref-settings-agent-slash-help-badge ${row.source !== 'builtin' ? 'ref-settings-agent-slash-help-badge--user' : ''}`}
+										>
+											{row.source === 'builtin'
+												? t('slashCmd.helpBuiltin')
+												: row.source === 'plugin'
+													? t('slashCmd.helpPlugin')
+													: t('slashCmd.helpUser')}
+										</span>
+									</div>
+									{row.description ? (
+										<p className="ref-settings-agent-slash-help-desc">{row.description}</p>
+									) : null}
+								</li>
+							))}
+						</ul>
+					</div>
+					{shouldCollapseSlashHelp ? (
+						<div className="ref-settings-agent-slash-help-actions">
+							<button
+								type="button"
+								className={`ref-settings-agent-slash-help-toggle ${slashHelpExpanded ? 'is-expanded' : ''}`}
+								onClick={() => setSlashHelpExpanded((prev) => !prev)}
+								aria-expanded={slashHelpExpanded}
+								aria-controls="ref-settings-agent-slash-help-list"
+							>
+								<span>
+									{slashHelpExpanded
+										? t('agentSettings.cmdSlashListCollapse')
+										: t('agentSettings.cmdSlashListExpand', { count: String(hiddenSlashCount) })}
+								</span>
+								<IconChevDown className="ref-settings-agent-slash-help-toggle-ico" />
+							</button>
+						</div>
+					) : null}
 				</div>
 				{pluginCommands.length > 0 ? (
 					<details className="ref-settings-provider-details" style={{ marginBottom: 14 }}>

--- a/src/SettingsPage.tsx
+++ b/src/SettingsPage.tsx
@@ -45,19 +45,13 @@ export type SettingsNavId =
 	| 'team'
 	| 'bots'
 	| 'agents'
-	| 'tab'
 	| 'models'
-	| 'cloud'
 	| 'plugins'
 	| 'rules'
 	| 'tools'
-	| 'hooks'
 	| 'indexing'
 	| 'autoUpdate'
-	| 'browser'
-	| 'network'
-	| 'beta'
-	| 'dev';
+	| 'browser';
 
 /** 与 `app:requestOpenSettings` 白名单及侧栏顺序对齐，供运行时校验导航 id */
 export const ALL_SETTINGS_NAV_IDS: SettingsNavId[] = [
@@ -74,18 +68,12 @@ export const ALL_SETTINGS_NAV_IDS: SettingsNavId[] = [
 	'tools',
 	'plan',
 	'team',
-	'tab',
-	'cloud',
 	'plugins',
-	'hooks',
-	'network',
-	'beta',
-	'dev',
 ];
 
 
 
-type NavItem = { id: SettingsNavId; label: string; badge?: number; soon?: boolean };
+type NavItem = { id: SettingsNavId; label: string; badge?: number };
 
 function navItemsForT(t: (key: string) => string): NavItem[] {
 	return [
@@ -102,13 +90,7 @@ function navItemsForT(t: (key: string) => string): NavItem[] {
 		{ id: 'tools', label: t('settings.nav.tools') },
 		{ id: 'plan', label: t('settings.nav.plan') },
 		{ id: 'team', label: t('settings.nav.team') },
-		{ id: 'tab', label: t('settings.nav.tab'), soon: true },
-		{ id: 'cloud', label: t('settings.nav.cloud'), soon: true },
 		{ id: 'plugins', label: t('settings.nav.plugins') },
-		{ id: 'hooks', label: t('settings.nav.hooks'), soon: true },
-		{ id: 'network', label: t('settings.nav.network'), soon: true },
-		{ id: 'beta', label: t('settings.nav.beta'), soon: true },
-		{ id: 'dev', label: t('settings.nav.dev'), soon: true },
 	];
 }
 
@@ -242,36 +224,10 @@ function IconDatabase({ className }: { className?: string }) {
 	);
 }
 
-function IconCloudNav({ className }: { className?: string }) {
-	return (
-		<svg className={className} width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
-			<path d="M7 18a4 4 0 1 1 .9-7.9A5 5 0 0 1 20 12a3 3 0 0 1-1 5.8H7Z" strokeLinecap="round" strokeLinejoin="round" />
-		</svg>
-	);
-}
-
 function IconPuzzle({ className }: { className?: string }) {
 	return (
 		<svg className={className} width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
 			<path d="M10 5a2 2 0 1 1 4 0v1h3a1 1 0 0 1 1 1v3h-1a2 2 0 1 0 0 4h1v3a1 1 0 0 1-1 1h-3v-1a2 2 0 1 0-4 0v1H7a1 1 0 0 1-1-1v-3h1a2 2 0 1 0 0-4H6V7a1 1 0 0 1 1-1h3V5Z" strokeLinecap="round" strokeLinejoin="round" />
-		</svg>
-	);
-}
-
-function IconHook({ className }: { className?: string }) {
-	return (
-		<svg className={className} width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
-			<path d="M10 12a4 4 0 1 1 8 0v1a6 6 0 1 1-12 0V7" strokeLinecap="round" strokeLinejoin="round" />
-			<path d="M10 7h4" strokeLinecap="round" />
-		</svg>
-	);
-}
-
-function IconGlobe({ className }: { className?: string }) {
-	return (
-		<svg className={className} width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
-			<circle cx="12" cy="12" r="9" />
-			<path d="M3 12h18M12 3a15 15 0 0 1 0 18M12 3a15 15 0 0 0 0 18" />
 		</svg>
 	);
 }
@@ -284,32 +240,6 @@ function IconBrowserNav({ className }: { className?: string }) {
 			<path d="M3 8h18" strokeLinecap="round" />
 			<circle cx="12" cy="14" r="3.25" />
 			<path d="M8.75 14h6.5M12 10.75v6.5" strokeLinecap="round" />
-		</svg>
-	);
-}
-
-function IconFlask({ className }: { className?: string }) {
-	return (
-		<svg className={className} width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
-			<path d="M10 2v6l-5.5 9.5A2 2 0 0 0 6.2 21h11.6a2 2 0 0 0 1.7-3.5L14 8V2" strokeLinecap="round" strokeLinejoin="round" />
-			<path d="M8.5 14h7" strokeLinecap="round" />
-		</svg>
-	);
-}
-
-function IconTerminalNav({ className }: { className?: string }) {
-	return (
-		<svg className={className} width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
-			<path d="m4 17 6-5-6-5M12 19h8" strokeLinecap="round" strokeLinejoin="round" />
-		</svg>
-	);
-}
-
-function IconTabs({ className }: { className?: string }) {
-	return (
-		<svg className={className} width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
-			<path d="M4 7h8l2 3h6v7a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V7Z" strokeLinecap="round" strokeLinejoin="round" />
-			<path d="M4 7V5a2 2 0 0 1 2-2h5l2 3" strokeLinecap="round" strokeLinejoin="round" />
 		</svg>
 	);
 }
@@ -359,20 +289,8 @@ function navIcon(id: SettingsNavId) {
 			);
 		case 'browser':
 			return <IconBrowserNav />;
-		case 'cloud':
-			return <IconCloudNav />;
 		case 'plugins':
 			return <IconPuzzle />;
-		case 'hooks':
-			return <IconHook />;
-		case 'network':
-			return <IconGlobe />;
-		case 'beta':
-			return <IconFlask />;
-		case 'dev':
-			return <IconTerminalNav />;
-		case 'tab':
-			return <IconTabs />;
 		case 'plan':
 			return <IconBarChart />;
 		case 'team':
@@ -690,19 +608,14 @@ export function SettingsPage({
 								type="button"
 								className={`ref-settings-nav-row ${nav === item.id ? 'is-active' : ''}`}
 								onClick={() => {
-									if (item.soon) {
-										return;
-									}
 									startNavTransition(() => {
 										setNav(item.id);
 									});
 								}}
-								disabled={!!item.soon}
 							>
 								<span className="ref-settings-nav-ico">{navIcon(item.id)}</span>
 								<span className="ref-settings-nav-label">{item.label}</span>
 								{item.badge != null ? <span className="ref-settings-nav-badge">{item.badge}</span> : null}
-								{item.soon ? <span className="ref-settings-nav-soon">{t('common.soon')}</span> : null}
 							</button>
 						))}
 					</nav>
@@ -737,22 +650,6 @@ export function SettingsPage({
 								{nav === 'team' ? t('settings.title.team') : null}
 								{nav === 'bots' ? t('settings.title.bots') : null}
 								{nav === 'plugins' ? t('settings.title.plugins') : null}
-								{nav !== 'general' &&
-								nav !== 'appearance' &&
-								nav !== 'agents' &&
-								nav !== 'bots' &&
-								nav !== 'models' &&
-								nav !== 'rules' &&
-								nav !== 'editor' &&
-								nav !== 'tools' &&
-								nav !== 'indexing' &&
-								nav !== 'autoUpdate' &&
-								nav !== 'browser' &&
-								nav !== 'plan' &&
-								nav !== 'team' &&
-								nav !== 'plugins'
-									? t('settings.title.comingSoon')
-									: null}
 							</h1>
 							{navPending ? (
 								<div className="ref-settings-nav-loading" role="status" aria-live="polite">

--- a/src/SettingsPluginsPanel.tsx
+++ b/src/SettingsPluginsPanel.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import type { PluginInstallScope, PluginPanelState } from './pluginMarketplaceTypes';
 import type { PluginRuntimeState } from './pluginRuntimeTypes';
 import { useI18n } from './i18n';
@@ -812,16 +813,19 @@ export function SettingsPluginsPanel({ shell, workspaceOpen }: Props) {
 				</div>
 			</section>
 
-			{toast ? (
-				<div
-					key={toast.key}
-					className={`ref-settings-plugins-toast ref-settings-plugins-toast--${toast.kind}`}
-					role={toast.kind === 'error' ? 'alert' : 'status'}
-					aria-live="polite"
-				>
-					{toast.text}
-				</div>
-			) : null}
+			{toast && typeof document !== 'undefined'
+				? createPortal(
+					<div
+						key={toast.key}
+						className={`ref-settings-plugins-toast ref-settings-plugins-toast--${toast.kind}`}
+						role={toast.kind === 'error' ? 'alert' : 'status'}
+						aria-live="polite"
+					>
+						{toast.text}
+					</div>,
+					document.body
+				)
+				: null}
 		</div>
 	);
 }

--- a/src/i18n/messages.en.ts
+++ b/src/i18n/messages.en.ts
@@ -1257,6 +1257,8 @@ export const messagesEn: Record<string, string> = {
 	'agentSettings.cmdDescFieldPh': 'Short hint shown in / menu and command list',
 	'agentSettings.cmdSlashListTitle': 'Commands available in chat',
 	'agentSettings.cmdSlashListAria': 'Built-in and custom slash command list',
+	'agentSettings.cmdSlashListExpand': 'Show {{count}} more',
+	'agentSettings.cmdSlashListCollapse': 'Collapse list',
 
 	'errors.modelNotChosen': 'No model selected. Pick one from the input bar or add models under Settings → Models.',
 	'errors.modelResolve':

--- a/src/i18n/messages.zh-CN.ts
+++ b/src/i18n/messages.zh-CN.ts
@@ -1252,6 +1252,8 @@ export const messagesZhCN: Record<string, string> = {
 	'agentSettings.cmdDescFieldPh': '简短说明，显示在 / 菜单与命令列表中',
 	'agentSettings.cmdSlashListTitle': '在聊天中可用的命令',
 	'agentSettings.cmdSlashListAria': '内置与自定义斜杠命令列表',
+	'agentSettings.cmdSlashListExpand': '展开其余 {{count}} 条',
+	'agentSettings.cmdSlashListCollapse': '收起列表',
 
 	// errors (known IPC / UI)
 	'errors.modelNotChosen': '未选择模型。请在输入区选择模型，或在设置 → 模型中添加并选择默认模型。',

--- a/src/index.css
+++ b/src/index.css
@@ -13507,6 +13507,34 @@ select.ref-settings-native-select:focus {
 	background: rgba(0, 0, 0, 0.12);
 }
 
+.ref-settings-agent-slash-help-list-shell {
+	position: relative;
+	overflow: hidden;
+	transition: max-height 0.32s var(--void-ease-out-expo, ease);
+	will-change: max-height;
+}
+
+.ref-settings-agent-slash-help-list-shell::after {
+	content: '';
+	position: absolute;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	height: 42px;
+	background: linear-gradient(
+		180deg,
+		color-mix(in srgb, rgba(0, 0, 0, 0.02) 20%, transparent) 0%,
+		color-mix(in srgb, rgba(0, 0, 0, 0.12) 92%, var(--void-bg-1)) 100%
+	);
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 0.22s ease;
+}
+
+.ref-settings-agent-slash-help-list-shell.is-collapsed::after {
+	opacity: 1;
+}
+
 .ref-settings-agent-slash-help-list {
 	list-style: none;
 	margin: 0;
@@ -13560,6 +13588,48 @@ select.ref-settings-native-select:focus {
 	line-height: 1.45;
 }
 
+.ref-settings-agent-slash-help-actions {
+	display: flex;
+	justify-content: center;
+	padding-top: 12px;
+}
+
+.ref-settings-agent-slash-help-toggle {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	padding: 7px 12px;
+	border-radius: 999px;
+	border: 1px solid var(--void-border-soft);
+	background: color-mix(in srgb, var(--void-bg-2) 88%, transparent);
+	color: var(--void-fg-2);
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: 0.01em;
+	cursor: pointer;
+	transition:
+		background 0.18s ease,
+		border-color 0.18s ease,
+		color 0.18s ease,
+		transform 0.18s ease;
+}
+
+.ref-settings-agent-slash-help-toggle:hover {
+	background: color-mix(in srgb, var(--void-bg-2) 96%, var(--void-accent-soft) 18%);
+	border-color: color-mix(in srgb, var(--void-accent) 22%, var(--void-border-soft));
+	color: var(--void-fg-1);
+	transform: translateY(-1px);
+}
+
+.ref-settings-agent-slash-help-toggle-ico {
+	flex-shrink: 0;
+	transition: transform 0.22s ease;
+}
+
+.ref-settings-agent-slash-help-toggle.is-expanded .ref-settings-agent-slash-help-toggle-ico {
+	transform: rotate(180deg);
+}
+
 .ref-settings-agent-list {
 	list-style: none;
 	margin: 0;
@@ -13591,6 +13661,11 @@ select.ref-settings-native-select:focus {
 .ref-settings-agent-skill-disk-main {
 	flex: 1;
 	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	justify-content: flex-start;
+	gap: 8px;
 	margin: 0;
 	padding: 12px 14px 14px;
 	text-align: left;
@@ -13599,6 +13674,7 @@ select.ref-settings-native-select:focus {
 	color: inherit;
 	font-family: inherit;
 	cursor: default;
+	box-sizing: border-box;
 }
 
 .ref-settings-agent-skill-disk-main.is-clickable:not(:disabled) {
@@ -13613,12 +13689,17 @@ select.ref-settings-native-select:focus {
 	opacity: 0.85;
 }
 
+.ref-settings-agent-skill-disk-main .ref-settings-plugins-badge-row {
+	align-items: flex-start;
+	gap: 8px;
+}
+
 .ref-settings-agent-skill-disk-title {
 	font-size: 14px;
 	font-weight: 700;
 	color: var(--void-fg-0);
 	line-height: 1.35;
-	margin-bottom: 6px;
+	margin: 0;
 }
 
 .ref-settings-agent-skill-disk-desc {
@@ -13629,13 +13710,20 @@ select.ref-settings-native-select:focus {
 	-webkit-line-clamp: 3;
 	-webkit-box-orient: vertical;
 	overflow: hidden;
-	margin-bottom: 8px;
+	margin: 0;
+	max-width: 72ch;
 }
 
 .ref-settings-agent-skill-disk-path {
+	display: block;
+	width: 100%;
+	margin-top: auto;
+	padding-top: 8px;
+	border-top: 1px solid color-mix(in srgb, var(--void-border-soft) 82%, transparent);
 	font-size: 11px;
 	color: var(--void-fg-3);
 	font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+	line-height: 1.45;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;


### PR DESCRIPTION
## Summary

This PR improves the Settings experience around navigation clarity, the Agents slash-command reference, and plugin notifications.

## Changes

### Settings navigation

- Removed placeholder "coming soon" sidebar entries (`tab`, `cloud`, `hooks`, `network`, `beta`, `dev`) from the UI and from the `app:requestOpenSettings` allowlist so deep links stay consistent with what users can actually open.
- Dropped the `soon` nav row state, related icons, and the generic "coming soon" panel title fallback.

### Agents: slash command list

- When many commands exist, the in-chat slash command help list shows the first items by default with a measured `max-height` animation.
- Added expand/collapse control with `ResizeObserver` and layout measurement for stable heights when resizing.
- New i18n strings in English and Chinese for expand/collapse labels.

### Plugins panel

- Plugin toasts are rendered with `createPortal(..., document.body)` so they layer correctly above nested scroll/stacking contexts.

### Styling

- CSS for the slash-help shell (gradient fade when collapsed), pill-style toggle, and small layout tweaks for agent skill disk cards.

## Testing

- Manually verified Settings sidebar navigation and Agents slash list expand/collapse with a long command list.
- Confirmed plugin operation toasts still appear and are readable.

## Commit

`feat(settings): drop soon nav stubs; collapsible slash commands; portal plugin toasts`
