### PR TITLE
Agent tool executor, terminal sessions, and UI/theme alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,13 +5,142 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Async</title>
     <link rel="icon" type="image/png" href="/favicon.png" />
+    <script>
+      (() => {
+        const COLOR_MODE_STORAGE_KEY = 'async:color-mode-v1';
+        const INITIAL_WINDOW_THEME_STORAGE_KEY = 'async:initial-window-theme-v1';
+        const INITIAL_WINDOW_THEME_QUERY_PARAM = 'initialWindowTheme';
+        const DEFAULTS = {
+          dark: { backgroundColor: '#111111', foregroundColor: '#FCFCFC', accentColor: '#0169CC' },
+          light: { backgroundColor: '#F5F5F7', foregroundColor: '#1D1D1F', accentColor: '#0169CC' },
+        };
+
+        const root = document.documentElement;
+
+        const normalizeColorMode = (raw) =>
+          raw === 'light' || raw === 'dark' || raw === 'system' ? raw : 'dark';
+        const normalizeHexColor = (raw, fallback) => {
+          const value = String(raw ?? '').trim();
+          if (/^#[0-9a-fA-F]{6}$/.test(value)) {
+            return value.toUpperCase();
+          }
+          if (/^#[0-9a-fA-F]{3}$/.test(value)) {
+            const parts = value.slice(1).split('');
+            return `#${parts.map((part) => part + part).join('')}`.toUpperCase();
+          }
+          return fallback.toUpperCase();
+        };
+        const hexToRgb = (hex) => {
+          const normalized = normalizeHexColor(hex, '#000000');
+          return {
+            r: Number.parseInt(normalized.slice(1, 3), 16),
+            g: Number.parseInt(normalized.slice(3, 5), 16),
+            b: Number.parseInt(normalized.slice(5, 7), 16),
+          };
+        };
+        const rgbToHex = ({ r, g, b }) =>
+          `#${[r, g, b]
+            .map((channel) => Math.max(0, Math.min(255, Math.round(channel))).toString(16).padStart(2, '0'))
+            .join('')}`.toUpperCase();
+        const mixHex = (baseHex, overlayHex, overlayWeight) => {
+          const base = hexToRgb(baseHex);
+          const overlay = hexToRgb(overlayHex);
+          const weight = Math.max(0, Math.min(1, overlayWeight));
+          return rgbToHex({
+            r: base.r * (1 - weight) + overlay.r * weight,
+            g: base.g * (1 - weight) + overlay.g * weight,
+            b: base.b * (1 - weight) + overlay.b * weight,
+          });
+        };
+        const hexToRgba = (hex, alpha) => {
+          const { r, g, b } = hexToRgb(hex);
+          return `rgba(${r}, ${g}, ${b}, ${Math.max(0, Math.min(1, alpha))})`;
+        };
+        const parseThemePayload = (raw) => {
+          if (!raw) {
+            return null;
+          }
+          try {
+            const parsed = JSON.parse(raw);
+            return parsed && typeof parsed === 'object' ? parsed : null;
+          } catch {
+            return null;
+          }
+        };
+        const readThemePayload = () => {
+          try {
+            const params = new URLSearchParams(window.location.search);
+            return (
+              parseThemePayload(params.get(INITIAL_WINDOW_THEME_QUERY_PARAM)) ||
+              parseThemePayload(window.localStorage.getItem(INITIAL_WINDOW_THEME_STORAGE_KEY))
+            );
+          } catch {
+            return null;
+          }
+        };
+
+        const payload = readThemePayload();
+        let colorMode = normalizeColorMode(payload?.colorMode);
+        if (!payload) {
+          try {
+            colorMode = normalizeColorMode(window.localStorage.getItem(COLOR_MODE_STORAGE_KEY));
+          } catch {
+            colorMode = 'dark';
+          }
+        }
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const scheme =
+          payload?.scheme === 'light' || payload?.scheme === 'dark'
+            ? payload.scheme
+            : colorMode === 'system'
+              ? prefersDark
+                ? 'dark'
+                : 'light'
+              : colorMode;
+        const defaults = DEFAULTS[scheme];
+        const ui = payload?.ui && typeof payload.ui === 'object' ? payload.ui : {};
+        const backgroundColor = normalizeHexColor(ui.backgroundColor, defaults.backgroundColor);
+        const foregroundColor = normalizeHexColor(ui.foregroundColor, defaults.foregroundColor);
+        const accentColor = normalizeHexColor(ui.accentColor, defaults.accentColor);
+        const bodyBg = mixHex(backgroundColor, scheme === 'dark' ? '#000000' : '#FFFFFF', scheme === 'dark' ? 0.08 : 0.02);
+        const splashTop = mixHex(backgroundColor, accentColor, scheme === 'dark' ? 0.14 : 0.08);
+        const splashBottom = mixHex(backgroundColor, scheme === 'dark' ? '#000000' : '#FFFFFF', scheme === 'dark' ? 0.16 : 0.08);
+        const cardBg = mixHex(backgroundColor, scheme === 'dark' ? '#FFFFFF' : '#FFFFFF', scheme === 'dark' ? 0.1 : 0.62);
+        const cardBorder = mixHex(backgroundColor, foregroundColor, scheme === 'dark' ? 0.2 : 0.16);
+        const subtitleColor = mixHex(backgroundColor, foregroundColor, scheme === 'dark' ? 0.62 : 0.58);
+        const loaderRing = mixHex(backgroundColor, foregroundColor, scheme === 'dark' ? 0.18 : 0.12);
+        const cardShadow = scheme === 'dark'
+          ? `0 28px 80px ${hexToRgba('#000000', 0.34)}, inset 0 1px 0 ${hexToRgba('#FFFFFF', 0.04)}`
+          : `0 28px 80px ${hexToRgba('#5B6472', 0.16)}, inset 0 1px 0 ${hexToRgba('#FFFFFF', 0.72)}`;
+
+        root.setAttribute('data-ui-style', 'mac-codex');
+        root.setAttribute('data-color-scheme', scheme);
+        root.style.setProperty('--boot-body-bg', bodyBg);
+        root.style.setProperty('--boot-body-fg', foregroundColor);
+        root.style.setProperty(
+          '--boot-splash-bg',
+          [
+            `radial-gradient(circle at top center, ${hexToRgba(accentColor, scheme === 'dark' ? 0.14 : 0.1)} 0%, transparent 30%)`,
+            `radial-gradient(circle at 82% 16%, ${hexToRgba(foregroundColor, scheme === 'dark' ? 0.08 : 0.05)} 0%, transparent 18%)`,
+            `linear-gradient(180deg, ${splashTop} 0%, ${splashBottom} 100%)`,
+          ].join(', ')
+        );
+        root.style.setProperty('--boot-card-bg', `linear-gradient(180deg, ${cardBg} 0%, ${mixHex(cardBg, backgroundColor, 0.22)} 100%)`);
+        root.style.setProperty('--boot-card-border', cardBorder);
+        root.style.setProperty('--boot-card-shadow', cardShadow);
+        root.style.setProperty('--boot-subtitle-color', subtitleColor);
+        root.style.setProperty('--boot-loader-ring', loaderRing);
+        root.style.setProperty('--boot-loader-accent', accentColor);
+        root.style.setProperty('--boot-logo-shadow', `drop-shadow(0 12px 24px ${hexToRgba(accentColor, scheme === 'dark' ? 0.18 : 0.12)})`);
+      })();
+    </script>
     <style>
       html, body {
         margin: 0;
         width: 100%;
         height: 100%;
-        background: #0b0f13;
-        color: #f4f4f5;
+        background: var(--boot-body-bg, #0b0f13);
+        color: var(--boot-body-fg, #f4f4f5);
         overflow: hidden;
       }
       body {
@@ -28,10 +157,12 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        background:
+        background: var(
+          --boot-splash-bg,
           radial-gradient(circle at top center, rgba(56, 189, 248, 0.10) 0%, transparent 28%),
           radial-gradient(circle at 82% 16%, rgba(251, 146, 60, 0.08) 0%, transparent 18%),
-          linear-gradient(180deg, #0f1419 0%, #0a0e12 100%);
+          linear-gradient(180deg, #0f1419 0%, #0a0e12 100%)
+        );
         transition: opacity 280ms ease, visibility 280ms ease;
       }
       #boot-splash.is-hidden {
@@ -45,16 +176,16 @@
         gap: 16px;
         padding: 22px 24px;
         border-radius: 20px;
-        border: 1px solid rgba(255,255,255,0.08);
-        background: linear-gradient(180deg, rgba(25, 32, 39, 0.96) 0%, rgba(18, 24, 30, 0.96) 100%);
-        box-shadow: 0 28px 80px rgba(0,0,0,0.34), inset 0 1px 0 rgba(255,255,255,0.04);
+        border: 1px solid var(--boot-card-border, rgba(255,255,255,0.08));
+        background: var(--boot-card-bg, linear-gradient(180deg, rgba(25, 32, 39, 0.96) 0%, rgba(18, 24, 30, 0.96) 100%));
+        box-shadow: var(--boot-card-shadow, 0 28px 80px rgba(0,0,0,0.34), inset 0 1px 0 rgba(255,255,255,0.04));
       }
       .boot-splash-logo {
         width: 42px;
         height: 42px;
         flex-shrink: 0;
         animation: boot-float 1.8s ease-in-out infinite;
-        filter: drop-shadow(0 12px 24px rgba(255,255,255,0.08));
+        filter: var(--boot-logo-shadow, drop-shadow(0 12px 24px rgba(255,255,255,0.08)));
       }
       .boot-splash-copy {
         display: flex;
@@ -68,15 +199,15 @@
       }
       .boot-splash-subtitle {
         font-size: 12px;
-        color: rgba(228, 228, 231, 0.72);
+        color: var(--boot-subtitle-color, rgba(228, 228, 231, 0.72));
       }
       .boot-splash-loader {
         width: 18px;
         height: 18px;
         margin-left: 6px;
         border-radius: 999px;
-        border: 2px solid rgba(255,255,255,0.14);
-        border-top-color: #67e8f9;
+        border: 2px solid var(--boot-loader-ring, rgba(255,255,255,0.14));
+        border-top-color: var(--boot-loader-accent, #67e8f9);
         animation: boot-spin 0.9s linear infinite;
       }
       @keyframes boot-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }

--- a/main-src/agent/agentTools.ts
+++ b/main-src/agent/agentTools.ts
@@ -257,11 +257,16 @@ export const AGENT_TOOLS: AgentToolDef[] = [
 	{
 		name: 'Bash',
 		description:
-			'Run a shell command in the workspace directory (on Windows the runtime uses PowerShell for the same purpose). Use for tests, installs, builds, git, etc. Do not use Bash for reading or discovering source files when **Read**, **Glob**, or **Grep** can do the job. Do not use Bash to run `grep` or `rg` for codebase search — use **Grep**. 120-second timeout.',
+			'Run a shell command in the workspace directory (on Windows the runtime uses PowerShell for the same purpose). Use for tests, installs, builds, git, etc. Do not use Bash for reading or discovering source files when **Read**, **Glob**, or **Grep** can do the job. Do not use Bash to run `grep` or `rg` for codebase search — use **Grep**. Default timeout is 120 seconds; set **timeout_ms** for slower installs/downloads.',
 		parameters: {
 			type: 'object',
 			properties: {
 				command: { type: 'string', description: 'The command line to execute' },
+				timeout_ms: {
+					type: 'number',
+					description:
+						'Optional max milliseconds to wait for the command to finish. Default 120000, max 600000.',
+				},
 			},
 			required: ['command'],
 		},
@@ -269,7 +274,7 @@ export const AGENT_TOOLS: AgentToolDef[] = [
 	{
 		name: 'Terminal',
 		description:
-			"Interact with the app's shared Universal Terminal sessions. Sessions are persistent pty processes (the user's real shell) that survive even when no terminal window is open. Use this when you need an interactive session, want to drive a long-running or REPL-style command, or need to keep terminal state (cwd, env, background processes) across calls. For one-shot commands, prefer **Bash** unless you specifically need a saved Universal Terminal profile. You can also enumerate saved Universal Terminal profiles, then open one in the background by profile id or name. This is the supported way to reuse saved SSH profiles without opening the terminal window.\n\nActions: **open** (spawn a new session, optionally from a saved profile, returns id), **write** (send keystrokes/data; include \\r or \\n to submit a line), **read** (return the tail of the output buffer), **list** (enumerate active sessions), **list_profiles** (enumerate saved terminal profiles, including SSH), **resize** (change cols/rows), **close** (kill session), **run** (one-shot convenience for local/non-interactive shells), **exec** (execute a one-shot command through a saved SSH profile in the background; useful for remote Linux hosts when you want profile auth/settings but no visible terminal window).",
+			"Interact with the app's shared Universal Terminal sessions. Sessions are persistent pty processes (the user's real shell) that survive even when no terminal window is open. Use this when you need an interactive session, want to drive a long-running or REPL-style command, or need to keep terminal state (cwd, env, background processes) across calls. For one-shot commands, prefer **Bash** unless you specifically need a saved Universal Terminal profile. You can also enumerate saved Universal Terminal profiles, then open one in the background by profile id or name. This is the supported way to reuse saved SSH profiles without opening the terminal window.\n\nActions: **open** (spawn a new session, optionally from a saved profile, returns id), **write** (send keystrokes/data; include \\r or \\n to submit a line), **read** (return the tail of the output buffer), **list** (enumerate active sessions), **list_profiles** (enumerate saved terminal profiles, including SSH), **resize** (change cols/rows), **close** (kill session), **run** (one-shot convenience for local/non-interactive shells), **exec** (execute a one-shot command through a saved SSH profile with no visible terminal window). For **run**/**exec**, set **run_in_background** to return immediately with a session id; if a foreground wait times out, the session is kept so you can continue with **read**/**close**.",
 		parameters: {
 			type: 'object',
 			properties: {
@@ -327,6 +332,11 @@ export const AGENT_TOOLS: AgentToolDef[] = [
 					type: 'number',
 					description:
 						'For run/exec: max milliseconds to wait for the command to exit before killing it. Default 120000, max 600000.',
+				},
+				run_in_background: {
+					type: 'boolean',
+					description:
+						'For run/exec: if true, start the command and return immediately with a session id. Use read/list/close to monitor it later.',
 				},
 			},
 			required: ['action'],

--- a/main-src/agent/toolExecutor.test.ts
+++ b/main-src/agent/toolExecutor.test.ts
@@ -4,6 +4,9 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 const resolveTerminalToolExecCreateOptsMock = vi.fn();
+const createTerminalSessionMock = vi.fn();
+const startOneShotCommandSessionMock = vi.fn();
+const runOneShotCommandMock = vi.fn();
 const runTerminalSessionToExitMock = vi.fn();
 
 vi.mock('../terminalProfileStore.js', () => ({
@@ -11,6 +14,9 @@ vi.mock('../terminalProfileStore.js', () => ({
 }));
 
 vi.mock('../terminalSessionService.js', () => ({
+	createTerminalSession: (...args: unknown[]) => createTerminalSessionMock(...args),
+	startOneShotCommandSession: (...args: unknown[]) => startOneShotCommandSessionMock(...args),
+	runOneShotCommand: (...args: unknown[]) => runOneShotCommandMock(...args),
 	runTerminalSessionToExit: (...args: unknown[]) => runTerminalSessionToExitMock(...args),
 }));
 
@@ -95,7 +101,7 @@ describe('executeTool view_image', () => {
 });
 
 describe('executeTool Terminal exec', () => {
-	it('executes a saved SSH profile command in the background', async () => {
+	it('waits for a saved SSH profile command to finish', async () => {
 		resolveTerminalToolExecCreateOptsMock.mockReturnValue({
 			createOpts: {
 				shell: 'ssh',
@@ -120,6 +126,8 @@ describe('executeTool Terminal exec', () => {
 			output: 'Linux host 6.8.0',
 			timedOut: false,
 			authPrompt: null,
+			sessionKept: false,
+			alive: false,
 		});
 
 		const result = await executeTool({
@@ -143,10 +151,67 @@ describe('executeTool Terminal exec', () => {
 				rows: undefined,
 			},
 			timeoutMs: undefined,
+			preserveOnTimeout: true,
+			preserveOnAuthPrompt: true,
 		});
 		expect(result.isError).toBe(false);
 		expect(result.content).toContain('profile=Prod SSH');
 		expect(result.content).toContain('Linux host 6.8.0');
+	});
+
+	it('can start a saved SSH profile command in the background and return a session id immediately', async () => {
+		resolveTerminalToolExecCreateOptsMock.mockReturnValue({
+			createOpts: {
+				shell: 'ssh',
+				args: ['user@example.com', "sh -lc 'uname -a'"],
+				title: 'Prod SSH',
+			},
+			profile: {
+				id: 'ssh-prod',
+				name: 'Prod SSH',
+				kind: 'ssh',
+				source: 'user',
+				target: 'root@example.com',
+				authMode: 'publicKey',
+				hasStoredPassword: false,
+				defaultProfile: false,
+				hasRemoteCommand: false,
+			},
+		});
+		createTerminalSessionMock.mockReturnValue({
+			id: 'term-bg-1',
+			title: 'Prod SSH',
+			cwd: process.cwd(),
+			shell: 'ssh',
+			cols: 120,
+			rows: 30,
+			alive: true,
+			bufferBytes: 0,
+			createdAt: Date.now(),
+		});
+
+		const result = await executeTool({
+			id: 'terminal-exec-bg-1',
+			name: 'Terminal',
+			arguments: {
+				action: 'exec',
+				profile_id: 'ssh-prod',
+				command: 'uname -a',
+				run_in_background: true,
+			},
+		});
+
+		expect(createTerminalSessionMock).toHaveBeenCalledWith({
+			shell: 'ssh',
+			args: ['user@example.com', "sh -lc 'uname -a'"],
+			title: 'Prod SSH',
+			cwd: undefined,
+			cols: undefined,
+			rows: undefined,
+		});
+		expect(result.isError).toBe(false);
+		expect(result.content).toContain('session_id=term-bg-1');
+		expect(result.content).toContain('profile "Prod SSH"');
 	});
 
 	it('surfaces background auth prompts as actionable errors', async () => {
@@ -178,6 +243,8 @@ describe('executeTool Terminal exec', () => {
 				kind: 'password',
 				seq: 3,
 			},
+			sessionKept: true,
+			alive: true,
 		});
 
 		const result = await executeTool({
@@ -191,7 +258,132 @@ describe('executeTool Terminal exec', () => {
 		});
 
 		expect(result.isError).toBe(true);
-		expect(result.content).toContain('Authentication prompt blocked background exec');
+		expect(result.content).toContain('session_id=term-2');
+		expect(result.content).toContain('Interactive prompt blocked completion');
 		expect(result.content).toContain('Password:');
+	});
+
+	it('keeps the session alive when foreground exec times out', async () => {
+		resolveTerminalToolExecCreateOptsMock.mockReturnValue({
+			createOpts: {
+				shell: 'ssh',
+				args: ['user@example.com', "sh -lc 'npm install'"],
+				title: 'Prod SSH',
+			},
+			profile: {
+				id: 'ssh-prod',
+				name: 'Prod SSH',
+				kind: 'ssh',
+				source: 'user',
+				target: 'root@example.com',
+				authMode: 'publicKey',
+				hasStoredPassword: false,
+				defaultProfile: false,
+				hasRemoteCommand: false,
+			},
+		});
+		runTerminalSessionToExitMock.mockResolvedValue({
+			id: 'term-timeout-1',
+			exitCode: null,
+			output: 'Downloading packages...',
+			timedOut: true,
+			authPrompt: null,
+			sessionKept: true,
+			alive: true,
+		});
+
+		const result = await executeTool({
+			id: 'terminal-exec-timeout-1',
+			name: 'Terminal',
+			arguments: {
+				action: 'exec',
+				profile_id: 'ssh-prod',
+				command: 'npm install',
+				timeout_ms: 1000,
+			},
+		});
+
+		expect(result.isError).toBe(false);
+		expect(result.content).toContain('session_id=term-timeout-1');
+		expect(result.content).toContain('Downloading packages...');
+	});
+});
+
+describe('executeTool Terminal run', () => {
+	it('can start a local one-shot command in the background', async () => {
+		startOneShotCommandSessionMock.mockReturnValue({
+			id: 'term-run-bg-1',
+			title: '(one-shot) npm install',
+			cwd: process.cwd(),
+			shell: process.platform === 'win32' ? 'cmd.exe' : '/bin/bash',
+			cols: 120,
+			rows: 30,
+			alive: true,
+			bufferBytes: 0,
+			createdAt: Date.now(),
+		});
+
+		const result = await executeTool(
+			{
+				id: 'terminal-run-bg-1',
+				name: 'Terminal',
+				arguments: {
+					action: 'run',
+					command: 'npm install',
+					run_in_background: true,
+				},
+			},
+			undefined,
+			{ workspaceRoot: process.cwd() }
+		);
+
+		expect(startOneShotCommandSessionMock).toHaveBeenCalledWith({
+			command: 'npm install',
+			cwd: process.cwd(),
+			shell: undefined,
+			cols: undefined,
+			rows: undefined,
+		});
+		expect(result.isError).toBe(false);
+		expect(result.content).toContain('session_id=term-run-bg-1');
+		expect(result.content).toContain('Started background terminal command.');
+	});
+
+	it('keeps the session alive when foreground run times out', async () => {
+		runOneShotCommandMock.mockResolvedValue({
+			id: 'term-run-timeout-1',
+			exitCode: null,
+			output: 'Downloading packages...',
+			timedOut: true,
+			sessionKept: true,
+			alive: true,
+		});
+
+		const result = await executeTool(
+			{
+				id: 'terminal-run-timeout-1',
+				name: 'Terminal',
+				arguments: {
+					action: 'run',
+					command: 'npm install',
+					timeout_ms: 1000,
+				},
+			},
+			undefined,
+			{ workspaceRoot: process.cwd() }
+		);
+
+		expect(runOneShotCommandMock).toHaveBeenCalledWith({
+			command: 'npm install',
+			cwd: process.cwd(),
+			shell: undefined,
+			timeoutMs: 1000,
+			cols: undefined,
+			rows: undefined,
+			preserveOnTimeout: true,
+		});
+		expect(result.isError).toBe(false);
+		expect(result.content).toContain('session_id=term-run-timeout-1');
+		expect(result.content).toContain('Downloading packages...');
 	});
 });

--- a/main-src/agent/toolExecutor.ts
+++ b/main-src/agent/toolExecutor.ts
@@ -2073,6 +2073,11 @@ async function executeCommand(
 	const args = isWin
 		? ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-Command', psCommand]
 		: ['-lc', command];
+	const timeoutMsRaw = Number(call.arguments.timeout_ms);
+	const timeoutMs =
+		Number.isFinite(timeoutMsRaw) && timeoutMsRaw > 0
+			? Math.max(1_000, Math.min(Math.floor(timeoutMsRaw), 600_000))
+			: 120_000;
 	const beforeGitState = await captureBashGitDirtyState(root);
 
 	try {
@@ -2080,7 +2085,7 @@ async function executeCommand(
 			cwd: root,
 			windowsHide: true,
 			maxBuffer: 5 * 1024 * 1024,
-			timeout: 120_000,
+			timeout: timeoutMs,
 			encoding: 'utf8',
 			signal: execCtx.signal,
 		});
@@ -2102,6 +2107,65 @@ async function executeCommand(
 		if (!output.trim()) output = err.message ?? String(e);
 		return { toolCallId: call.id, name: call.name, content: `Exit code ${err.code ?? 'unknown'}\n${output}`, isError: true };
 	}
+}
+
+function parseTerminalRunInBackground(args: Record<string, unknown>): boolean {
+	return args.run_in_background === true || args.run_in_background === 'true';
+}
+
+function parseTerminalTimeoutMs(args: Record<string, unknown>): number | undefined {
+	const raw = Number(args.timeout_ms);
+	if (!Number.isFinite(raw) || raw <= 0) {
+		return undefined;
+	}
+	return Math.max(500, Math.min(Math.floor(raw), 600_000));
+}
+
+function formatBackgroundTerminalSessionResult(opts: {
+	sessionId: string;
+	command: string;
+	profileName?: string;
+}): string {
+	const lines = [
+		`session_id=${opts.sessionId} background=true`,
+		'---',
+		opts.profileName
+			? `Started background terminal command via profile "${opts.profileName}".`
+			: 'Started background terminal command.',
+		`Command: ${opts.command}`,
+		'Use Terminal read with this session_id to inspect output, and close when finished.',
+	];
+	return lines.join('\n');
+}
+
+function formatPreservedTerminalSessionResult(opts: {
+	sessionId: string;
+	output: string;
+	command?: string;
+	profileName?: string;
+	authPrompt?: string;
+}): string {
+	const lines = [
+		opts.profileName
+			? `session_id=${opts.sessionId} profile=${opts.profileName} session_kept=true`
+			: `session_id=${opts.sessionId} session_kept=true`,
+		'---',
+	];
+	if (opts.authPrompt) {
+		lines.push(`Interactive prompt blocked completion: ${opts.authPrompt}`);
+	} else if (opts.profileName) {
+		lines.push(`Foreground wait ended, but the terminal session for profile "${opts.profileName}" is still alive.`);
+	} else {
+		lines.push('Foreground wait ended, but the terminal session is still alive.');
+	}
+	if (opts.command) {
+		lines.push(`Command: ${opts.command}`);
+	}
+	lines.push('Use Terminal read with this session_id to inspect more output, or close it when finished.');
+	if (opts.output.trim()) {
+		lines.push('', opts.output);
+	}
+	return lines.join('\n');
 }
 
 function resolveTerminalCwd(raw: unknown, execCtx: ToolExecutionContext): string | undefined {
@@ -2139,6 +2203,8 @@ async function executeTerminalTool(call: ToolCall, execCtx: ToolExecutionContext
 		return { toolCallId: call.id, name: call.name, content: 'Error: action is required', isError: true };
 	}
 	const svc = await import('../terminalSessionService.js');
+	const runInBackground = parseTerminalRunInBackground(args);
+	const timeoutMs = parseTerminalTimeoutMs(args);
 	try {
 		switch (action) {
 			case 'list_profiles': {
@@ -2274,14 +2340,45 @@ async function executeTerminalTool(call: ToolCall, execCtx: ToolExecutionContext
 				if (!command) {
 					return { toolCallId: call.id, name: call.name, content: 'Error: command is required for run', isError: true };
 				}
+				if (runInBackground) {
+					const info = svc.startOneShotCommandSession({
+						command,
+						cwd: resolveTerminalCwd(args.cwd, execCtx),
+						shell: typeof args.shell === 'string' && args.shell.trim() ? args.shell.trim() : undefined,
+						cols: typeof args.cols === 'number' ? args.cols : undefined,
+						rows: typeof args.rows === 'number' ? args.rows : undefined,
+					});
+					return {
+						toolCallId: call.id,
+						name: call.name,
+						content: formatBackgroundTerminalSessionResult({
+							sessionId: info.id,
+							command,
+						}),
+						isError: false,
+					};
+				}
 				const res = await svc.runOneShotCommand({
 					command,
 					cwd: resolveTerminalCwd(args.cwd, execCtx),
 					shell: typeof args.shell === 'string' && args.shell.trim() ? args.shell.trim() : undefined,
-					timeoutMs: typeof args.timeout_ms === 'number' ? args.timeout_ms : undefined,
+					timeoutMs,
 					cols: typeof args.cols === 'number' ? args.cols : undefined,
 					rows: typeof args.rows === 'number' ? args.rows : undefined,
+					preserveOnTimeout: true,
 				});
+				if (res.timedOut && res.sessionKept) {
+					return {
+						toolCallId: call.id,
+						name: call.name,
+						content: formatPreservedTerminalSessionResult({
+							sessionId: res.id,
+							output: res.output,
+							command,
+						}),
+						isError: false,
+					};
+				}
 				const header = `exit_code=${res.exitCode ?? 'null'} timed_out=${res.timedOut}\n---\n`;
 				return {
 					toolCallId: call.id,
@@ -2327,6 +2424,30 @@ async function executeTerminalTool(call: ToolCall, execCtx: ToolExecutionContext
 						isError: true,
 					};
 				}
+				if (runInBackground) {
+					const info = svc.createTerminalSession({
+						...resolved.createOpts,
+						cwd: resolved.createOpts.cwd
+							? resolveTerminalCwd(resolved.createOpts.cwd, execCtx)
+							: resolved.createOpts.cwd,
+						cols: typeof args.cols === 'number' ? args.cols : resolved.createOpts.cols,
+						rows: typeof args.rows === 'number' ? args.rows : resolved.createOpts.rows,
+						title:
+							typeof args.title === 'string' && args.title.trim()
+								? args.title
+								: resolved.createOpts.title,
+					});
+					return {
+						toolCallId: call.id,
+						name: call.name,
+						content: formatBackgroundTerminalSessionResult({
+							sessionId: info.id,
+							command,
+							profileName: resolved.profile.name,
+						}),
+						isError: false,
+					};
+				}
 				const res = await svc.runTerminalSessionToExit({
 					createOpts: {
 						...resolved.createOpts,
@@ -2340,17 +2461,35 @@ async function executeTerminalTool(call: ToolCall, execCtx: ToolExecutionContext
 								? args.title
 								: resolved.createOpts.title,
 					},
-					timeoutMs: typeof args.timeout_ms === 'number' ? args.timeout_ms : undefined,
+					timeoutMs,
+					preserveOnTimeout: true,
+					preserveOnAuthPrompt: true,
 				});
 				if (res.authPrompt) {
 					return {
 						toolCallId: call.id,
 						name: call.name,
-						content:
-							`Authentication prompt blocked background exec for profile "${resolved.profile.name}". ` +
-							`Prompt: ${res.authPrompt.prompt}. Save credentials for the profile or use open + write/read for manual interaction.\n---\n` +
-							res.output,
+						content: formatPreservedTerminalSessionResult({
+							sessionId: res.id,
+							output: res.output,
+							command,
+							profileName: resolved.profile.name,
+							authPrompt: res.authPrompt.prompt,
+						}),
 						isError: true,
+					};
+				}
+				if (res.timedOut && res.sessionKept) {
+					return {
+						toolCallId: call.id,
+						name: call.name,
+						content: formatPreservedTerminalSessionResult({
+							sessionId: res.id,
+							output: res.output,
+							command,
+							profileName: resolved.profile.name,
+						}),
+						isError: false,
 					};
 				}
 				const header = `profile=${resolved.profile.name} exit_code=${res.exitCode ?? 'null'} timed_out=${res.timedOut}\n---\n`;

--- a/main-src/appWindow.ts
+++ b/main-src/appWindow.ts
@@ -1,7 +1,12 @@
 import { BrowserWindow, app, screen, type WebContents } from 'electron';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { THEME_CHROME } from './themeChrome.js';
+import {
+	applyThemeChromeToWindow,
+	THEME_CHROME,
+	type NativeChromeOverride,
+	type ThemeChromeScheme,
+} from './themeChrome.js';
 import {
 	bindWorkspaceRootToWebContents,
 	getWorkspaceRootForWebContents,
@@ -80,6 +85,10 @@ export function createAppWindow(opts?: {
 	blank?: boolean;
 	surface?: AppWindowSurface;
 	initialWorkspace?: string | null;
+	initialThemeChrome?: {
+		scheme: ThemeChromeScheme;
+		override?: NativeChromeOverride | null;
+	};
 	queryParams?: Record<string, string | number | boolean | null | undefined>;
 }): BrowserWindow {
 	const preloadPath = path.join(__dirname, 'preload.cjs');
@@ -92,14 +101,25 @@ export function createAppWindow(opts?: {
 	const x = wa.x + Math.round((wa.width - w) / 2);
 	const y = wa.y + Math.round((wa.height - h) / 2);
 
-	const darkChrome = THEME_CHROME.dark;
+	const initialThemeChrome = opts?.initialThemeChrome ?? { scheme: 'dark' as const, override: null };
+	const initialChromeTokens = THEME_CHROME[initialThemeChrome.scheme];
+	const initialBackgroundColor =
+		initialThemeChrome.override?.backgroundColor ?? initialChromeTokens.backgroundColor;
+	const initialTitleBarColor =
+		initialThemeChrome.override?.titleBarColor ?? initialChromeTokens.titleBarOverlay.color;
+	const initialSymbolColor =
+		initialThemeChrome.override?.symbolColor ?? initialChromeTokens.titleBarOverlay.symbolColor;
 	const titleBarOptions =
 		process.platform === 'darwin'
 			? { titleBarStyle: 'hiddenInset' as const }
 			: process.platform === 'win32'
 				? {
 						titleBarStyle: 'hidden' as const,
-						titleBarOverlay: { ...darkChrome.titleBarOverlay },
+						titleBarOverlay: {
+							color: initialTitleBarColor,
+							symbolColor: initialSymbolColor,
+							height: initialChromeTokens.titleBarOverlay.height,
+						},
 					}
 				: {};
 
@@ -110,7 +130,7 @@ export function createAppWindow(opts?: {
 		height: h,
 		minWidth: 800,
 		minHeight: 600,
-		backgroundColor: darkChrome.backgroundColor,
+		backgroundColor: initialBackgroundColor,
 		...(appIconPath ? { icon: appIconPath } : {}),
 		...titleBarOptions,
 		webPreferences: {
@@ -122,6 +142,7 @@ export function createAppWindow(opts?: {
 		},
 		show: false,
 	});
+	applyThemeChromeToWindow(win, initialThemeChrome.scheme, initialThemeChrome.override);
 
 	const surface: AppWindowSurface = opts?.surface ?? 'agent';
 	const webContentsId = win.webContents.id;

--- a/main-src/terminalSessionIpc.ts
+++ b/main-src/terminalSessionIpc.ts
@@ -3,7 +3,14 @@
  * 会话本身由 terminalSessionService.ts 管理；这里只暴露 IPC 面。
  */
 
-import { BrowserWindow, dialog, ipcMain, type FileFilter, type WebContents } from 'electron';
+import {
+	BrowserWindow,
+	dialog,
+	ipcMain,
+	nativeTheme,
+	type FileFilter,
+	type WebContents,
+} from 'electron';
 import path from 'node:path';
 import { existsSync, statSync } from 'node:fs';
 import { getWorkspaceRootForWebContents, resolveWorkspacePath } from './workspace.js';
@@ -46,6 +53,16 @@ import {
 	setTerminalProfilePassword,
 } from './terminalProfileSecrets.js';
 import { syncTerminalSettings } from './terminalProfileStore.js';
+import { getSettings } from './settingsStore.js';
+import {
+	nativeWindowChromeFromAppearance,
+	normalizeAppearanceSettings,
+} from '../src/appearanceSettings.js';
+import {
+	INITIAL_WINDOW_THEME_QUERY_PARAM,
+	serializeInitialWindowThemePayload,
+} from '../src/initialWindowTheme.js';
+import type { ThemeChromeScheme } from './themeChrome.js';
 
 const openPromisesByHost = new Map<number, Promise<number | null>>();
 const terminalWindowRendererByHost = new Map<number, number>();
@@ -54,6 +71,31 @@ const terminalWindowHostByRenderer = new Map<number, number>();
 type OpenTerminalWindowOptions = {
 	startPage?: boolean;
 };
+
+function resolveInitialTerminalWindowTheme(): {
+	queryValue: string;
+	scheme: ThemeChromeScheme;
+	chromeOverride: ReturnType<typeof nativeWindowChromeFromAppearance>;
+} {
+	const settings = getSettings();
+	const ui = (settings.ui ?? {}) as Partial<Record<string, unknown>>;
+	const colorMode =
+		ui.colorMode === 'light' || ui.colorMode === 'dark' || ui.colorMode === 'system'
+			? ui.colorMode
+			: 'dark';
+	const scheme: ThemeChromeScheme =
+		colorMode === 'system' ? (nativeTheme.shouldUseDarkColors ? 'dark' : 'light') : colorMode;
+	const appearance = normalizeAppearanceSettings(ui, scheme);
+	return {
+		queryValue: serializeInitialWindowThemePayload({
+			colorMode,
+			scheme,
+			ui,
+		}),
+		scheme,
+		chromeOverride: nativeWindowChromeFromAppearance(appearance, scheme),
+	};
+}
 
 function resolveHostId(sender: WebContents): number {
 	return terminalWindowHostByRenderer.get(sender.id) ?? sender.id;
@@ -120,12 +162,18 @@ async function ensureTerminalWindowForHostId(hostId: number, options: OpenTermin
 			}
 			const initialWorkspace = getWorkspaceRootForWebContents(source);
 			const { createAppWindow } = await import('./appWindow.js');
+			const initialTheme = resolveInitialTerminalWindowTheme();
 			const win = createAppWindow({
 				blank: true,
 				surface: 'agent',
 				initialWorkspace,
+				initialThemeChrome: {
+					scheme: initialTheme.scheme,
+					override: initialTheme.chromeOverride,
+				},
 				queryParams: {
 					terminalWindow: '1',
+					[INITIAL_WINDOW_THEME_QUERY_PARAM]: initialTheme.queryValue,
 					...(options.startPage ? { startPage: '1' } : {}),
 				},
 			});

--- a/main-src/terminalSessionService.ts
+++ b/main-src/terminalSessionService.ts
@@ -264,6 +264,25 @@ export type TerminalBufferSlice = {
 	authPrompt: TerminalSessionAuthPrompt | null;
 };
 
+export type TerminalOneShotCommandResult = {
+	id: string;
+	exitCode: number | null;
+	output: string;
+	timedOut: boolean;
+	sessionKept: boolean;
+	alive: boolean;
+};
+
+export type TerminalWaitForExitResult = {
+	id: string;
+	exitCode: number | null;
+	output: string;
+	timedOut: boolean;
+	authPrompt: TerminalSessionAuthPrompt | null;
+	sessionKept: boolean;
+	alive: boolean;
+};
+
 export function getTerminalBuffer(id: string, maxBytes?: number): TerminalBufferSlice | null {
 	const s = sessions.get(id);
 	if (!s) {
@@ -337,14 +356,13 @@ export function renameTerminalSession(id: string, title: string): boolean {
  * 启动一个短命会话、等待其退出（或超时后强杀），返回完整输出。
  * 适合 agent `Terminal run` 动作：不需要持续交互时无副作用地执行命令。
  */
-export async function runOneShotCommand(opts: {
+export function startOneShotCommandSession(opts: {
 	command: string;
 	cwd?: string;
 	shell?: string;
-	timeoutMs?: number;
 	cols?: number;
 	rows?: number;
-}): Promise<{ id: string; exitCode: number | null; output: string; timedOut: boolean }> {
+}): TerminalSessionInfo {
 	const info = createTerminalSession({
 		cwd: opts.cwd,
 		shell: opts.shell,
@@ -352,23 +370,60 @@ export async function runOneShotCommand(opts: {
 		rows: opts.rows,
 		title: '(one-shot) ' + opts.command.slice(0, 40),
 	});
+	const cr = isWindows() ? '\r\n' : '\n';
+	const submitted = writeTerminalSession(info.id, opts.command + cr + (isWindows() ? 'exit\r\n' : 'exit\n'));
+	if (!submitted) {
+		killTerminalSession(info.id);
+		throw new Error('Failed to submit one-shot command to terminal session.');
+	}
+	return info;
+}
+
+export async function runOneShotCommand(opts: {
+	command: string;
+	cwd?: string;
+	shell?: string;
+	timeoutMs?: number;
+	cols?: number;
+	rows?: number;
+	preserveOnTimeout?: boolean;
+}): Promise<TerminalOneShotCommandResult> {
+	const info = startOneShotCommandSession(opts);
 	const session = sessions.get(info.id)!;
 	const timeoutMs = Math.max(500, Math.min(opts.timeoutMs ?? 120_000, 600_000));
-	return await new Promise<{ id: string; exitCode: number | null; output: string; timedOut: boolean }>((resolve) => {
+	return await new Promise<TerminalOneShotCommandResult>((resolve) => {
 		let settled = false;
 		const timer = setTimeout(() => {
 			if (settled) {
 				return;
 			}
 			settled = true;
+			const slice = getTerminalBuffer(info.id, MAX_BUFFER_BYTES);
+			if (opts.preserveOnTimeout) {
+				resolve({
+					id: info.id,
+					exitCode: slice?.exitCode ?? session.exitCode,
+					output: slice?.content ?? '',
+					timedOut: true,
+					sessionKept: true,
+					alive: slice?.alive ?? session.alive,
+				});
+				return;
+			}
 			try {
 				session.pty.kill();
 			} catch {
 				/* ignore */
 			}
-			const slice = getTerminalBuffer(info.id, MAX_BUFFER_BYTES);
 			sessions.delete(info.id);
-			resolve({ id: info.id, exitCode: null, output: slice?.content ?? '', timedOut: true });
+			resolve({
+				id: info.id,
+				exitCode: null,
+				output: slice?.content ?? '',
+				timedOut: true,
+				sessionKept: false,
+				alive: false,
+			});
 		}, timeoutMs);
 		const disposeExit = session.pty.onExit(({ exitCode }) => {
 			if (settled) {
@@ -384,43 +439,38 @@ export async function runOneShotCommand(opts: {
 				exitCode: typeof exitCode === 'number' ? exitCode : null,
 				output: slice?.content ?? '',
 				timedOut: false,
+				sessionKept: false,
+				alive: false,
 			});
 		});
-		try {
-			const cr = isWindows() ? '\r\n' : '\n';
-			session.pty.write(opts.command + cr + (isWindows() ? 'exit\r\n' : 'exit\n'));
-		} catch {
-			clearTimeout(timer);
-			disposeExit.dispose();
-			sessions.delete(info.id);
-			resolve({ id: info.id, exitCode: null, output: '', timedOut: false });
-		}
 	});
 }
 
 export async function runTerminalSessionToExit(opts: {
 	createOpts: TerminalSessionCreateOpts;
 	timeoutMs?: number;
-}): Promise<{
-	id: string;
-	exitCode: number | null;
-	output: string;
-	timedOut: boolean;
-	authPrompt: TerminalSessionAuthPrompt | null;
-}> {
+	preserveOnTimeout?: boolean;
+	preserveOnAuthPrompt?: boolean;
+}): Promise<TerminalWaitForExitResult> {
 	const info = createTerminalSession(opts.createOpts);
 	const session = sessions.get(info.id)!;
 	const timeoutMs = Math.max(500, Math.min(opts.timeoutMs ?? 120_000, 600_000));
 	const deadline = Date.now() + timeoutMs;
+	let shouldKillOnFinally = true;
 	try {
 		while (Date.now() < deadline) {
 			if (session.pendingAuthPrompt) {
+				if (opts.preserveOnAuthPrompt) {
+					shouldKillOnFinally = false;
+				}
 				return {
 					id: info.id,
 					exitCode: null,
 					output: getTerminalBuffer(info.id, MAX_BUFFER_BYTES)?.content ?? '',
 					timedOut: false,
 					authPrompt: session.pendingAuthPrompt,
+					sessionKept: opts.preserveOnAuthPrompt === true,
+					alive: session.alive,
 				};
 			}
 			if (!session.alive) {
@@ -431,9 +481,14 @@ export async function runTerminalSessionToExit(opts: {
 					output: slice?.content ?? '',
 					timedOut: false,
 					authPrompt: null,
+					sessionKept: false,
+					alive: false,
 				};
 			}
 			await delay(120);
+		}
+		if (opts.preserveOnTimeout) {
+			shouldKillOnFinally = false;
 		}
 		return {
 			id: info.id,
@@ -441,9 +496,13 @@ export async function runTerminalSessionToExit(opts: {
 			output: getTerminalBuffer(info.id, MAX_BUFFER_BYTES)?.content ?? '',
 			timedOut: true,
 			authPrompt: session.pendingAuthPrompt,
+			sessionKept: opts.preserveOnTimeout === true,
+			alive: session.alive,
 		};
 	} finally {
-		killTerminalSession(info.id);
+		if (shouldKillOnFinally) {
+			killTerminalSession(info.id);
+		}
 	}
 }
 

--- a/src/AgentChatPanel.tsx
+++ b/src/AgentChatPanel.tsx
@@ -208,6 +208,106 @@ function expandStartIndexByPixelBudget(
 	return newStart;
 }
 
+type AgentTodoItem = {
+	id: string;
+	content: string;
+	status: 'pending' | 'in_progress' | 'completed';
+	activeForm?: string;
+};
+
+function AgentTodoPanel({
+	t,
+	todos,
+	isCollapsed,
+	onToggle,
+}: {
+	t: TFunction;
+	todos: AgentTodoItem[];
+	isCollapsed: boolean;
+	onToggle: () => void;
+}) {
+	const doneCount = todos.filter((todo) => todo.status === 'completed').length;
+
+	return (
+		<div className="ref-plan-review-todos ref-agent-todo-panel">
+			<button
+				type="button"
+				className="ref-plan-review-todos-head"
+				aria-expanded={!isCollapsed}
+				onClick={onToggle}
+			>
+				<span>{t('plan.review.todo', { done: doneCount, total: todos.length })}</span>
+				<svg
+					className={`ref-plan-review-chev${isCollapsed ? '' : ' is-open'}`}
+					width="16"
+					height="16"
+					viewBox="0 0 16 16"
+					fill="none"
+					aria-hidden
+				>
+					<path
+						d="M4 6l4 4 4-4"
+						stroke="currentColor"
+						strokeWidth="1.5"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+					/>
+				</svg>
+			</button>
+			{!isCollapsed ? (
+				<div className="ref-plan-review-todos-list">
+					{todos.map((todo) => {
+						const done = todo.status === 'completed';
+						const active = todo.status === 'in_progress';
+						return (
+							<div
+								key={todo.id}
+								className={`ref-plan-todo ${done ? 'is-done' : ''} ${active ? 'is-active' : ''}`}
+							>
+								{active ? (
+									<span className="ref-plan-todo-spinner" aria-hidden />
+								) : (
+									<svg
+										className="ref-plan-todo-check"
+										width="16"
+										height="16"
+										viewBox="0 0 16 16"
+										fill="none"
+										aria-hidden
+									>
+										<rect
+											x="1"
+											y="1"
+											width="14"
+											height="14"
+											rx="3"
+											stroke="currentColor"
+											strokeWidth="1.5"
+											fill={done ? 'currentColor' : 'none'}
+										/>
+										{done ? (
+											<path
+												d="M4.5 8l2.5 2.5 4.5-5"
+												stroke="var(--void-bg-3, #1a1a1a)"
+												strokeWidth="1.8"
+												strokeLinecap="round"
+												strokeLinejoin="round"
+											/>
+										) : null}
+									</svg>
+								)}
+								<span className="ref-plan-todo-text">
+									{active && todo.activeForm ? todo.activeForm : todo.content}
+								</span>
+							</div>
+						);
+					})}
+				</div>
+			) : null}
+		</div>
+	);
+}
+
 export const AgentChatPanel = memo(function AgentChatPanel({
 	layout = 'agent-center',
 	t,
@@ -721,6 +821,18 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 				isLast &&
 				streamingToolPreview == null &&
 				!(agentOrPlanStreaming && (liveAssistantBlocks.blocks.length > 0 || liveThoughtMeta != null));
+			const activeAssistantTodos: AgentTodoItem[] | null =
+				agentOrPlanStreaming && m.role === 'assistant'
+					? (extractTodosFromLiveBlocks(liveAssistantBlocks.blocks) ??
+						(typeof m.content === 'string' ? extractLastTodosFromContent(m.content) : null))
+					: null;
+			const hasActiveAssistantTodoPanel =
+				activeAssistantTodos != null && activeAssistantTodos.length > 0;
+			const activeAssistantTodoCollapsed =
+				hasActiveAssistantTodoPanel &&
+				collapsedTodos.has(i)
+					? !activeAssistantTodos.every((todo) => todo.status === 'completed')
+					: Boolean(hasActiveAssistantTodoPanel && activeAssistantTodos.every((todo) => todo.status === 'completed'));
 			const userMessageIndex = i < persistedMessageCount && m.role === 'user' ? i : -1;
 			const isEditingThisUser = userMessageIndex >= 0 && resendFromUserIndex === userMessageIndex;
 
@@ -743,21 +855,8 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 			if (m.role === 'user') {
 				const userSegs = cachedUserMessageToSegments(m.content, m.parts);
 
-				// Look ahead: does the next assistant message contain TodoWrite?
-				const nextMsg = displayMessages[i + 1];
-				const isNextAssistantStreaming = nextMsg?.role === 'assistant' && (i + 1) === displayMessages.length - 1 && awaitingReply;
-				const userTodos = nextMsg?.role === 'assistant'
-					? (isNextAssistantStreaming && liveAssistantBlocks
-						? (extractTodosFromLiveBlocks(liveAssistantBlocks.blocks) ??
-								(typeof nextMsg.content === 'string' ? extractLastTodosFromContent(nextMsg.content) : null))
-						: typeof nextMsg.content === 'string'
-							? extractLastTodosFromContent(nextMsg.content)
-							: null)
-					: null;
-				const hasTodoPanel = userTodos != null && userTodos.length > 0;
-
 				return (
-					<div className={`ref-msg-slot ref-msg-slot--user${hasTodoPanel ? ' has-todo-panel' : ''}`}>
+					<div className="ref-msg-slot ref-msg-slot--user">
 						<button
 							type="button"
 							className="ref-msg-user"
@@ -772,56 +871,6 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 						>
 							<UserMessageRich segments={userSegs} onFileClick={onOpenWorkspaceFile} />
 						</button>
-						{hasTodoPanel && (() => {
-							const doneCount = userTodos!.filter(td => td.status === 'completed').length;
-							const allDone = doneCount === userTodos!.length;
-							const userToggled = collapsedTodos.has(i);
-							const isCollapsed = userToggled ? !allDone : allDone;
-							return (
-								<div className="ref-plan-review-todos ref-agent-todo-panel">
-									<button
-										type="button"
-										className="ref-plan-review-todos-head"
-										onClick={(e) => { e.stopPropagation(); toggleTodoCollapse(i); }}
-									>
-										<span>{t('plan.review.todo', { done: doneCount, total: userTodos!.length })}</span>
-										<svg className={`ref-plan-review-chev${isCollapsed ? '' : ' is-open'}`} width="16" height="16" viewBox="0 0 16 16" fill="none">
-											<path d="M4 6l4 4 4-4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-										</svg>
-									</button>
-									{!isCollapsed && (
-										<div className="ref-plan-review-todos-list">
-											{userTodos!.map((todo) => {
-												const done = todo.status === 'completed';
-												const active = todo.status === 'in_progress';
-												return (
-													<div key={todo.id} className={`ref-plan-todo ${done ? 'is-done' : ''} ${active ? 'is-active' : ''}`}>
-														{active ? (
-															<span className="ref-plan-todo-spinner" aria-hidden />
-														) : (
-															<svg className="ref-plan-todo-check" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden>
-																<rect
-																	x="1" y="1" width="14" height="14" rx="3"
-																	stroke="currentColor"
-																	strokeWidth="1.5"
-																	fill={done ? 'currentColor' : 'none'}
-																/>
-																{done ? (
-																	<path d="M4.5 8l2.5 2.5 4.5-5" stroke="var(--void-bg-3, #1a1a1a)" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
-																) : null}
-															</svg>
-														)}
-														<span className="ref-plan-todo-text">
-															{active && todo.activeForm ? todo.activeForm : todo.content}
-														</span>
-													</div>
-												);
-											})}
-										</div>
-									)}
-								</div>
-							);
-						})()}
 					</div>
 				);
 			}
@@ -829,7 +878,6 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 			return (
 				<div key={`a-${convoKey}-${i}`} className="ref-msg-slot ref-msg-slot--assistant">
 					{thoughtBlock && !thoughtAfterBody ? thoughtBlock : null}
-					{/* TODO panel moved to user message bubble */}
 					<div className="ref-msg-assistant-body">
 						{pendingEmptyAssistant ? (
 							<span className="ref-bubble-pending" aria-hidden>
@@ -867,6 +915,14 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 								skipPlanTodo
 							/>
 						)}
+						{hasActiveAssistantTodoPanel ? (
+							<AgentTodoPanel
+								t={t}
+								todos={activeAssistantTodos}
+								isCollapsed={activeAssistantTodoCollapsed}
+								onToggle={() => toggleTodoCollapse(i)}
+							/>
+						) : null}
 					</div>
 					{thoughtBlock && thoughtAfterBody ? thoughtBlock : null}
 				</div>

--- a/src/AgentFilePreviewPanel.tsx
+++ b/src/AgentFilePreviewPanel.tsx
@@ -15,6 +15,7 @@ import {
 } from './agentFilePreviewShiki';
 import { useI18n } from './i18n';
 import { voidShellDebugLog } from './tabCloseDebug';
+import { useDomColorScheme } from './useDomColorScheme';
 
 type Props = {
 	filePath: string;
@@ -105,6 +106,7 @@ export function AgentFilePreviewPanel({
 	busyHunkPatch = null,
 }: Props) {
 	const { t } = useI18n();
+	const colorScheme = useDomColorScheme();
 	const scrollRef = useRef<HTMLDivElement>(null);
 	const [rows, setRows] = useState<AgentFilePreviewRow[]>(() =>
 		String(diff ?? '').trim() ? [] : buildPlainAgentFilePreviewRows(content)
@@ -152,7 +154,7 @@ export function AgentFilePreviewPanel({
 				if (cancelled) {
 					return;
 				}
-				const next = computeAgentFilePreviewLineHtmls(h, lang, rows);
+				const next = computeAgentFilePreviewLineHtmls(h, lang, rows, colorScheme);
 				if (!cancelled) {
 					setShikiHtmlByRow(next);
 				}
@@ -166,7 +168,7 @@ export function AgentFilePreviewPanel({
 		return () => {
 			cancelled = true;
 		};
-	}, [filePath, rows, loading, readError, isBinary]);
+	}, [filePath, rows, loading, readError, isBinary, colorScheme]);
 
 	const hunkMap = useMemo(() => new Map(hunks.map((hunk) => [hunk.id, hunk])), [hunks]);
 	const blocks = useMemo(() => buildPreviewBlocks(rows, hunks), [rows, hunks]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,6 +52,10 @@ import {
 	type ThemeTransitionOrigin,
 	writeStoredColorMode,
 } from './colorMode';
+import {
+	persistInitialWindowThemeSnapshot,
+	type InitialWindowThemeSnapshot,
+} from './initialWindowTheme';
 // modelCatalog types are re-exported via useSettings hook return type
 import { type ComposerMode } from './ComposerPlusMenu';
 import {
@@ -217,11 +221,13 @@ type OnSendOptions = {
 export default function App({
 	appSurface,
 	browserWindow = false,
+	initialThemeSnapshot = null,
 	terminalWindow = false,
 	terminalStartPage = false,
 }: {
 	appSurface?: LayoutMode;
 	browserWindow?: boolean;
+	initialThemeSnapshot?: InitialWindowThemeSnapshot | null;
 	terminalWindow?: boolean;
 	terminalStartPage?: boolean;
 } = {}) {
@@ -240,8 +246,12 @@ export default function App({
 			syncTerminalSettingsToMain(loadTerminalSettings());
 		});
 	}, [shell]);
-	const [colorMode, setColorMode] = useState<AppColorMode>(() => readStoredColorMode());
-	const [appearanceSettings, setAppearanceSettings] = useState<AppAppearanceSettings>(() => defaultAppearanceSettings());
+	const [colorMode, setColorMode] = useState<AppColorMode>(
+		() => initialThemeSnapshot?.colorMode ?? readStoredColorMode()
+	);
+	const [appearanceSettings, setAppearanceSettings] = useState<AppAppearanceSettings>(
+		() => initialThemeSnapshot?.appearanceSettings ?? defaultAppearanceSettings()
+	);
 	const { effectiveScheme, setTransitionOrigin } = useAppColorScheme({ colorMode });
 	const monacoChromeTheme = getVoidMonacoTheme(effectiveScheme);
 	const effectiveSchemePrevRef = useRef(effectiveScheme);
@@ -299,6 +309,11 @@ export default function App({
 	// 合并 appearanceSettings 相关的 DOM 更新,减少级联渲染
 	useEffect(() => {
 		applyAppearanceSettingsToDom(appearanceSettings, effectiveScheme);
+		persistInitialWindowThemeSnapshot({
+			colorMode,
+			effectiveScheme,
+			appearanceSettings,
+		});
 		if (!shell) {
 			return;
 		}
@@ -309,7 +324,7 @@ export default function App({
 			titleBarColor: c.titleBarColor,
 			symbolColor: c.symbolColor,
 		});
-	}, [shell, appearanceSettings, effectiveScheme]);
+	}, [shell, colorMode, appearanceSettings, effectiveScheme]);
 
 	const { t, setLocale, locale } = useI18n();
 	const [ipcOk, setIpcOk] = useState<string>('…');

--- a/src/GitScmVirtualLists.tsx
+++ b/src/GitScmVirtualLists.tsx
@@ -12,6 +12,7 @@ import {
 	getAgentFilePreviewHighlighter,
 	type GitSidebarDiffLineRender,
 } from './agentFilePreviewShiki';
+import { useDomColorScheme } from './useDomColorScheme';
 
 /** 达到条数后 Agent 侧栏 Git 卡片使用虚拟列表（卡片含 diff，高度由 measureElement 测量） */
 export const AGENT_GIT_SCM_VIRTUAL_THRESHOLD = 8;
@@ -77,6 +78,7 @@ const GitDiffLines = memo(function GitDiffLines({
 	relPath: string;
 	t: TFunction;
 }) {
+	const colorScheme = useDomColorScheme();
 	const trimmed = useMemo(() => trimGitDiffForSidebarCard(diff), [diff]);
 	const lines = useMemo(() => trimmed.split('\n').slice(0, 120), [trimmed]);
 	const [views, setViews] = useState<GitSidebarDiffLineRender[] | null>(null);
@@ -95,7 +97,7 @@ const GitDiffLines = memo(function GitDiffLines({
 					return;
 				}
 				const next = lines.map((line) =>
-					buildGitSidebarDiffLineRender(h, lang, line, gitSidebarDiffLineClass(line))
+					buildGitSidebarDiffLineRender(h, lang, line, gitSidebarDiffLineClass(line), colorScheme)
 				);
 				if (!cancelled) {
 					setViews(next);
@@ -110,7 +112,7 @@ const GitDiffLines = memo(function GitDiffLines({
 		return () => {
 			cancelled = true;
 		};
-	}, [lines, relPath]);
+	}, [lines, relPath, colorScheme]);
 
 	return (
 		<div className="ref-git-card-diff" role="region" aria-label={t('git.diffPreview')}>

--- a/src/agentFilePreviewShiki.test.ts
+++ b/src/agentFilePreviewShiki.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import {
+	AGENT_FILE_PREVIEW_SHIKI_THEME_DARK,
+	AGENT_FILE_PREVIEW_SHIKI_THEME_LIGHT,
+	resolveAgentFilePreviewShikiTheme,
+} from './agentFilePreviewShiki';
+
+describe('resolveAgentFilePreviewShikiTheme', () => {
+	it('returns the dark Shiki theme for dark mode', () => {
+		expect(resolveAgentFilePreviewShikiTheme('dark')).toBe(AGENT_FILE_PREVIEW_SHIKI_THEME_DARK);
+	});
+
+	it('returns the light Shiki theme for light mode', () => {
+		expect(resolveAgentFilePreviewShikiTheme('light')).toBe(AGENT_FILE_PREVIEW_SHIKI_THEME_LIGHT);
+	});
+});

--- a/src/agentFilePreviewShiki.ts
+++ b/src/agentFilePreviewShiki.ts
@@ -1,7 +1,9 @@
-import type { BundledLanguage, Highlighter } from 'shiki';
+import type { BundledLanguage, BundledTheme, Highlighter } from 'shiki';
 import type { AgentFilePreviewRow } from './agentFilePreviewDiff';
+import type { EffectiveColorScheme } from './colorMode';
 
-export const AGENT_FILE_PREVIEW_SHIKI_THEME = 'github-dark' as const;
+export const AGENT_FILE_PREVIEW_SHIKI_THEME_DARK = 'github-dark' as const;
+export const AGENT_FILE_PREVIEW_SHIKI_THEME_LIGHT = 'github-light-default' as const;
 
 type ShikiHighlighter = Highlighter;
 
@@ -61,6 +63,12 @@ const EXT_TO_LANG: Record<string, string> = {
 
 let highlighterPromise: Promise<ShikiHighlighter> | null = null;
 
+export function resolveAgentFilePreviewShikiTheme(colorScheme: EffectiveColorScheme): BundledTheme {
+	return colorScheme === 'light'
+		? AGENT_FILE_PREVIEW_SHIKI_THEME_LIGHT
+		: AGENT_FILE_PREVIEW_SHIKI_THEME_DARK;
+}
+
 export function agentFilePreviewPathToLang(filePath: string): string {
 	const seg = filePath.replace(/\\/g, '/').split('/').pop() ?? '';
 	const i = seg.lastIndexOf('.');
@@ -78,7 +86,7 @@ export async function getAgentFilePreviewHighlighter(): Promise<ShikiHighlighter
 	if (!highlighterPromise) {
 		const { createHighlighter, createJavaScriptRegexEngine } = await import('shiki');
 		highlighterPromise = createHighlighter({
-			themes: [AGENT_FILE_PREVIEW_SHIKI_THEME],
+			themes: [AGENT_FILE_PREVIEW_SHIKI_THEME_DARK, AGENT_FILE_PREVIEW_SHIKI_THEME_LIGHT],
 			langs: ['plaintext'],
 			engine: createJavaScriptRegexEngine(),
 		});
@@ -111,12 +119,17 @@ function escapeHtml(s: string): string {
 /**
  * 行内 HTML（各 span 带 style="color:…"），用 dangerouslySetInnerHTML 渲染，不依赖外层 CSS 传色。
  */
-export function shikiLineToInlineHtml(h: ShikiHighlighter, lineText: string, lang: string): string {
+export function shikiLineToInlineHtml(
+	h: ShikiHighlighter,
+	lineText: string,
+	lang: string,
+	colorScheme: EffectiveColorScheme = 'dark'
+): string {
 	const raw = lineText === '' ? ' ' : lineText;
 	try {
 		return h.codeToHtml(raw, {
 			lang: asBundledLang(lang),
-			theme: AGENT_FILE_PREVIEW_SHIKI_THEME,
+			theme: resolveAgentFilePreviewShikiTheme(colorScheme),
 			structure: 'inline',
 		});
 	} catch {
@@ -127,9 +140,10 @@ export function shikiLineToInlineHtml(h: ShikiHighlighter, lineText: string, lan
 export function computeAgentFilePreviewLineHtmls(
 	h: ShikiHighlighter,
 	lang: string,
-	rows: AgentFilePreviewRow[]
+	rows: AgentFilePreviewRow[],
+	colorScheme: EffectiveColorScheme = 'dark'
 ): string[] {
-	return rows.map((row) => shikiLineToInlineHtml(h, row.text, lang));
+	return rows.map((row) => shikiLineToInlineHtml(h, row.text, lang, colorScheme));
 }
 
 export type GitSidebarDiffLineRender =
@@ -141,7 +155,8 @@ export function buildGitSidebarDiffLineRender(
 	h: ShikiHighlighter,
 	lang: string,
 	line: string,
-	lineClassName: string
+	lineClassName: string,
+	colorScheme: EffectiveColorScheme = 'dark'
 ): GitSidebarDiffLineRender {
 	if (lineClassName.includes('is-meta')) {
 		return { mode: 'raw', className: lineClassName, html: escapeHtml(line || '\u00a0') };
@@ -151,6 +166,6 @@ export function buildGitSidebarDiffLineRender(
 	}
 	const prefix = line[0]!;
 	const body = line.slice(1);
-	const bodyHtml = shikiLineToInlineHtml(h, body, lang);
+	const bodyHtml = shikiLineToInlineHtml(h, body, lang, colorScheme);
 	return { mode: 'split', className: lineClassName, prefix, bodyHtml };
 }

--- a/src/colorMode.test.ts
+++ b/src/colorMode.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { readDomColorScheme } from './colorMode';
+
+describe('readDomColorScheme', () => {
+	it('reads the light scheme from the document root attribute', () => {
+		const doc = {
+			documentElement: {
+				getAttribute(name: string) {
+					return name === 'data-color-scheme' ? 'light' : null;
+				},
+			},
+		} as unknown as Document;
+
+		expect(readDomColorScheme(doc)).toBe('light');
+	});
+
+	it('falls back to dark when the scheme attribute is missing', () => {
+		const doc = {
+			documentElement: {
+				getAttribute() {
+					return null;
+				},
+			},
+		} as unknown as Document;
+
+		expect(readDomColorScheme(doc)).toBe('dark');
+	});
+});

--- a/src/colorMode.ts
+++ b/src/colorMode.ts
@@ -1,5 +1,6 @@
 /** ???? `ShellColorMode` ??????????? main-src ??? */
 export type AppColorMode = 'light' | 'dark' | 'system';
+export type EffectiveColorScheme = 'light' | 'dark';
 export type ThemeTransitionOrigin = { x: number; y: number };
 
 export const APP_UI_STYLE = 'mac-codex';
@@ -38,21 +39,25 @@ export function readPrefersDark(): boolean {
 	return window.matchMedia('(prefers-color-scheme: dark)').matches;
 }
 
-export function resolveEffectiveScheme(mode: AppColorMode, prefersDark: boolean): 'light' | 'dark' {
+export function resolveEffectiveScheme(mode: AppColorMode, prefersDark: boolean): EffectiveColorScheme {
 	if (mode === 'system') {
 		return prefersDark ? 'dark' : 'light';
 	}
 	return mode;
 }
 
-export function getVoidMonacoTheme(effective: 'light' | 'dark'): 'void-light' | 'void-dark' {
+export function readDomColorScheme(doc: Document | null | undefined = typeof document !== 'undefined' ? document : null): EffectiveColorScheme {
+	if (!doc) {
+		return 'dark';
+	}
+	return doc.documentElement.getAttribute('data-color-scheme') === 'light' ? 'light' : 'dark';
+}
+
+export function getVoidMonacoTheme(effective: EffectiveColorScheme): 'void-light' | 'void-dark' {
 	return effective === 'light' ? 'void-light' : 'void-dark';
 }
 
 /** Agent ????????????? DOM */
 export function getVoidMonacoThemeFromDom(): 'void-light' | 'void-dark' {
-	if (typeof document === 'undefined') {
-		return 'void-dark';
-	}
-	return document.documentElement.getAttribute('data-color-scheme') === 'light' ? 'void-light' : 'void-dark';
+	return getVoidMonacoTheme(readDomColorScheme());
 }

--- a/src/index.css
+++ b/src/index.css
@@ -4946,7 +4946,7 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 
 .ref-agent-diff-card-open:hover .ref-agent-diff-card-head,
 .ref-agent-diff-card-open:focus-visible .ref-agent-diff-card-head {
-	background: rgba(129, 140, 248, 0.1);
+	background: color-mix(in srgb, var(--void-accent-assist) 12%, transparent);
 }
 
 .ref-agent-diff-card-open:focus-visible {
@@ -5008,11 +5008,11 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 }
 
 .ref-agent-diff-stat-add {
-	color: #86efac;
+	color: var(--void-git-added);
 }
 
 .ref-agent-diff-stat-del {
-	color: #fca5a5;
+	color: var(--void-git-deleted);
 }
 
 .ref-agent-diff-stat-neutral {
@@ -5050,7 +5050,11 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 	margin-top: 0;
 	padding: 6px 0 4px;
 	border-top: 1px solid var(--void-border-soft);
-	background: linear-gradient(to top, rgba(10, 10, 14, 0.98) 70%, rgba(10, 10, 14, 0));
+	background: linear-gradient(
+		to top,
+		color-mix(in srgb, var(--surface-panel-bg-strong) 98%, transparent) 70%,
+		transparent
+	);
 	position: sticky;
 	bottom: 0;
 }
@@ -5063,9 +5067,9 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 	height: 52px;
 	background: linear-gradient(
 		to bottom,
-		rgba(10, 10, 14, 0) 0%,
-		rgba(10, 10, 14, 0.75) 50%,
-		rgba(10, 10, 14, 0.96) 100%
+		transparent 0%,
+		color-mix(in srgb, var(--surface-panel-bg-strong) 74%, transparent) 50%,
+		color-mix(in srgb, var(--surface-panel-bg-strong) 96%, transparent) 100%
 	);
 	pointer-events: none;
 }
@@ -5078,9 +5082,10 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 	height: 28px;
 	margin: 0;
 	padding: 0;
-	border: none;
+	border: 1px solid color-mix(in srgb, var(--surface-glass-stroke) 88%, transparent);
 	border-radius: 8px;
-	background: rgba(255, 255, 255, 0.06);
+	background: color-mix(in srgb, var(--surface-control-bg) 92%, transparent);
+	box-shadow: var(--shadow-pressed);
 	color: var(--void-fg-3);
 	cursor: pointer;
 	position: relative;
@@ -5089,7 +5094,7 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 }
 
 .ref-agent-diff-toggle:hover {
-	background: rgba(255, 255, 255, 0.1);
+	background: color-mix(in srgb, var(--surface-control-bg-hover) 94%, transparent);
 	color: var(--void-fg-1);
 }
 
@@ -5118,18 +5123,18 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 }
 
 .ref-agent-diff-line.is-add {
-	background: rgba(22, 101, 52, 0.45);
-	color: #bbf7d0;
+	background: color-mix(in srgb, var(--void-git-added) 20%, transparent);
+	color: color-mix(in srgb, var(--void-git-added) 70%, var(--void-fg-0) 30%);
 }
 
 .ref-agent-diff-line.is-del {
-	background: rgba(127, 29, 29, 0.42);
-	color: #fecaca;
+	background: color-mix(in srgb, var(--void-git-deleted) 18%, transparent);
+	color: color-mix(in srgb, var(--void-git-deleted) 72%, var(--void-fg-0) 28%);
 }
 
 .ref-agent-diff-line.is-hunk {
-	color: #a5b4fc;
-	background: rgba(79, 70, 229, 0.12);
+	color: color-mix(in srgb, var(--void-accent-assist) 76%, var(--void-fg-0) 24%);
+	background: color-mix(in srgb, var(--void-accent-assist) 12%, transparent);
 }
 
 .ref-agent-diff-line.is-meta {
@@ -9421,16 +9426,24 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 
 .ref-agent-file-preview-hunk-segment--add {
 	background:
-		linear-gradient(90deg, color-mix(in srgb, #22c55e 18%, transparent) 0%, color-mix(in srgb, #22c55e 10%, transparent) 100%);
-	border-top: 1px solid color-mix(in srgb, #22c55e 18%, transparent);
-	border-bottom: 1px solid color-mix(in srgb, #22c55e 14%, transparent);
+		linear-gradient(
+			90deg,
+			color-mix(in srgb, var(--void-git-added) 18%, transparent) 0%,
+			color-mix(in srgb, var(--void-git-added) 10%, transparent) 100%
+		);
+	border-top: 1px solid color-mix(in srgb, var(--void-git-added) 18%, transparent);
+	border-bottom: 1px solid color-mix(in srgb, var(--void-git-added) 14%, transparent);
 }
 
 .ref-agent-file-preview-hunk-segment--del {
 	background:
-		linear-gradient(90deg, color-mix(in srgb, #ef4444 18%, transparent) 0%, color-mix(in srgb, #ef4444 10%, transparent) 100%);
-	border-top: 1px solid color-mix(in srgb, #ef4444 18%, transparent);
-	border-bottom: 1px solid color-mix(in srgb, #ef4444 14%, transparent);
+		linear-gradient(
+			90deg,
+			color-mix(in srgb, var(--void-git-deleted) 18%, transparent) 0%,
+			color-mix(in srgb, var(--void-git-deleted) 10%, transparent) 100%
+		);
+	border-top: 1px solid color-mix(in srgb, var(--void-git-deleted) 18%, transparent);
+	border-bottom: 1px solid color-mix(in srgb, var(--void-git-deleted) 14%, transparent);
 }
 
 .ref-agent-file-preview-hunk-segment-mark {
@@ -9444,11 +9457,11 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 }
 
 .ref-agent-file-preview-hunk-segment--add .ref-agent-file-preview-hunk-segment-mark {
-	color: #4ade80;
+	color: var(--void-git-added);
 }
 
 .ref-agent-file-preview-hunk-segment--del .ref-agent-file-preview-hunk-segment-mark {
-	color: #f87171;
+	color: var(--void-git-deleted);
 }
 
 .ref-agent-file-preview-row {
@@ -9464,15 +9477,23 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 }
 
 .ref-agent-file-preview-row--add {
-	border-left-color: color-mix(in srgb, #22c55e 82%, transparent);
+	border-left-color: color-mix(in srgb, var(--void-git-added) 82%, transparent);
 	background:
-		linear-gradient(90deg, color-mix(in srgb, #22c55e 16%, transparent) 0%, color-mix(in srgb, #22c55e 8%, transparent) 100%);
+		linear-gradient(
+			90deg,
+			color-mix(in srgb, var(--void-git-added) 16%, transparent) 0%,
+			color-mix(in srgb, var(--void-git-added) 8%, transparent) 100%
+		);
 }
 
 .ref-agent-file-preview-row--del {
-	border-left-color: color-mix(in srgb, #ef4444 82%, transparent);
+	border-left-color: color-mix(in srgb, var(--void-git-deleted) 82%, transparent);
 	background:
-		linear-gradient(90deg, color-mix(in srgb, #ef4444 15%, transparent) 0%, color-mix(in srgb, #ef4444 7%, transparent) 100%);
+		linear-gradient(
+			90deg,
+			color-mix(in srgb, var(--void-git-deleted) 15%, transparent) 0%,
+			color-mix(in srgb, var(--void-git-deleted) 7%, transparent) 100%
+		);
 }
 
 .ref-agent-file-preview-row.is-target {
@@ -9521,11 +9542,11 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 }
 
 .ref-agent-file-preview-row--add .ref-agent-file-preview-sign {
-	color: #4ade80;
+	color: var(--void-git-added);
 }
 
 .ref-agent-file-preview-row--del .ref-agent-file-preview-sign {
-	color: #f87171;
+	color: var(--void-git-deleted);
 }
 
 .ref-agent-file-preview-line {
@@ -9545,7 +9566,7 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 }
 
 .ref-agent-file-preview-row--del .ref-agent-file-preview-line {
-	color: color-mix(in srgb, var(--void-fg-1) 76%, #fca5a5 24%);
+	color: color-mix(in srgb, var(--void-fg-1) 74%, var(--void-git-deleted) 26%);
 	opacity: 0.9;
 }
 
@@ -9558,12 +9579,12 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 }
 
 .ref-agent-file-preview-token--add {
-	background: color-mix(in srgb, #22c55e 22%, transparent);
+	background: color-mix(in srgb, var(--void-git-added) 22%, transparent);
 	border-radius: 3px;
 }
 
 .ref-agent-file-preview-token--del {
-	background: color-mix(in srgb, #ef4444 24%, transparent);
+	background: color-mix(in srgb, var(--void-git-deleted) 24%, transparent);
 	border-radius: 3px;
 }
 
@@ -10683,18 +10704,18 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 }
 
 .ref-git-diff-line.is-add {
-	background: rgba(55, 120, 75, 0.28);
-	color: #b9f6c8;
+	background: color-mix(in srgb, var(--void-git-added) 14%, transparent);
+	color: color-mix(in srgb, var(--void-git-added) 68%, var(--void-fg-0) 32%);
 }
 
 .ref-git-diff-line.is-del {
-	background: rgba(120, 45, 45, 0.22);
-	color: #f5b8b8;
+	background: color-mix(in srgb, var(--void-git-deleted) 12%, transparent);
+	color: color-mix(in srgb, var(--void-git-deleted) 68%, var(--void-fg-0) 32%);
 }
 
 .ref-git-diff-line.is-hunk {
-	color: var(--void-ring);
-	background: rgba(129, 140, 248, 0.08);
+	color: color-mix(in srgb, var(--void-accent-assist) 76%, var(--void-fg-0) 24%);
+	background: color-mix(in srgb, var(--void-accent-assist) 10%, transparent);
 }
 
 .ref-git-diff-line.is-meta {
@@ -16834,11 +16855,11 @@ select.ref-settings-native-select:focus {
 }
 
 .ref-edit-card-preview-line--add {
-	background: color-mix(in srgb, #22c55e 10%, transparent);
+	background: color-mix(in srgb, var(--void-git-added) 10%, transparent);
 }
 
 .ref-edit-card-preview-line--del {
-	background: color-mix(in srgb, #ef4444 9%, transparent);
+	background: color-mix(in srgb, var(--void-git-deleted) 9%, transparent);
 }
 
 .ref-edit-card-preview-sign {
@@ -16849,11 +16870,11 @@ select.ref-settings-native-select:focus {
 }
 
 .ref-edit-card-preview-line--add .ref-edit-card-preview-sign {
-	color: #22c55e;
+	color: var(--void-git-added);
 }
 
 .ref-edit-card-preview-line--del .ref-edit-card-preview-sign {
-	color: #ef4444;
+	color: var(--void-git-deleted);
 }
 
 .ref-edit-card-preview-code {

--- a/src/index.css
+++ b/src/index.css
@@ -1463,7 +1463,7 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 	position: relative;
 	z-index: 2;
 	cursor: col-resize;
-	background: transparent;
+	background: color-mix(in srgb, var(--void-bg-1) 90%, transparent);
 	touch-action: none;
 	min-height: 0;
 }
@@ -1494,18 +1494,14 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 	display: flex;
 	flex-direction: column;
 	background: linear-gradient(180deg, rgba(18, 18, 22, 0.98) 0%, var(--void-bg-1) 32%, var(--void-bg-1) 100%);
-	border-right: 1px solid var(--void-border-soft);
 	min-width: 0;
 	min-height: 0;
-	box-shadow: inset -1px 0 0 rgba(255, 255, 255, 0.02);
 }
 
 .ref-left.is-collapsed {
 	opacity: 0;
 	pointer-events: none;
 	overflow: hidden;
-	border-right-color: transparent;
-	box-shadow: none;
 }
 
 .ref-left-scroll {
@@ -3406,13 +3402,7 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 	/* 勿在气泡下垫�?padding：背景为 void-bg-0，比气泡更暗，会像气泡底部一条黑�?*/
 	padding-bottom: 0;
 	margin-bottom: 0;
-	/* �?.ref-msg-user 同圆角：否则父级方角会在气泡左下/右下露出更深的楔�?*/
-	border-radius: 18px;
-	overflow: hidden;
-	/*background: var(--void-bg-0);*/
-	box-shadow:
-		0 1px 0 rgba(255, 255, 255, 0.04),
-		0 18px 32px -12px rgba(0, 0, 0, 0.65);
+	overflow: visible;
 }
 
 /* ?????????????? */
@@ -3447,8 +3437,7 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 	word-break: break-word;
 	cursor: pointer;
 	font-family: inherit;
-	transition: background 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease;
-	box-shadow: 0 1px 0 rgba(255, 255, 255, 0.04);
+	transition: background 0.12s ease, border-color 0.12s ease;
 	appearance: none;
 	-webkit-appearance: none;
 	max-height: var(--ref-user-bubble-max-h);
@@ -7500,10 +7489,8 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 	display: flex;
 	flex-direction: column;
 	background: linear-gradient(180deg, rgba(20, 20, 24, 0.98) 0%, var(--void-bg-1) 28%, var(--void-bg-1) 100%);
-	border-left: 1px solid var(--void-border-soft);
 	min-width: 0;
 	min-height: 0;
-	box-shadow: inset 1px 0 0 rgba(255, 255, 255, 0.02);
 }
 
 .ref-right-icon-tabs {
@@ -15936,55 +15923,15 @@ select.ref-settings-native-select:focus {
 }
 
 .ref-agent-todo-panel {
-	margin-top: 0;
-	margin-bottom: 4px;
-	border: 1px solid var(--void-border-soft);
-	border-top: 1px solid color-mix(in srgb, var(--void-border-soft) 60%, transparent);
-	border-top-left-radius: 0;
-	border-top-right-radius: 0;
-	border-bottom-left-radius: 18px;
-	border-bottom-right-radius: 18px;
-	background: var(--void-bg-3);
+	margin-top: 12px;
+	margin-bottom: 0;
+	border: 1px solid color-mix(in srgb, var(--void-border-soft) 82%, transparent);
+	border-radius: 14px;
+	background: color-mix(in srgb, var(--void-bg-2) 72%, var(--void-bg-3));
 	overflow: hidden;
 	max-width: 100%;
 	box-sizing: border-box;
-}
-
-/* ── Seamless bubble + TODO panel ── */
-
-/* Unified container: border + radius + clip so bubble & todo look like one card */
-.ref-msg-slot--user.has-todo-panel {
-	border: 1px solid var(--void-border-soft);
-	border-radius: 18px;
-	overflow: hidden;
-	background: var(--void-bg-3);
-	transition: border-color 0.12s ease;
-}
-
-/* Bubble inside unified container: strip own border / radius / shadow */
-.ref-msg-slot--user.has-todo-panel .ref-msg-user {
-	border: none;
-	border-radius: 0;
-	box-shadow: none;
-}
-
-/* TODO panel inside unified container: strip own border / radius / margin */
-.ref-msg-slot--user.has-todo-panel .ref-agent-todo-panel {
-	border: none;
-	border-top: 1px solid color-mix(in srgb, var(--void-border-soft) 30%, transparent);
-	border-radius: 0;
-	margin-bottom: 0;
-}
-
-/* Hover on bubble still lifts the whole card border */
-.ref-msg-slot--user.has-todo-panel:has(.ref-msg-user:hover:not(:disabled)) {
-	border-color: var(--void-border);
-}
-
-/* Sticky wrap: keep its existing radius so the outer shadow rounds correctly */
-.ref-msg-sticky-user-wrap:has(.has-todo-panel) {
-	border-bottom-left-radius: 18px;
-	border-bottom-right-radius: 18px;
+	box-shadow: 0 16px 32px -28px rgba(0, 0, 0, 0.7);
 }
 
 .ref-plan-review-todos-head {
@@ -16008,8 +15955,13 @@ select.ref-settings-native-select:focus {
 }
 
 /* Agent todo panel overrides for todo items */
+.ref-agent-todo-panel .ref-plan-review-todos-head {
+	padding: 9px 12px;
+}
+
 .ref-agent-todo-panel .ref-plan-todo {
 	border-top-color: color-mix(in srgb, var(--void-border-soft) 60%, transparent);
+	padding: 8px 12px;
 }
 
 .ref-agent-todo-panel .ref-plan-todo:hover {
@@ -16499,6 +16451,11 @@ select.ref-settings-native-select:focus {
 :root[data-color-scheme='light'] .ref-plan-review-todos {
 	border-color: rgba(148, 163, 184, 0.26);
 	background: rgba(255, 255, 255, 0.72);
+}
+
+:root[data-color-scheme='light'] .ref-msg-user,
+:root[data-color-scheme='light'] .ref-agent-todo-panel {
+	box-shadow: none;
 }
 
 :root[data-color-scheme='light'] .ref-plan-review-todos-head {

--- a/src/initialWindowTheme.test.ts
+++ b/src/initialWindowTheme.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import {
+	INITIAL_WINDOW_THEME_STORAGE_KEY,
+	readInitialWindowThemeSnapshot,
+	persistInitialWindowThemeSnapshot,
+	serializeInitialWindowThemePayload,
+	INITIAL_WINDOW_THEME_QUERY_PARAM,
+} from './initialWindowTheme';
+
+describe('initialWindowTheme', () => {
+	it('hydrates appearance settings from the serialized query payload', () => {
+		const payload = serializeInitialWindowThemePayload({
+			colorMode: 'light',
+			scheme: 'light',
+			ui: {
+				accentColor: '#2255AA',
+				backgroundColor: '#F6F7FB',
+				foregroundColor: '#162033',
+				uiFontPreset: 'segoe',
+			},
+		});
+		const snapshot = readInitialWindowThemeSnapshot(
+			`?${INITIAL_WINDOW_THEME_QUERY_PARAM}=${encodeURIComponent(payload)}`,
+			{ prefersDark: true }
+		);
+
+		expect(snapshot).not.toBeNull();
+		expect(snapshot?.colorMode).toBe('light');
+		expect(snapshot?.effectiveScheme).toBe('light');
+		expect(snapshot?.appearanceSettings.backgroundColor).toBe('#F6F7FB');
+		expect(snapshot?.appearanceSettings.foregroundColor).toBe('#162033');
+		expect(snapshot?.appearanceSettings.uiFontPreset).toBe('segoe');
+	});
+
+	it('falls back to prefersDark when the serialized payload omits scheme', () => {
+		const payload = serializeInitialWindowThemePayload({
+			colorMode: 'system',
+			ui: {
+				backgroundColor: '#131A23',
+			},
+		});
+		const snapshot = readInitialWindowThemeSnapshot(
+			`?${INITIAL_WINDOW_THEME_QUERY_PARAM}=${encodeURIComponent(payload)}`,
+			{ prefersDark: true }
+		);
+
+		expect(snapshot).not.toBeNull();
+		expect(snapshot?.effectiveScheme).toBe('dark');
+		expect(snapshot?.appearanceSettings.backgroundColor).toBe('#131A23');
+	});
+
+	it('returns null for malformed payloads', () => {
+		expect(
+			readInitialWindowThemeSnapshot(`?${INITIAL_WINDOW_THEME_QUERY_PARAM}=%7Bnot-json%7D`, {
+				prefersDark: false,
+			})
+		).toBeNull();
+	});
+
+	it('reads from storage when the query payload is absent', () => {
+		const backing = new Map<string, string>();
+		backing.set(
+			INITIAL_WINDOW_THEME_STORAGE_KEY,
+			serializeInitialWindowThemePayload({
+				colorMode: 'dark',
+				scheme: 'dark',
+				ui: {
+					backgroundColor: '#101820',
+					foregroundColor: '#EEF3F8',
+				},
+			})
+		);
+		const storage = {
+			getItem(key: string) {
+				return backing.get(key) ?? null;
+			},
+			setItem(key: string, value: string) {
+				backing.set(key, value);
+			},
+		};
+
+		const snapshot = readInitialWindowThemeSnapshot('', {
+			prefersDark: false,
+			storage,
+		});
+
+		expect(snapshot).not.toBeNull();
+		expect(snapshot?.effectiveScheme).toBe('dark');
+		expect(snapshot?.appearanceSettings.backgroundColor).toBe('#101820');
+	});
+
+	it('persists snapshots in the shared storage format', () => {
+		const backing = new Map<string, string>();
+		const storage = {
+			getItem(key: string) {
+				return backing.get(key) ?? null;
+			},
+			setItem(key: string, value: string) {
+				backing.set(key, value);
+			},
+		};
+
+		persistInitialWindowThemeSnapshot(
+			{
+				colorMode: 'light',
+				effectiveScheme: 'light',
+				appearanceSettings: {
+					accentColor: '#3366AA',
+					backgroundColor: '#F4F6FA',
+					foregroundColor: '#182030',
+					themePresetId: 'custom',
+					uiFontPreset: 'inter',
+					codeFontPreset: 'jetbrains',
+					translucentSidebar: false,
+					contrast: 42,
+					usePointerCursors: true,
+					uiFontSize: 14,
+					codeFontSize: 13,
+				},
+			},
+			storage
+		);
+
+		const roundTrip = readInitialWindowThemeSnapshot('', {
+			prefersDark: true,
+			storage,
+		});
+		expect(roundTrip).not.toBeNull();
+		expect(roundTrip?.colorMode).toBe('light');
+		expect(roundTrip?.appearanceSettings.codeFontPreset).toBe('jetbrains');
+	});
+});

--- a/src/initialWindowTheme.ts
+++ b/src/initialWindowTheme.ts
@@ -1,0 +1,110 @@
+import {
+	normalizeAppearanceSettings,
+	type AppAppearanceSettings,
+} from './appearanceSettings';
+import {
+	normalizeColorMode,
+	readPrefersDark,
+	resolveEffectiveScheme,
+	type AppColorMode,
+	type EffectiveColorScheme,
+} from './colorMode';
+
+export const INITIAL_WINDOW_THEME_QUERY_PARAM = 'initialWindowTheme';
+export const INITIAL_WINDOW_THEME_STORAGE_KEY = 'async:initial-window-theme-v1';
+
+type InitialWindowThemePayload = {
+	colorMode?: unknown;
+	scheme?: unknown;
+	ui?: Partial<Record<string, unknown>> | null;
+};
+
+export type InitialWindowThemeSnapshot = {
+	colorMode: AppColorMode;
+	effectiveScheme: EffectiveColorScheme;
+	appearanceSettings: AppAppearanceSettings;
+};
+
+type StorageLike = Pick<Storage, 'getItem' | 'setItem'>;
+
+export function serializeInitialWindowThemePayload(payload: InitialWindowThemePayload): string {
+	return JSON.stringify({
+		colorMode: payload.colorMode,
+		scheme: payload.scheme,
+		ui: payload.ui ?? null,
+	});
+}
+
+function parseInitialWindowThemePayload(raw: string | null): InitialWindowThemePayload | null {
+	if (!raw) {
+		return null;
+	}
+	try {
+		const parsed = JSON.parse(raw) as InitialWindowThemePayload;
+		return parsed && typeof parsed === 'object' ? parsed : null;
+	} catch {
+		return null;
+	}
+}
+
+function readInitialWindowThemePayloadFromStorage(storage: StorageLike | undefined): InitialWindowThemePayload | null {
+	if (!storage) {
+		return null;
+	}
+	try {
+		return parseInitialWindowThemePayload(storage.getItem(INITIAL_WINDOW_THEME_STORAGE_KEY));
+	} catch {
+		return null;
+	}
+}
+
+export function readInitialWindowThemeSnapshot(
+	search: string,
+	options?: { prefersDark?: boolean; storage?: StorageLike }
+): InitialWindowThemeSnapshot | null {
+	try {
+		const params = new URLSearchParams(search);
+		const payload =
+			parseInitialWindowThemePayload(params.get(INITIAL_WINDOW_THEME_QUERY_PARAM)) ??
+			readInitialWindowThemePayloadFromStorage(
+				options?.storage ?? (typeof window !== 'undefined' ? window.localStorage : undefined)
+			);
+		if (!payload) {
+			return null;
+		}
+		const colorMode = normalizeColorMode(payload.colorMode);
+		const prefersDark = options?.prefersDark ?? readPrefersDark();
+		const effectiveScheme =
+			payload.scheme === 'light' || payload.scheme === 'dark'
+				? payload.scheme
+				: resolveEffectiveScheme(colorMode, prefersDark);
+		return {
+			colorMode,
+			effectiveScheme,
+			appearanceSettings: normalizeAppearanceSettings(payload.ui, effectiveScheme),
+		};
+	} catch {
+		return null;
+	}
+}
+
+export function persistInitialWindowThemeSnapshot(
+	snapshot: InitialWindowThemeSnapshot,
+	storage: StorageLike | undefined = typeof window !== 'undefined' ? window.localStorage : undefined
+): void {
+	if (!storage) {
+		return;
+	}
+	try {
+		storage.setItem(
+			INITIAL_WINDOW_THEME_STORAGE_KEY,
+			serializeInitialWindowThemePayload({
+				colorMode: snapshot.colorMode,
+				scheme: snapshot.effectiveScheme,
+				ui: snapshot.appearanceSettings,
+			})
+		);
+	} catch {
+		/* ignore */
+	}
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,9 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
+import { applyAppearanceSettingsToDom } from './appearanceSettings';
 import { APP_UI_STYLE, readPrefersDark, readStoredColorMode, resolveEffectiveScheme } from './colorMode';
+import { readInitialWindowThemeSnapshot } from './initialWindowTheme';
 import { I18nProvider } from './i18n';
 import '@fontsource/inter/400.css';
 import '@fontsource/inter/500.css';
@@ -15,9 +17,16 @@ import './styles/motion.css';
 import './styles/mac-codex.css';
 import './styles/terminal-window.css';
 
-const initialScheme = resolveEffectiveScheme(readStoredColorMode(), readPrefersDark());
+const initialThemeSnapshot = readInitialWindowThemeSnapshot(window.location.search, {
+	prefersDark: readPrefersDark(),
+});
+const initialScheme =
+	initialThemeSnapshot?.effectiveScheme ?? resolveEffectiveScheme(readStoredColorMode(), readPrefersDark());
 document.documentElement.setAttribute('data-ui-style', APP_UI_STYLE);
 document.documentElement.setAttribute('data-color-scheme', initialScheme);
+if (initialThemeSnapshot) {
+	applyAppearanceSettingsToDom(initialThemeSnapshot.appearanceSettings, initialThemeSnapshot.effectiveScheme);
+}
 const userAgentData = (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData;
 const platformRaw = userAgentData?.platform ?? navigator.platform ?? navigator.userAgent;
 const platform = /win/i.test(platformRaw) ? 'win32' : /mac/i.test(platformRaw) ? 'darwin' : 'linux';
@@ -70,6 +79,7 @@ createRoot(document.getElementById('root')!).render(
 			<App
 				appSurface={appSurface}
 				browserWindow={browserWindow}
+				initialThemeSnapshot={initialThemeSnapshot}
 				terminalWindow={terminalWindow}
 				terminalStartPage={terminalStartPage}
 			/>

--- a/src/styles/mac-codex.css
+++ b/src/styles/mac-codex.css
@@ -73,7 +73,6 @@
 :root[data-ui-style='mac-codex'] .ref-left {
 	background:
 		linear-gradient(180deg, color-mix(in srgb, var(--surface-panel-bg-strong) 94%, transparent) 0%, var(--surface-panel-bg) 100%);
-	border-right: 1px solid var(--surface-glass-stroke);
 }
 
 :root[data-ui-style='mac-codex'] .ref-center {
@@ -85,7 +84,10 @@
 :root[data-ui-style='mac-codex'] .ref-right {
 	background:
 		linear-gradient(180deg, color-mix(in srgb, var(--surface-panel-bg-strong) 92%, transparent) 0%, var(--surface-panel-bg-soft) 100%);
-	border-left: 1px solid var(--surface-glass-stroke);
+}
+
+:root[data-ui-style='mac-codex'] .ref-resize-handle {
+	background: color-mix(in srgb, var(--surface-panel-bg) 88%, transparent);
 }
 
 :root[data-ui-style='mac-codex'] .ref-resize-handle::after {
@@ -828,7 +830,6 @@
 	background: var(--surface-bubble-user);
 	border-color: color-mix(in srgb, var(--color-accent) 16%, var(--surface-glass-stroke));
 	border-radius: 22px;
-	box-shadow: var(--shadow-floating), var(--shadow-pressed);
 }
 
 :root[data-ui-style='mac-codex'] .ref-msg-user:hover:not(:disabled) {
@@ -865,11 +866,17 @@
 
 :root[data-ui-style='mac-codex'] .ref-plan-review-md,
 :root[data-ui-style='mac-codex'] .ref-plan-review-todos,
+:root[data-ui-style='mac-codex'] .ref-agent-todo-panel,
 :root[data-ui-style='mac-codex'] .ref-agent-stream-tool-pre,
 :root[data-ui-style='mac-codex'] .ref-tool-approval-inline-body,
 :root[data-ui-style='mac-codex'] .ref-mistake-limit-textarea {
 	background: var(--surface-code-bg);
 	border-color: var(--surface-glass-stroke);
+}
+
+:root[data-ui-style='mac-codex'] .ref-agent-todo-panel {
+	border-radius: 18px;
+	box-shadow: var(--shadow-floating), var(--shadow-pressed);
 }
 
 :root[data-ui-style='mac-codex'] .ref-plan-review-todos-head,
@@ -1591,11 +1598,15 @@
 :root[data-ui-style='mac-codex'][data-color-scheme='dark'] .ref-msg-user {
 	background: var(--surface-bubble-user);
 	border-color: color-mix(in srgb, var(--void-fg-0) 6%, transparent);
-	box-shadow: 0 10px 22px color-mix(in srgb, black 14%, transparent);
 }
 
 :root[data-ui-style='mac-codex'][data-color-scheme='dark'] .ref-msg-user:hover:not(:disabled) {
 	background: linear-gradient(180deg, color-mix(in srgb, var(--void-bg-3) 98%, transparent) 0%, color-mix(in srgb, var(--void-bg-3) 98%, transparent) 100%);
+}
+
+:root[data-ui-style='mac-codex'][data-color-scheme='light'] .ref-msg-user,
+:root[data-ui-style='mac-codex'][data-color-scheme='light'] .ref-agent-todo-panel {
+	box-shadow: none;
 }
 
 :root[data-ui-style='mac-codex'][data-color-scheme='dark'] .ref-editor-welcome-inner {
@@ -2848,13 +2859,12 @@
 }
 
 :root[data-ui-style='mac-codex'] .ref-body--editor-shell .ref-resize-handle {
-	background: transparent;
+	background: color-mix(in srgb, var(--surface-panel-bg) 88%, transparent);
 }
 
 :root[data-ui-style='mac-codex'] .ref-body--editor-shell .ref-resize-handle::after {
 	width: 1px;
-	background:
-		linear-gradient(180deg, transparent 0%, color-mix(in srgb, var(--surface-glass-stroke) 90%, transparent) 10%, color-mix(in srgb, var(--surface-glass-stroke) 90%, transparent) 90%, transparent 100%);
+	background: color-mix(in srgb, var(--surface-glass-stroke) 90%, transparent);
 	opacity: 0.94;
 }
 
@@ -3048,8 +3058,7 @@
 }
 
 :root[data-ui-style='mac-codex'][data-color-scheme='dark'] .ref-body--editor-shell .ref-resize-handle::after {
-	background:
-		linear-gradient(180deg, transparent 0%, color-mix(in srgb, var(--void-fg-0) 8%, transparent) 10%, color-mix(in srgb, var(--void-fg-0) 8%, transparent) 90%, transparent 100%);
+	background: color-mix(in srgb, var(--void-fg-0) 8%, transparent);
 }
 
 :root[data-ui-style='mac-codex'][data-color-scheme='dark'] .ref-left--editor-embedded .ref-project-block--editor::before {
@@ -3263,12 +3272,11 @@
 }
 
 :root[data-ui-style='mac-codex'] .ref-body--agent-shell .ref-resize-handle {
-	background: transparent;
+	background: color-mix(in srgb, var(--surface-panel-bg) 88%, transparent);
 }
 
 :root[data-ui-style='mac-codex'] .ref-body--agent-shell .ref-resize-handle::after {
-	background:
-		linear-gradient(180deg, transparent 0%, color-mix(in srgb, var(--surface-glass-stroke) 90%, transparent) 14%, color-mix(in srgb, var(--surface-glass-stroke) 90%, transparent) 86%, transparent 100%);
+	background: color-mix(in srgb, var(--surface-glass-stroke) 90%, transparent);
 }
 
 :root[data-ui-style='mac-codex'] .ref-body--agent-shell .ref-resize-handle:hover,
@@ -3750,8 +3758,7 @@
 }
 
 :root[data-ui-style='mac-codex'][data-color-scheme='dark'] .ref-body--agent-shell .ref-resize-handle::after {
-	background:
-		linear-gradient(180deg, transparent 0%, color-mix(in srgb, var(--void-fg-0) 8%, transparent) 12%, color-mix(in srgb, var(--void-fg-0) 8%, transparent) 88%, transparent 100%);
+	background: color-mix(in srgb, var(--void-fg-0) 8%, transparent);
 }
 
 :root[data-ui-style='mac-codex'][data-color-scheme='dark'] .ref-left--agent-layout .ref-agent-empty-workspace,

--- a/src/useDomColorScheme.ts
+++ b/src/useDomColorScheme.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import { readDomColorScheme, type EffectiveColorScheme } from './colorMode';
+
+export function useDomColorScheme(): EffectiveColorScheme {
+	const [scheme, setScheme] = useState<EffectiveColorScheme>(() => readDomColorScheme());
+
+	useEffect(() => {
+		if (typeof document === 'undefined') {
+			return;
+		}
+		const sync = () => {
+			setScheme((current) => {
+				const next = readDomColorScheme();
+				return current === next ? current : next;
+			});
+		};
+		sync();
+		const observer = new MutationObserver(sync);
+		observer.observe(document.documentElement, {
+			attributes: true,
+			attributeFilter: ['data-color-scheme'],
+		});
+		return () => observer.disconnect();
+	}, []);
+
+	return scheme;
+}


### PR DESCRIPTION
## Summary

This branch improves the agent tool execution pipeline, terminal integration, and visual consistency across boot, terminal windows, and chat UI.

## Changes

### Agent / tool execution
- Add configurable **Bash 	imeout_ms** for shell tool runs.
- Extend **terminal session IPC/service** so commands can run in the background or with **preserved sessions**, with expanded test coverage in 	oolExecutor.test.ts.

### Chat & preview UI
- **Agent chat**: render a **live todo panel** on the assistant message bubble; simplify chrome and shadows.
- **Shiki / file preview**: theme-aware highlighting and **diff styling**, with related tests.

### Appearance & startup
- **Boot splash** (index.html) and **terminal/app windows** follow **saved appearance** settings via new initialWindowTheme helpers and colorMode / DOM color-scheme wiring.
- Refresh global styles (index.css, mac-codex.css) and small related component tweaks (App.tsx, main.tsx, etc.).

## Testing
- Unit tests updated/added for tool executor, Shiki preview, color mode, and initial window theme.

## Stats
~21 files touched; net additions across main process, renderer, and styles.