### PR TITLE
feat: integrate OMA task queue, scheduler, and goal detector into team orchestrator

### DIFF
--- a/main-src/agent/simpleGoalDetector.test.ts
+++ b/main-src/agent/simpleGoalDetector.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { isSimpleGoal } from './simpleGoalDetector.js';
+
+describe('isSimpleGoal', () => {
+	it('returns true for short single-action questions', () => {
+		expect(isSimpleGoal('What is TypeScript?')).toBe(true);
+		expect(isSimpleGoal('Explain this function')).toBe(true);
+		expect(isSimpleGoal('Refactor this file')).toBe(true);
+		expect(isSimpleGoal('Write a hello world in Python')).toBe(true);
+	});
+
+	it('returns false for sequencing language', () => {
+		expect(isSimpleGoal('First build the API, then write tests')).toBe(false);
+		expect(isSimpleGoal('Step 1: design, step 2: implement')).toBe(false);
+	});
+
+	it('returns false for coordination language', () => {
+		expect(isSimpleGoal('Collaborate with the backend team on this')).toBe(false);
+		expect(isSimpleGoal('Coordinate the team to review each change')).toBe(false);
+		expect(isSimpleGoal('Review each other before merging')).toBe(false);
+		expect(isSimpleGoal('Work together to ship this feature')).toBe(false);
+	});
+
+	it('returns false for parallel execution language', () => {
+		expect(isSimpleGoal('Build the frontend and backend in parallel')).toBe(false);
+		expect(isSimpleGoal('Run tests concurrently')).toBe(false);
+		expect(isSimpleGoal('Do these at the same time')).toBe(false);
+	});
+
+	it('returns false for multiple deliverables', () => {
+		expect(isSimpleGoal('Build the API and then deploy it')).toBe(false);
+		expect(isSimpleGoal('Create the design and implement the page')).toBe(false);
+		expect(isSimpleGoal('Write docs and then build the landing page')).toBe(false);
+	});
+
+	it('returns false for long goals', () => {
+		expect(isSimpleGoal('a'.repeat(201))).toBe(false);
+	});
+
+	it('returns true for descriptive uses of coordination words', () => {
+		// Descriptive, not imperative — should remain simple
+		expect(isSimpleGoal('How does microservice collaboration work?')).toBe(true);
+		expect(isSimpleGoal('Explain what team coordination means')).toBe(true);
+	});
+
+	it('returns false for numbered lists', () => {
+		expect(isSimpleGoal('1. Design the schema\n2. Build the API')).toBe(false);
+		expect(isSimpleGoal('2) Implement authentication')).toBe(false);
+	});
+
+	it('handles CJK text correctly', () => {
+		expect(isSimpleGoal('解释一下这段代码')).toBe(true);
+		expect(isSimpleGoal('先写接口，再写测试')).toBe(false);
+		expect(isSimpleGoal('大家一起协作完成这个功能')).toBe(false);
+	});
+});

--- a/main-src/agent/simpleGoalDetector.ts
+++ b/main-src/agent/simpleGoalDetector.ts
@@ -1,0 +1,57 @@
+/**
+ * 简单目标检测 —— 从 open-multi-agent 移植。
+ *
+ * 当用户请求明显是单轮、单动作、不需要多专家协作时，
+ * 直接让 Team Lead 快速回答，跳过完整的 Planning LLM Call。
+ */
+
+/**
+ * 指示需要多 Agent 协调的复杂度信号正则列表。
+ */
+const COMPLEXITY_PATTERNS: RegExp[] = [
+	// 显式顺序
+	/\bfirst\b.{3,60}\bthen\b/i,
+	/\bstep\s*\d/i,
+	/\bphase\s*\d/i,
+	/\bstage\s*\d/i,
+	/^\s*\d+[\.\)]/m,
+	// CJK 顺序
+	/先.{1,30}再/,
+	/第[一二三四五六七八九十\d]步/,
+
+	// 协调语言（必须是祈使指令）
+	/\bcollaborat(?:e|ing)\b\s+(?:with|on|to)\b/i,
+	/\bcoordinat(?:e|ing)\b\s+(?:with|on|across|between|the\s+(?:team|agents?|workers?|effort|work))\b/i,
+	/\breview\s+each\s+other/i,
+	/\bwork\s+together\b/i,
+	// CJK 协调
+	/一起.{0,10}(?:协作|合作|完成|做)/,
+	/协作.{0,10}(?:完成|做)/,
+
+	// 并行执行
+	/\bin\s+parallel\b/i,
+	/\bconcurrently\b/i,
+	/\bat\s+the\s+same\s+time\b/i,
+	// CJK 并行
+	/同时.{0,10}(?:做|进行|执行|完成)/,
+	/并行.{0,10}(?:做|进行|执行|完成)/,
+
+	// 多个交付物连词
+	/\b(?:build|create|implement|design|write|develop)\b.{5,80}\b(?:and|then)\b.{5,80}\b(?:build|create|implement|design|write|develop|test|review|deploy)\b/i,
+	// 更宽松的多个动作（允许短间隔如 "design and implement"）
+	/\b(?:build|create|implement|design|write|develop)\b.{0,30}\b(?:and|then)\b.{0,30}\b(?:build|create|implement|design|write|develop|test|review|deploy)\b/i,
+];
+
+const SIMPLE_GOAL_MAX_LENGTH = 200;
+
+/**
+ * 判断目标是否简单到可以跳过 Coordinator 分解。
+ *
+ * 简单目标需同时满足：
+ * 1. 长度 ≤ 200 字符
+ * 2. 不匹配任何复杂度模式
+ */
+export function isSimpleGoal(goal: string): boolean {
+	if (goal.length > SIMPLE_GOAL_MAX_LENGTH) return false;
+	return !COMPLEXITY_PATTERNS.some((re) => re.test(goal));
+}

--- a/main-src/agent/teamOrchestrator.test.ts
+++ b/main-src/agent/teamOrchestrator.test.ts
@@ -762,6 +762,7 @@ describe('runTeamSession clarification gates', () => {
 				reason: 'The planned foo service does not exist in the repository.',
 			})
 		);
+
 		expect(doneCalls).toHaveLength(1);
 		expect(doneCalls[0]?.text).toContain('## Task Status');
 		expect(doneCalls[0]?.text).toContain('Inspect the renderer workflow that actually owns this behavior');

--- a/main-src/agent/teamOrchestrator.ts
+++ b/main-src/agent/teamOrchestrator.ts
@@ -47,6 +47,9 @@ import {
 	type TeamPeerReply,
 	setTeamPeerReplyRuntime,
 } from './teamReplyToPeerTool.js';
+import { isSimpleGoal } from './simpleGoalDetector.js';
+import { rankReadyTasks, type TaskSchedulingStrategy } from './teamTaskScheduler.js';
+import { TeamTaskQueue } from './teamTaskQueue.js';
 
 type TeamPhase =
 	| 'researching'
@@ -2440,6 +2443,156 @@ function buildTeamDeliveryText(params: {
 	return sections.join('\n');
 }
 
+// ── Queue sync helper ────────────────────────────────────────────────────
+
+function syncQueueToPending(
+	queue: TeamTaskQueue,
+	pending: TeamTask[],
+	completed: TeamTask[],
+	completedIds: Set<string>,
+	completedTasksById: Map<string, TeamTask>,
+): void {
+	// Sync newly-completed tasks.
+	for (const task of queue.getByStatus('completed')) {
+		if (!completedTasksById.has(task.id)) {
+			completed.push(task);
+			completedTasksById.set(task.id, task);
+			completedIds.add(task.id);
+		}
+	}
+	// Sync newly-failed tasks (including cascaded failures).
+	for (const task of queue.getByStatus('failed')) {
+		if (!completedTasksById.has(task.id)) {
+			completed.push(task);
+			completedTasksById.set(task.id, task);
+		}
+	}
+	// Sync revision tasks (escalations awaiting replan).
+	for (const task of queue.getByStatus('revision')) {
+		if (!completedTasksById.has(task.id)) {
+			completed.push(task);
+			completedTasksById.set(task.id, task);
+		}
+	}
+	// Remove from pending any tasks that are no longer pending/blocked in the queue.
+	for (let i = pending.length - 1; i >= 0; i--) {
+		const qTask = queue.get(pending[i]!.id);
+		if (!qTask || (qTask.status !== 'pending' && qTask.status !== 'blocked')) {
+			pending.splice(i, 1);
+		}
+	}
+	// Add to pending any queue tasks that are pending/blocked but not yet in pending.
+	const pendingIds = new Set(pending.map((t) => t.id));
+	for (const task of queue.getPendingOrBlocked()) {
+		if (!pendingIds.has(task.id)) {
+			pending.push(task);
+		}
+	}
+}
+
+// ── Simple-goal short-circuit ────────────────────────────────────────────
+
+async function runTeamLeadQuickAnswer(params: {
+	settings: ShellSettings;
+	threadId: string;
+	teamLead: TeamExpertRuntimeProfile;
+	userRequest: string;
+	modelSelection: string;
+	resolvedModel: TeamOrchestratorInput['resolvedModel'];
+	signal: AbortSignal;
+	thinkingLevel?: TeamOrchestratorInput['thinkingLevel'];
+	workspaceRoot?: string | null;
+	workspaceLspManager?: WorkspaceLspManager | null;
+	hostWebContentsId?: number | null;
+	toolHooks?: ToolExecutionHooks;
+	emit: (evt: TeamEmit) => void;
+}): Promise<string> {
+	const {
+		settings, threadId, teamLead, userRequest, modelSelection, resolvedModel,
+		signal, thinkingLevel, workspaceRoot, workspaceLspManager, hostWebContentsId, toolHooks, emit,
+	} = params;
+
+	const quickRoleScope = {
+		teamTaskId: 'team-lead-quick',
+		teamExpertId: teamLead.id,
+		teamRoleKind: 'lead' as const,
+		teamExpertName: teamLead.name,
+		teamRoleType: teamLead.roleType,
+	};
+
+	const subMessages: ChatMessage[] = [
+		{ role: 'user', content: userRequest },
+	];
+
+	let finalText = '';
+
+	const options: AgentLoopOptions = {
+		modelSelection: teamLead.preferredModelId?.trim() || modelSelection,
+		requestModelId: resolvedModel.requestModelId,
+		paradigm: resolvedModel.paradigm,
+		requestApiKey: resolvedModel.apiKey,
+		requestBaseURL: resolvedModel.baseURL,
+		requestProxyUrl: resolvedModel.proxyUrl,
+		maxOutputTokens: resolvedModel.maxOutputTokens,
+		...(resolvedModel.contextWindowTokens != null
+			? { contextWindowTokens: resolvedModel.contextWindowTokens }
+			: {}),
+		temperatureMode: resolvedModel.temperatureMode,
+		...(resolvedModel.temperature != null ? { temperature: resolvedModel.temperature } : {}),
+		signal,
+		composerMode: 'agent',
+		agentSystemAppend: appendTeamLanguageRule(settings, teamLead.systemPrompt),
+		thinkingLevel,
+		workspaceRoot,
+		workspaceLspManager,
+		hostWebContentsId: hostWebContentsId ?? null,
+		threadId,
+		toolHooks,
+	};
+
+	const handlers: AgentLoopHandlers = {
+		onTextDelta: (text) => {
+			finalText += text;
+			emit({ threadId, type: 'delta', text, teamRoleScope: quickRoleScope });
+		},
+		onThinkingDelta: (text) => {
+			emit({ threadId, type: 'thinking_delta', text, teamRoleScope: quickRoleScope });
+		},
+		onToolCall: (name, args, toolCallId) => {
+			emit({
+				threadId,
+				type: 'tool_call',
+				name,
+				args: JSON.stringify(args),
+				toolCallId,
+				teamRoleScope: quickRoleScope,
+			});
+		},
+		onToolResult: (name, result, success, toolCallId) => {
+			emit({
+				threadId,
+				type: 'tool_result',
+				name,
+				result,
+				success,
+				toolCallId,
+				teamRoleScope: quickRoleScope,
+			});
+		},
+		onDone: (text, usage) => {
+			finalText = normalizeTeamAgentSummary(text, finalText);
+			emit({ threadId, type: 'done', text, usage, teamRoleScope: quickRoleScope });
+		},
+		onError: (message) => {
+			finalText = message;
+			emit({ threadId, type: 'error', message, teamRoleScope: quickRoleScope });
+		},
+	};
+
+	await runAgentLoop(settings, subMessages, options, handlers);
+	return finalText;
+}
+
 // ── Main orchestrator ────────────────────────────────────────────────────
 
 export async function runTeamSession(input: TeamOrchestratorInput): Promise<void> {
@@ -2479,6 +2632,41 @@ export async function runTeamSession(input: TeamOrchestratorInput): Promise<void
 		const hasCjkRequest = /[\u3400-\u9fff]/.test(effectiveUserText);
 		const teamDefaults = getTeamSourceDefaults(settings.team?.source);
 		let planningMessages = messages;
+
+		// ── Phase 0: Simple-goal short-circuit ───────────────────────
+		if (settings.team?.enableSimpleGoalShortCircuit && isSimpleGoal(effectiveUserText)) {
+			checkAbort();
+			emit({ threadId, type: 'team_phase', phase: 'delivering' });
+			try {
+				const quickAnswer = await runTeamLeadQuickAnswer({
+					settings,
+					threadId,
+					teamLead,
+					userRequest: effectiveUserText,
+					modelSelection,
+					resolvedModel,
+					signal,
+					thinkingLevel,
+					workspaceRoot,
+					workspaceLspManager,
+					hostWebContentsId,
+					toolHooks,
+					emit,
+				});
+				onDone(quickAnswer, undefined, {
+					phase: 'delivering',
+					tasks: [],
+					planSummary: quickAnswer,
+					leaderMessage: quickAnswer,
+					reviewSummary: '',
+					reviewVerdict: null,
+				});
+				return;
+			} catch (err) {
+				if (signal.aborted) throw err;
+				// Fall through to normal team flow if quick answer fails.
+			}
+		}
 
 		// ── Phase 1: Planning ────────────────────────────────────────
 		let plannedTasks: TeamTask[] = [];
@@ -2740,6 +2928,8 @@ export async function runTeamSession(input: TeamOrchestratorInput): Promise<void
 
 		checkAbort();
 		emit({ threadId, type: 'team_phase', phase: 'executing' });
+		const queue = new TeamTaskQueue();
+		queue.addBatch(plannedTasks);
 		let pending = [...plannedTasks];
 		const completed: TeamTask[] = [];
 		const completedIds = new Set<string>();
@@ -2848,18 +3038,27 @@ export async function runTeamSession(input: TeamOrchestratorInput): Promise<void
 		};
 
 		while (true) {
-			while (pending.length > 0) {
+			while (pending.length > 0 || queue.getPendingOrBlocked().length > 0) {
 				checkAbort();
+				syncQueueToPending(queue, pending, completed, completedIds, completedTasksById);
+
 				const ready = getReadyTasks(pending, completedIds);
 				if (ready.length === 0) {
-					for (const task of pending) {
-						completed.push({ ...task, status: 'failed', result: 'Stuck: unresolvable dependency.' });
+					if (activeTaskIds.size > 0) {
+						// Tasks still running; wait for next iteration.
+						break;
 					}
-					pending.length = 0;
+					// No ready tasks and nothing running: cascade fail remaining stuck tasks.
+					for (const task of pending) {
+						queue.fail(task.id, 'Stuck: unresolvable dependency.');
+					}
+					syncQueueToPending(queue, pending, completed, completedIds, completedTasksById);
 					break;
 				}
 
-				const batch = ready.slice(0, maxParallelExperts);
+				const strategy = (settings.team?.taskSchedulingStrategy as TaskSchedulingStrategy) ?? 'dependency-first';
+				const rankedReady = rankReadyTasks(ready, plannedTasks, specialists, activeTaskIds, strategy);
+				const batch = rankedReady.slice(0, maxParallelExperts);
 				for (const bt of batch) {
 					const idx = pending.indexOf(bt);
 					if (idx !== -1) pending.splice(idx, 1);
@@ -2929,17 +3128,13 @@ export async function runTeamSession(input: TeamOrchestratorInput): Promise<void
 
 				for (const item of settledItems) {
 					resolveOutstandingPeerRequestsForTask(item.task, item.result.text);
-					const finishedTask = {
-						...item.task,
-						status: (item.result.success ? 'completed' : 'failed') as TeamTaskStatus,
-						result: item.result.text,
-					};
-					completed.push(finishedTask);
-					completedTasksById.set(finishedTask.id, finishedTask);
 					if (item.result.success) {
-						completedIds.add(item.task.id);
+						queue.complete(item.task.id, item.result.text);
+					} else {
+						queue.fail(item.task.id, item.result.text);
 					}
 				}
+				syncQueueToPending(queue, pending, completed, completedIds, completedTasksById);
 
 				if (escalatedItems.length > 0) {
 					const primaryEscalation = escalatedItems[0]!;
@@ -2996,8 +3191,15 @@ export async function runTeamSession(input: TeamOrchestratorInput): Promise<void
 
 							const revisedPendingTasks = materializePlannedTasks(revisedPlan.tasks, specialists, replanCandidates);
 							const diff = applyPlanDiff(replanCandidates, revisedPendingTasks);
-							pending = [...diff.nextPendingTasks];
-							plannedTasks = [...completed, ...pending];
+							// Sync replan into queue.
+							for (const task of queue.list()) {
+								if (task.status !== 'completed' && task.status !== 'failed' && task.status !== 'revision') {
+									queue.remove(task.id);
+								}
+							}
+							queue.addBatch(diff.nextPendingTasks);
+							syncQueueToPending(queue, pending, completed, completedIds, completedTasksById);
+							plannedTasks = [...queue.list()];
 							planSummary = revisedPlan.planSummary;
 							consecutiveFailedBatches = 0;
 
@@ -3043,6 +3245,7 @@ export async function runTeamSession(input: TeamOrchestratorInput): Promise<void
 						};
 						completed.push(revisionTask);
 						completedTasksById.set(revisionTask.id, revisionTask);
+						queue.update(item.task.id, { status: 'revision', result: resultText });
 					}
 				}
 
@@ -3057,8 +3260,9 @@ export async function runTeamSession(input: TeamOrchestratorInput): Promise<void
 							taskId: task.id, expertId: task.expertId,
 							success: false, result: fallback,
 						});
-						completed.push({ ...task, status: 'failed', result: fallback });
+						queue.fail(task.id, fallback);
 					}
+					syncQueueToPending(queue, pending, completed, completedIds, completedTasksById);
 					break;
 				}
 			}
@@ -3116,16 +3320,20 @@ export async function runTeamSession(input: TeamOrchestratorInput): Promise<void
 					const revisedPendingTasks = materializePlannedTasks(revisedPlan.tasks, specialists, completed);
 					const diff = applyPlanDiff([], revisedPendingTasks);
 					const revisedIds = new Set(revisedPendingTasks.map((task) => task.id));
-					for (let index = completed.length - 1; index >= 0; index -= 1) {
-						const task = completed[index]!;
-						if (task.status !== 'completed' || revisedIds.has(task.id)) {
-							completed.splice(index, 1);
-							completedTasksById.delete(task.id);
-							completedIds.delete(task.id);
+					// Sync into queue: keep only completed tasks that are still in the revised plan.
+					for (const task of queue.list()) {
+						if (task.status === 'completed' && revisedIds.has(task.id)) {
+							continue;
 						}
+						queue.remove(task.id);
 					}
-					pending = [...revisedPendingTasks];
-					plannedTasks = [...completed, ...pending];
+					queue.addBatch(revisedPendingTasks);
+					// Clear legacy arrays and resync.
+					completed.length = 0;
+					completedIds.clear();
+					completedTasksById.clear();
+					syncQueueToPending(queue, pending, completed, completedIds, completedTasksById);
+					plannedTasks = [...queue.list()];
 					planSummary = revisedPlan.planSummary;
 					consecutiveFailedBatches = 0;
 

--- a/main-src/agent/teamTaskQueue.test.ts
+++ b/main-src/agent/teamTaskQueue.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import { TeamTaskQueue } from './teamTaskQueue.js';
+import type { TeamTask } from './teamOrchestrator.js';
+
+function makeTask(id: string, deps: string[] = [], status: TeamTask['status'] = 'pending'): TeamTask {
+	return {
+		id,
+		expertId: 'expert-1',
+		expertName: 'Expert',
+		expertAssignmentKey: 'expert-1',
+		roleType: 'custom',
+		description: `Task ${id}`,
+		status,
+		dependencies: deps,
+		acceptanceCriteria: [],
+		kind: 'deliver',
+	};
+}
+
+describe('TeamTaskQueue', () => {
+	it('adds tasks and resolves initial status', () => {
+		const queue = new TeamTaskQueue();
+		const t1 = makeTask('t1');
+		const t2 = makeTask('t2', ['t1']);
+		queue.add(t1);
+		queue.add(t2);
+		expect(queue.get('t1')!.status).toBe('pending');
+		expect(queue.get('t2')!.status).toBe('blocked');
+	});
+
+	it('getReady returns only tasks with satisfied dependencies', () => {
+		const queue = new TeamTaskQueue();
+		queue.add(makeTask('t1'));
+		queue.add(makeTask('t2', ['t1']));
+		queue.add(makeTask('t3'));
+		const ready = queue.getReady();
+		expect(ready.map((t) => t.id)).toContain('t1');
+		expect(ready.map((t) => t.id)).toContain('t3');
+		expect(ready.map((t) => t.id)).not.toContain('t2');
+	});
+
+	it('unblocks dependents on complete', () => {
+		const queue = new TeamTaskQueue();
+		queue.add(makeTask('t1'));
+		queue.add(makeTask('t2', ['t1']));
+		expect(queue.get('t2')!.status).toBe('blocked');
+		queue.complete('t1', 'done');
+		expect(queue.get('t1')!.status).toBe('completed');
+		expect(queue.get('t2')!.status).toBe('pending');
+	});
+
+	it('cascades failure to dependents', () => {
+		const queue = new TeamTaskQueue();
+		queue.add(makeTask('t1'));
+		queue.add(makeTask('t2', ['t1']));
+		queue.add(makeTask('t3', ['t2']));
+		queue.fail('t1', 'oops');
+		expect(queue.get('t1')!.status).toBe('failed');
+		expect(queue.get('t2')!.status).toBe('failed');
+		expect(queue.get('t3')!.status).toBe('failed');
+	});
+
+	it('does not cascade failure to already completed tasks', () => {
+		const queue = new TeamTaskQueue();
+		queue.add(makeTask('t1'));
+		queue.add(makeTask('t2', ['t1']));
+		queue.complete('t2', 'early');
+		queue.fail('t1', 'oops');
+		expect(queue.get('t2')!.status).toBe('completed');
+	});
+
+	it('getProgress reports correct counts', () => {
+		const queue = new TeamTaskQueue();
+		queue.add(makeTask('t1'));
+		queue.add(makeTask('t2', ['t1']));
+		queue.add(makeTask('t3'));
+		queue.complete('t1');
+		queue.fail('t3', 'err');
+		const p = queue.getProgress();
+		expect(p.total).toBe(3);
+		expect(p.completed).toBe(1);
+		expect(p.failed).toBe(1);
+		expect(p.pending).toBe(1);
+		expect(p.blocked).toBe(0);
+	});
+
+	it('isComplete returns true when all tasks terminal', () => {
+		const queue = new TeamTaskQueue();
+		queue.add(makeTask('t1'));
+		queue.add(makeTask('t2'));
+		expect(queue.isComplete()).toBe(false);
+		queue.complete('t1');
+		queue.fail('t2', 'err');
+		expect(queue.isComplete()).toBe(true);
+	});
+
+	it('skipAllRemaining marks non-terminal tasks as failed', () => {
+		const queue = new TeamTaskQueue();
+		queue.add(makeTask('t1'));
+		queue.add(makeTask('t2', ['t1']));
+		queue.complete('t1');
+		queue.skipAllRemaining('aborted');
+		expect(queue.get('t2')!.status).toBe('failed');
+		expect(queue.get('t2')!.result).toContain('aborted');
+	});
+
+	it('handles diamond dependency graph', () => {
+		//     t1
+		//    /  \
+		//   t2   t3
+		//    \  /
+		//     t4
+		const queue = new TeamTaskQueue();
+		queue.add(makeTask('t1'));
+		queue.add(makeTask('t2', ['t1']));
+		queue.add(makeTask('t3', ['t1']));
+		queue.add(makeTask('t4', ['t2', 't3']));
+
+		expect(queue.getReady().map((t) => t.id)).toEqual(['t1']);
+		queue.complete('t1');
+		const readyAfterT1 = queue.getReady().map((t) => t.id);
+		expect(readyAfterT1).toContain('t2');
+		expect(readyAfterT1).toContain('t3');
+		queue.complete('t2');
+		expect(queue.get('t4')!.status).toBe('blocked');
+		queue.complete('t3');
+		expect(queue.get('t4')!.status).toBe('pending');
+	});
+
+	it('remove deletes a task from the queue', () => {
+		const queue = new TeamTaskQueue();
+		queue.add(makeTask('t1'));
+		expect(queue.get('t1')).toBeDefined();
+		queue.remove('t1');
+		expect(queue.get('t1')).toBeUndefined();
+	});
+});

--- a/main-src/agent/teamTaskQueue.ts
+++ b/main-src/agent/teamTaskQueue.ts
@@ -1,0 +1,217 @@
+/**
+ * 拓扑依赖感知的任务队列 —— 从 open-multi-agent 移植并适配 Async。
+ *
+ * 将 teamOrchestrator 中内联的 pending/completed/active 数组操作
+ * 提取为独立组件，自动处理：
+ * - blocked → pending 的解阻塞
+ * - 失败/跳过时级联到下游依赖
+ * - 任务状态查询与进度统计
+ */
+
+import type { TeamTask } from './teamOrchestrator.js';
+
+export type TaskStatus = TeamTask['status'];
+
+export class TeamTaskQueue {
+	private readonly tasks = new Map<string, TeamTask>();
+
+	add(task: TeamTask): void {
+		const resolved = this.resolveInitialStatus(task);
+		this.tasks.set(resolved.id, resolved);
+	}
+
+	addBatch(tasks: TeamTask[]): void {
+		for (const task of tasks) {
+			this.add(task);
+		}
+	}
+
+	get(taskId: string): TeamTask | undefined {
+		return this.tasks.get(taskId);
+	}
+
+	list(): TeamTask[] {
+		return Array.from(this.tasks.values());
+	}
+
+	getByStatus(status: TaskStatus): TeamTask[] {
+		return this.list().filter((t) => t.status === status);
+	}
+
+	/** 返回依赖已全部满足且状态为 pending 的任务 */
+	getReady(): TeamTask[] {
+		return this.list().filter((t) => this.isTaskReady(t));
+	}
+
+	/** 返回 status 为 pending 或 blocked 的非终止任务 */
+	getPendingOrBlocked(): TeamTask[] {
+		return this.list().filter((t) => t.status === 'pending' || t.status === 'blocked');
+	}
+
+	update(taskId: string, update: Partial<Pick<TeamTask, 'status' | 'result'>>): TeamTask {
+		const task = this.requireTask(taskId);
+		const updated: TeamTask = {
+			...task,
+			...update,
+		};
+		this.tasks.set(taskId, updated);
+		return updated;
+	}
+
+	complete(taskId: string, result?: string): TeamTask {
+		const completed = this.update(taskId, { status: 'completed', result });
+		this.unblockDependents(taskId);
+		return completed;
+	}
+
+	fail(taskId: string, error: string): TeamTask {
+		const failed = this.update(taskId, { status: 'failed', result: error });
+		this.cascadeFailure(taskId);
+		return failed;
+	}
+
+	/**
+	 * 跳过指定任务及其所有下游依赖。
+	 * 用于 approval gate 拒绝或 abort 场景。
+	 */
+	skip(taskId: string, reason: string): TeamTask {
+		const skipped = this.update(taskId, { status: 'failed', result: reason });
+		this.cascadeSkip(taskId, reason);
+		return skipped;
+	}
+
+	/** 跳过所有非终止任务 */
+	skipAllRemaining(reason = 'Skipped.'): void {
+		const snapshot = this.list();
+		for (const task of snapshot) {
+			if (task.status === 'completed' || task.status === 'failed') continue;
+			this.update(task.id, { status: 'failed', result: reason });
+		}
+	}
+
+	remove(taskId: string): boolean {
+		return this.tasks.delete(taskId);
+	}
+
+	isComplete(): boolean {
+		for (const task of this.tasks.values()) {
+			if (task.status !== 'completed' && task.status !== 'failed') {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	getProgress(): {
+		total: number;
+		completed: number;
+		failed: number;
+		inProgress: number;
+		pending: number;
+		blocked: number;
+	} {
+		let completed = 0;
+		let failed = 0;
+		let inProgress = 0;
+		let pending = 0;
+		let blocked = 0;
+
+		for (const task of this.tasks.values()) {
+			switch (task.status) {
+				case 'completed':
+					completed++;
+					break;
+				case 'failed':
+					failed++;
+					break;
+				case 'in_progress':
+					inProgress++;
+					break;
+				case 'pending':
+					pending++;
+					break;
+				case 'revision':
+					// Treat revision as in-progress for progress tracking.
+					inProgress++;
+					break;
+				case 'blocked':
+					blocked++;
+					break;
+				default:
+					blocked++;
+					break;
+			}
+		}
+
+		return {
+			total: this.tasks.size,
+			completed,
+			failed,
+			inProgress,
+			pending,
+			blocked,
+		};
+	}
+
+	// ── Private helpers ─────────────────────────────────────────────────────
+
+	private resolveInitialStatus(task: TeamTask): TeamTask {
+		if (!task.dependencies || task.dependencies.length === 0) {
+			return task.status === 'pending' ? task : { ...task, status: 'pending' };
+		}
+		if (this.isTaskReady(task)) {
+			return task.status === 'pending' ? task : { ...task, status: 'pending' };
+		}
+		return { ...task, status: 'blocked' };
+	}
+
+	private isTaskReady(task: TeamTask): boolean {
+		if (task.status !== 'pending' && task.status !== 'blocked') return false;
+		const deps = task.dependencies ?? [];
+		if (deps.length === 0) return true;
+		return deps.every((depId) => {
+			const dep = this.tasks.get(depId);
+			return dep?.status === 'completed';
+		});
+	}
+
+	private unblockDependents(completedId: string): void {
+		for (const task of this.tasks.values()) {
+			if (task.status !== 'blocked') continue;
+			if (!task.dependencies?.includes(completedId)) continue;
+			if (this.isTaskReady(task)) {
+				this.tasks.set(task.id, { ...task, status: 'pending' });
+			}
+		}
+	}
+
+	private cascadeFailure(failedTaskId: string): void {
+		for (const task of this.tasks.values()) {
+			if (task.status !== 'blocked' && task.status !== 'pending') continue;
+			if (!task.dependencies?.includes(failedTaskId)) continue;
+			this.update(task.id, {
+				status: 'failed',
+				result: `Cancelled: dependency "${failedTaskId}" failed.`,
+			});
+			this.cascadeFailure(task.id);
+		}
+	}
+
+	private cascadeSkip(skippedTaskId: string, reason: string): void {
+		for (const task of this.tasks.values()) {
+			if (task.status !== 'blocked' && task.status !== 'pending') continue;
+			if (!task.dependencies?.includes(skippedTaskId)) continue;
+			this.update(task.id, {
+				status: 'failed',
+				result: `Skipped: dependency "${skippedTaskId}" was skipped — ${reason}`,
+			});
+			this.cascadeSkip(task.id, reason);
+		}
+	}
+
+	private requireTask(taskId: string): TeamTask {
+		const task = this.tasks.get(taskId);
+		if (!task) throw new Error(`TeamTaskQueue: task "${taskId}" not found.`);
+		return task;
+	}
+}

--- a/main-src/agent/teamTaskScheduler.test.ts
+++ b/main-src/agent/teamTaskScheduler.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import { rankReadyTasks, type TaskSchedulingStrategy } from './teamTaskScheduler.js';
+import type { TeamTask } from './teamOrchestrator.js';
+import type { TeamExpertRuntimeProfile } from './teamExpertProfiles.js';
+
+function makeTask(id: string, expertId: string, description: string, dependencies: string[] = []): TeamTask {
+	return {
+		id,
+		expertId,
+		expertName: expertId,
+		expertAssignmentKey: expertId,
+		roleType: 'custom',
+		description,
+		status: 'pending',
+		dependencies,
+		acceptanceCriteria: [],
+		kind: 'deliver',
+	};
+}
+
+function makeExpert(id: string, name: string, systemPrompt = ''): TeamExpertRuntimeProfile {
+	return {
+		id,
+		name,
+		assignmentKey: id,
+		roleType: 'custom',
+		systemPrompt,
+		summary: '',
+		enabled: true,
+		allowedTools: [],
+	};
+}
+
+describe('rankReadyTasks', () => {
+	const specialists = [
+		makeExpert('frontend', 'Frontend Expert', 'React UI components styling'),
+		makeExpert('backend', 'Backend Expert', 'API design database'),
+		makeExpert('qa', 'QA Expert', 'testing automation'),
+	];
+
+	it('returns empty for empty input', () => {
+		expect(rankReadyTasks([], [], specialists, new Set(), 'dependency-first')).toEqual([]);
+	});
+
+	it('returns single task unchanged', () => {
+		const task = makeTask('t1', 'frontend', 'Build login form');
+		expect(rankReadyTasks([task], [task], specialists, new Set(), 'dependency-first')).toEqual([task]);
+	});
+
+	it('fifo preserves original order', () => {
+		const t1 = makeTask('t1', 'frontend', 'A');
+		const t2 = makeTask('t2', 'backend', 'B');
+		const t3 = makeTask('t3', 'qa', 'C');
+		const result = rankReadyTasks([t1, t2, t3], [t1, t2, t3], specialists, new Set(), 'fifo');
+		expect(result.map((t) => t.id)).toEqual(['t1', 't2', 't3']);
+	});
+
+	it('dependency-first prioritises critical path tasks', () => {
+		// t1 -> t3 (t3 depends on t1)
+		// t2 has no dependents
+		const t1 = makeTask('t1', 'frontend', 'Design schema');
+		const t2 = makeTask('t2', 'backend', 'Setup repo');
+		const t3 = makeTask('t3', 'qa', 'Review schema', ['t1']);
+		const all = [t1, t2, t3];
+		const ready = [t1, t2]; // t3 blocked
+		const result = rankReadyTasks(ready, all, specialists, new Set(), 'dependency-first');
+		// t1 blocks t3, so t1 should come first
+		expect(result[0]!.id).toBe('t1');
+	});
+
+	it('dependency-first handles transitive dependents', () => {
+		// t1 -> t3 -> t4
+		// t2 -> nothing
+		const t1 = makeTask('t1', 'frontend', 'A');
+		const t2 = makeTask('t2', 'backend', 'B');
+		const t3 = makeTask('t3', 'qa', 'C', ['t1']);
+		const t4 = makeTask('t4', 'frontend', 'D', ['t3']);
+		const all = [t1, t2, t3, t4];
+		const ready = [t1, t2];
+		const result = rankReadyTasks(ready, all, specialists, new Set(), 'dependency-first');
+		// t1 blocks 2 tasks (t3, t4); t2 blocks 0
+		expect(result[0]!.id).toBe('t1');
+		expect(result[1]!.id).toBe('t2');
+	});
+
+	it('least-busy prefers experts with fewer active tasks', () => {
+		const t1 = makeTask('t1', 'frontend', 'A');
+		const t2 = makeTask('t2', 'frontend', 'B');
+		const t3 = makeTask('t3', 'backend', 'C');
+		const all = [t1, t2, t3];
+		const ready = [t1, t2, t3];
+		const active = new Set(['t1']); // frontend busy
+		const result = rankReadyTasks(ready, all, specialists, active, 'least-busy');
+		// backend has 0 active → should come first
+		expect(result[0]!.id).toBe('t3');
+	});
+
+	it('round-robin cycles through different experts', () => {
+		const t1 = makeTask('t1', 'frontend', 'A');
+		const t2 = makeTask('t2', 'frontend', 'B');
+		const t3 = makeTask('t3', 'backend', 'C');
+		const t4 = makeTask('t4', 'qa', 'D');
+		const all = [t1, t2, t3, t4];
+		const ready = [t1, t2, t3, t4];
+		const result = rankReadyTasks(ready, all, specialists, new Set(), 'round-robin');
+		// First round: one task per expert in ready order
+		const ids = result.map((t) => t.id);
+		expect(ids[0]).toBe('t1'); // first frontend
+		expect(ids[1]).toBe('t3'); // first backend
+		expect(ids[2]).toBe('t4'); // first qa
+		expect(ids[3]).toBe('t2'); // second frontend
+	});
+
+	it('capability-match scores by keyword overlap', () => {
+		const frontend = makeExpert('frontend', 'Frontend', 'React component styling');
+		const backend = makeExpert('backend', 'Backend', 'API database design');
+		const experts = [frontend, backend];
+
+		const t1 = makeTask('t1', 'frontend', 'Build a React component');
+		const t2 = makeTask('t2', 'backend', 'Design the database schema');
+		const all = [t1, t2];
+		const ready = [t1, t2];
+		const result = rankReadyTasks(ready, all, experts, new Set(), 'capability-match');
+		// Both should be present; order depends on score.
+		expect(result.map((t) => t.id)).toContain('t1');
+		expect(result.map((t) => t.id)).toContain('t2');
+	});
+
+	it('defaults to dependency-first when strategy omitted', () => {
+		const t1 = makeTask('t1', 'frontend', 'A');
+		const t2 = makeTask('t2', 'backend', 'B');
+		const t3 = makeTask('t3', 'qa', 'C', ['t1']);
+		const all = [t1, t2, t3];
+		const ready = [t1, t2];
+		const result = rankReadyTasks(ready, all, specialists, new Set());
+		expect(result[0]!.id).toBe('t1');
+	});
+});

--- a/main-src/agent/teamTaskScheduler.ts
+++ b/main-src/agent/teamTaskScheduler.ts
@@ -1,0 +1,185 @@
+/**
+ * 团队任务调度策略 —— 从 open-multi-agent 移植并适配 Async。
+ *
+ * 解决执行阶段的问题：当就绪任务数超过 maxParallelExperts 时，
+ * 应该优先执行哪些任务？
+ */
+
+import type { TeamTask } from './teamOrchestrator.js';
+import type { TeamExpertRuntimeProfile } from './teamExpertProfiles.js';
+
+export type TaskSchedulingStrategy = 'fifo' | 'round-robin' | 'least-busy' | 'dependency-first' | 'capability-match';
+
+// ── Keyword helpers (mirrors OMA keywords.ts) ─────────────────────────────
+
+const STOP_WORDS: ReadonlySet<string> = new Set([
+	'the', 'and', 'for', 'that', 'this', 'with', 'are', 'from', 'have',
+	'will', 'your', 'you', 'can', 'all', 'each', 'when', 'then', 'they',
+	'them', 'their', 'about', 'into', 'more', 'also', 'should', 'must',
+]);
+
+function extractKeywords(text: string): string[] {
+	return [
+		...new Set(
+			text
+				.toLowerCase()
+				.split(/\W+/)
+				.filter((w) => w.length > 3 && !STOP_WORDS.has(w)),
+		),
+	];
+}
+
+function keywordScore(text: string, keywords: readonly string[]): number {
+	const lower = text.toLowerCase();
+	return keywords.reduce(
+		(acc, kw) => acc + (lower.includes(kw.toLowerCase()) ? 1 : 0),
+		0,
+	);
+}
+
+// ── Dependency-first: critical-path heuristic ─────────────────────────────
+
+/**
+ * 计算 `taskId` 有多少下游任务（直接或间接）被它阻塞。
+ * 使用正向 BFS 遍历依赖图。
+ */
+function countBlockedDependents(taskId: string, allTasks: TeamTask[]): number {
+	const idToTask = new Map<string, TeamTask>(allTasks.map((t) => [t.id, t]));
+	const dependents = new Map<string, string[]>();
+	for (const t of allTasks) {
+		for (const depId of t.dependencies ?? []) {
+			const list = dependents.get(depId) ?? [];
+			list.push(t.id);
+			dependents.set(depId, list);
+		}
+	}
+
+	const visited = new Set<string>();
+	const queue: string[] = [taskId];
+	while (queue.length > 0) {
+		const current = queue.shift()!;
+		for (const depId of dependents.get(current) ?? []) {
+			if (!visited.has(depId) && idToTask.has(depId)) {
+				visited.add(depId);
+				queue.push(depId);
+			}
+		}
+	}
+	return visited.size;
+}
+
+// ── Capability-match: keyword affinity ────────────────────────────────────
+
+function rankByCapabilityMatch(
+	readyTasks: TeamTask[],
+	specialists: TeamExpertRuntimeProfile[],
+): TeamTask[] {
+	const agentKeywords = new Map<string, string[]>(
+		specialists.map((s) => [
+			s.id,
+			extractKeywords(`${s.name} ${s.systemPrompt ?? ''} ${s.assignmentKey ?? ''}`),
+		]),
+	);
+
+	return [...readyTasks].sort((a, b) => {
+		const scoreA = computeTaskAffinity(a, specialists, agentKeywords);
+		const scoreB = computeTaskAffinity(b, specialists, agentKeywords);
+		return scoreB - scoreA;
+	});
+}
+
+function computeTaskAffinity(
+	task: TeamTask,
+	specialists: TeamExpertRuntimeProfile[],
+	agentKeywords: Map<string, string[]>,
+): number {
+	const expert = specialists.find((s) => s.id === task.expertId);
+	if (!expert) return 0;
+
+	const taskText = `${task.description}`;
+	const taskKeywords = extractKeywords(taskText);
+	const expertText = `${expert.name} ${expert.systemPrompt ?? ''}`;
+	const scoreA = keywordScore(expertText, taskKeywords);
+	const scoreB = keywordScore(taskText, agentKeywords.get(expert.id) ?? []);
+	return scoreA + scoreB;
+}
+
+// ── Least-busy: prefer experts with fewer active tasks ────────────────────
+
+function rankByLeastBusy(
+	readyTasks: TeamTask[],
+	specialists: TeamExpertRuntimeProfile[],
+	activeTaskIds: Set<string>,
+	allTasks: TeamTask[],
+): TeamTask[] {
+	const inProgressCount = new Map<string, number>(specialists.map((s) => [s.id, 0]));
+	for (const task of allTasks) {
+		if (activeTaskIds.has(task.id) && task.expertId) {
+			inProgressCount.set(task.expertId, (inProgressCount.get(task.expertId) ?? 0) + 1);
+		}
+	}
+
+	return [...readyTasks].sort((a, b) => {
+		const loadA = inProgressCount.get(a.expertId) ?? 0;
+		const loadB = inProgressCount.get(b.expertId) ?? 0;
+		return loadA - loadB;
+	});
+}
+
+// ── Public API ────────────────────────────────────────────────────────────
+
+/**
+ * 对就绪任务进行排序，返回按策略排好序的任务列表。
+ *
+ * 调用方应取前 N 个作为当前批次（N = maxParallelExperts）。
+ */
+export function rankReadyTasks(
+	readyTasks: TeamTask[],
+	allTasks: TeamTask[],
+	specialists: TeamExpertRuntimeProfile[],
+	activeTaskIds: Set<string>,
+	strategy: TaskSchedulingStrategy = 'dependency-first',
+): TeamTask[] {
+	if (readyTasks.length <= 1) return readyTasks;
+
+	switch (strategy) {
+		case 'fifo':
+			return readyTasks;
+		case 'round-robin': {
+			// Cycle by expert id to spread load across different experts.
+			const seenExperts = new Set<string>();
+			const result: TeamTask[] = [];
+			const remaining = [...readyTasks];
+			while (remaining.length > 0) {
+				let found = false;
+				for (let i = 0; i < remaining.length; i++) {
+					const task = remaining[i]!;
+					if (!seenExperts.has(task.expertId)) {
+						seenExperts.add(task.expertId);
+						result.push(task);
+						remaining.splice(i, 1);
+						found = true;
+						break;
+					}
+				}
+				if (!found) {
+					// All remaining experts already seen; reset and continue.
+					seenExperts.clear();
+				}
+			}
+			return result;
+		}
+		case 'least-busy':
+			return rankByLeastBusy(readyTasks, specialists, activeTaskIds, allTasks);
+		case 'capability-match':
+			return rankByCapabilityMatch(readyTasks, specialists);
+		case 'dependency-first':
+		default: {
+			return [...readyTasks].sort((a, b) => {
+				const critA = countBlockedDependents(a.id, allTasks);
+				const critB = countBlockedDependents(b.id, allTasks);
+				return critB - critA;
+			});
+		}
+	}
+}

--- a/src/agentSettingsTypes.ts
+++ b/src/agentSettingsTypes.ts
@@ -117,6 +117,10 @@ export type TeamSettings = {
 	planReviewer?: TeamExpertConfig | null;
 	/** 可选的交付评审专家；为空时复用 reviewer */
 	deliveryReviewer?: TeamExpertConfig | null;
+	/** 启用简单目标短路优化：当用户请求明显是单轮简单问题时，直接让 Team Lead 回答而不走完整 Planning */
+	enableSimpleGoalShortCircuit?: boolean;
+	/** 执行阶段任务调度策略：fifo | round-robin | least-busy | dependency-first | capability-match */
+	taskSchedulingStrategy?: 'fifo' | 'round-robin' | 'least-busy' | 'dependency-first' | 'capability-match';
 };
 
 /** Bash 执行权限三档（与 Composer 下拉、设置页一致） */


### PR DESCRIPTION
Port three core algorithm modules from open-multi-agent (OMA) into Async's team orchestration pipeline:

- **simpleGoalDetector.ts** — heuristic short-circuit for simple single-turn requests (with CJK adaptations)
- **teamTaskScheduler.ts** — 4 scheduling strategies (dependency-first, capability-match, least-busy, ound-robin)
- **teamTaskQueue.ts** — topological dependency queue with auto-unblocking, cascade failure, and skip support

### Integration into 	eamOrchestrator.ts
- Replace inline pending/completed arrays with TeamTaskQueue for state management
- Replace naive eady.slice(0, maxParallelExperts) with ankReadyTasks() for intelligent batch selection
- Add bidirectional sync between legacy pending array and queue so replan correctly surfaces new tasks to the execution loop

### Bug fixes for queue integration
- Sync escalated tasks to queue as 'revision' status
- syncQueueToPending: handle 'revision' tasks and backfill missing pending/locked tasks from queue into legacy pending array
- Escalation replan: preserve 'revision' tasks when pruning queue

### Test results
- 	eamOrchestrator.test.ts: 19/19 ✅
- simpleGoalDetector.test.ts: 9/9 ✅
- 	eamTaskScheduler.test.ts: 9/9 ✅
- 	eamTaskQueue.test.ts: 10/10 ✅