### PR TITLE
fix(auto-update): prevent repeated native dialogs and add non-intrusive toast

### DIFF
--- a/main-src/autoUpdate.ts
+++ b/main-src/autoUpdate.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, dialog } from 'electron';
+import { app, BrowserWindow } from 'electron';
 import { autoUpdater, UpdateInfo, ProgressInfo } from 'electron-updater';
 import { getSettings } from './settingsStore.js';
 
@@ -15,6 +15,7 @@ export type AutoUpdateStatus =
 let currentStatus: AutoUpdateStatus = { state: 'idle' };
 let updateCheckPromise: Promise<void> | null = null;
 let mainWindow: BrowserWindow | null = null;
+let isConfigured = false;
 
 /** 设置主窗口引用，用于发送更新事件 */
 export function setMainWindow(win: BrowserWindow | null): void {
@@ -42,6 +43,11 @@ function isDifferentialAllowed(): boolean {
 
 /** 配置 autoUpdater */
 function configureUpdater(): void {
+	if (isConfigured) {
+		return;
+	}
+	isConfigured = true;
+
 	autoUpdater.autoDownload = true;
 	autoUpdater.autoInstallOnAppQuit = true;
 	
@@ -86,26 +92,6 @@ function configureUpdater(): void {
 		console.log('[AutoUpdate] Update downloaded:', info.version);
 		currentStatus = { state: 'downloaded' };
 		sendStatusToRenderer();
-
-		// 通知用户并询问是否立即重启
-		if (mainWindow && !mainWindow.isDestroyed()) {
-			dialog.showMessageBox(mainWindow, {
-				type: 'info',
-				title: '更新已就绪',
-				message: `Async IDE ${info.version} 已下载完成`,
-				detail: '是否立即重启以应用更新？',
-				buttons: ['立即重启', '稍后重启'],
-				defaultId: 0,
-				cancelId: 1,
-			}).then((result) => {
-				if (result.response === 0) {
-					// 用户选择立即重启
-					autoUpdater.quitAndInstall();
-				}
-			}).catch(() => {
-				// 忽略错误
-			});
-		}
 	});
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -658,11 +658,27 @@ function AppMainWorkspaceInner() {
 	const [layoutSwitchTarget, setLayoutSwitchTarget] = useState<LayoutMode | null>(null);
 	const [modelPickerOpen, setModelPickerOpen] = useState(false);
 	const [plusMenuOpen, setPlusMenuOpen] = useState(false);
+	const [updateDownloaded, setUpdateDownloaded] = useState(false);
 	useEffect(() => {
 		if (plusMenuOpen || modelPickerOpen) {
 			setGitBranchPickerOpen(false);
 		}
 	}, [plusMenuOpen, modelPickerOpen, setGitBranchPickerOpen]);
+	useEffect(() => {
+		const unsubscribe = shell?.subscribeAutoUpdateStatus?.((status) => {
+			if (status?.state === 'downloaded') {
+				setUpdateDownloaded(true);
+			}
+		});
+		return () => {
+			unsubscribe?.();
+		};
+	}, [shell]);
+	const onInstallUpdate = useCallback(() => {
+		shell?.invoke('auto-update:install').catch(() => {
+			/* ignore */
+		});
+	}, [shell]);
 	const {
 		composerSegments,
 		setComposerSegments,
@@ -4095,7 +4111,18 @@ function AppMainWorkspaceInner() {
 				onSubAgentToastClick={onSubAgentToastClick}
 			/>
 
-
+			{updateDownloaded ? (
+				<div className="ref-update-ready-toast">
+					<span className="ref-update-ready-toast-text">{t('app.updateReady')}</span>
+					<button
+						type="button"
+						className="ref-update-ready-toast-btn"
+						onClick={onInstallUpdate}
+					>
+						{t('settings.autoUpdate.restartNow')}
+					</button>
+				</div>
+			) : null}
 		</div>
 		</ComposerActionsProvider>
 		</AppProvider>

--- a/src/i18n/messages.en.ts
+++ b/src/i18n/messages.en.ts
@@ -78,6 +78,7 @@ export const messagesEn: Record<string, string> = {
 	'app.help.releases': 'Release Notes',
 	'app.help.about': 'About Async IDE',
 	'app.help.aboutVersion': 'Version {version}',
+	'app.updateReady': 'Update ready — restart to apply',
 	'app.help.aboutTagline': 'An async-native IDE for working with AI coding agents.',
 	'app.help.aboutOpenRepo': 'Open Repository',
 	'app.help.aboutCopyInfo': 'Copy Info',

--- a/src/i18n/messages.zh-CN.ts
+++ b/src/i18n/messages.zh-CN.ts
@@ -82,6 +82,7 @@ export const messagesZhCN: Record<string, string> = {
 	'app.help.releases': '发布说明',
 	'app.help.about': '关于 Async IDE',
 	'app.help.aboutVersion': '版本 {version}',
+	'app.updateReady': '更新已就绪，重启即可应用',
 	'app.help.aboutTagline': '面向 AI 编程代理的异步原生 IDE。',
 	'app.help.aboutOpenRepo': '打开仓库',
 	'app.help.aboutCopyInfo': '复制信息',

--- a/src/index.css
+++ b/src/index.css
@@ -19530,6 +19530,54 @@ select.ref-settings-native-select:focus {
 	color: #fca5a5;
 }
 
+/* ── Update ready toast (window bottom-left) ──────────────────────────── */
+.ref-update-ready-toast {
+	position: fixed;
+	bottom: 24px;
+	left: 24px;
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 10px 16px;
+	border-radius: 10px;
+	background: rgba(129, 140, 248, 0.14);
+	border: 1px solid rgba(129, 140, 248, 0.32);
+	color: #a5b4fc;
+	font-size: 13px;
+	font-weight: 500;
+	pointer-events: auto;
+	box-shadow: 0 4px 24px rgba(0, 0, 0, 0.3);
+	animation: ref-update-toast-in 0.24s ease;
+	z-index: 9999;
+}
+
+@keyframes ref-update-toast-in {
+	from { opacity: 0; transform: translateY(10px); }
+	to { opacity: 1; transform: translateY(0); }
+}
+
+.ref-update-ready-toast-text {
+	white-space: nowrap;
+}
+
+.ref-update-ready-toast-btn {
+	appearance: none;
+	border: none;
+	border-radius: 6px;
+	padding: 5px 12px;
+	background: rgba(129, 140, 248, 0.24);
+	color: #c7d2fe;
+	font-size: 12px;
+	font-weight: 600;
+	cursor: pointer;
+	transition: background 0.15s ease;
+	font: inherit;
+}
+
+.ref-update-ready-toast-btn:hover {
+	background: rgba(129, 140, 248, 0.38);
+}
+
 /* ── Team Session ────────────────────────────────────────────────────── */
 
 .ref-team-session {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -34,6 +34,8 @@ export interface AsyncShellAPI {
 	/** 查询全能终端设置页可显示的内置 Shell / 连接模板 */
 	/** 主进程请求主窗口打开设置并切换到指定侧栏项（如从独立浏览器窗口唤起） */
 	subscribeOpenSettingsNav?(callback: (nav: string) => void): () => void;
+	/** 自动更新状态推送（checking / available / downloading / downloaded / error 等） */
+	subscribeAutoUpdateStatus?(callback: (payload: { state: string } & Record<string, unknown>) => void): () => void;
 }
 declare global {
 interface AsyncShellWebviewElement extends HTMLElement {


### PR DESCRIPTION
## Problem

Users reported that after an update was downloaded, the app would repeatedly show native dialog.showMessageBox prompts saying the update was ready. This eventually caused the system to freeze.

### Root Cause

configureUpdater() was called on every checkForUpdates() invocation (initial check after 30s + hourly periodic checks). Each call registered a new autoUpdater.on('update-downloaded', ...) listener on the singleton utoUpdater instance. Over time, these listeners accumulated, so when an update finished downloading, **all** of them fired simultaneously, each spawning a blocking native dialog.

## Solution

### 1. Fix the repeated dialog bug (main process)

- Added an isConfigured guard in main-src/autoUpdate.ts so configureUpdater() only runs once.
- Removed the dialog.showMessageBox call from the update-downloaded handler. The main process now **only** broadcasts the status to the renderer via auto-update:status.

### 2. Add a non-intrusive UI prompt (renderer)

- Added subscribeAutoUpdateStatus to the AsyncShellAPI type definition.
- In App.tsx, subscribed to the auto-update status stream. When state === 'downloaded', a fixed toast appears at the **bottom-left corner of the window**.
- The toast contains the update-ready message and a **'Restart Now'** button. The user must explicitly click it to call uto-update:install.
- Added pp.updateReady i18n keys for both zh-CN and en.
- Added CSS animations and styling for the toast component (
ef-update-ready-toast).

## Files Changed

| File | Change |
|------|--------|
| main-src/autoUpdate.ts | Guard configureUpdater(); remove native dialog |
| src/App.tsx | Subscribe to status; render fixed toast |
| src/vite-env.d.ts | Add subscribeAutoUpdateStatus type |
| src/index.css | Add toast styles and animation |
| src/i18n/messages.en.ts | Add app.updateReady key |
| src/i18n/messages.zh-CN.ts | Add app.updateReady key |

## Testing

- 
px tsc --noEmit passes.
- 
px vitest run main-src/autoUpdate.test.ts passes.
- To manually verify the toast UI, temporarily set updateDownloaded = true in App.tsx and run 
pm run dev.

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code follows the project style guidelines
- [x] TypeScript compiles without errors
- [x] Existing tests pass
- [x] i18n keys added for both supported languages