### PR TITLE
Chat turn containers, scroll/layout fixes, MCP settings improvements

### DIFF
--- a/main-src/index.ts
+++ b/main-src/index.ts
@@ -2,9 +2,11 @@ import { app, BrowserWindow } from 'electron';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { initWindowsConsoleUtf8 } from './winUtf8.js';
-import { initSettingsStore, getRestorableWorkspace, getSettings } from './settingsStore.js';
+import { initSettingsStore, getRestorableWorkspace, getSettings, getMcpServerConfigs } from './settingsStore.js';
 import { ensureDefaultThread, flushPendingSave, initThreadStore } from './threadStore.js';
 import { registerIpc } from './ipc/register.js';
+import { getMcpManager } from './mcp/index.js';
+import { getEffectiveMcpServerConfigs } from './plugins/pluginRuntimeService.js';
 import { configureAppWindowIcon, createAppWindow } from './appWindow.js';
 import { initAutoUpdate } from './autoUpdate.js';
 import { disposeBotController, initBotController, syncBotControllerFromSettings } from './bots/botController.js';
@@ -113,6 +115,13 @@ app.whenReady().then(() => {
 
 	registerIpc();
 	lap('IPC registered');
+
+	// 自动启动已启用且 autoStart 的 MCP 服务器
+	const mcpManager = getMcpManager();
+	mcpManager.loadConfigs(getEffectiveMcpServerConfigs(getMcpServerConfigs(), restoredUsable));
+	void mcpManager.startAll().then(() => {
+		lap('MCP auto-start done');
+	});
 
 	createAppWindow({
 		surface: 'agent',

--- a/main-src/ipc/register.ts
+++ b/main-src/ipc/register.ts
@@ -52,6 +52,7 @@ import {
 	removeRecentWorkspace,
 	getMcpServerConfigs,
 	patchMcpServerConfigs,
+	addMcpServerConfig,
 	removeMcpServerConfig,
 	type UserLlmProvider,
 } from '../settingsStore.js';
@@ -3802,7 +3803,7 @@ ipcMain.handle(
 	/** 添加或更新 MCP 服务器配置 */
 	ipcMain.handle('mcp:saveServer', (event, config: McpServerConfig) => {
 		try {
-			patchMcpServerConfigs([config]);
+			addMcpServerConfig(config);
 			const manager = getMcpManager();
 			manager.loadConfigs(getEffectiveMcpServerConfigs(getMcpServerConfigs(), senderWorkspaceRoot(event)));
 			return { ok: true as const, server: config };
@@ -3837,10 +3838,10 @@ ipcMain.handle(
 	});
 
 	/** 停止 MCP 服务器 */
-	ipcMain.handle('mcp:stopServer', (_e, id: string) => {
+	ipcMain.handle('mcp:stopServer', async (_e, id: string) => {
 		try {
 			const manager = getMcpManager();
-			manager.stopServer(id);
+			await manager.stopServer(id);
 			return { ok: true as const };
 		} catch (e) {
 			return { ok: false as const, error: String(e) };

--- a/main-src/mcp/mcpClient.ts
+++ b/main-src/mcp/mcpClient.ts
@@ -230,8 +230,8 @@ export class McpClient extends EventEmitter<McpClientEvents> implements McpClien
 		}
 	}
 
-	disconnect(): void {
-		void this.closeSdk();
+	async disconnect(): Promise<void> {
+		await this.closeSdk();
 		this.setStatus('disconnected');
 	}
 

--- a/main-src/mcp/mcpFixesVerification.test.ts
+++ b/main-src/mcp/mcpFixesVerification.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { McpManager } from './mcpManager.js';
+import type { McpServerConfig, McpServerStatus } from './mcpTypes.js';
+
+function makeConfig(id: string, patch?: Partial<McpServerConfig>): McpServerConfig {
+	return {
+		id,
+		name: id,
+		enabled: true,
+		transport: 'stdio',
+		command: 'npx',
+		args: ['-y', 'demo'],
+		...patch,
+	};
+}
+
+function makeStatus(id: string, status: McpServerStatus['status']): McpServerStatus {
+	return {
+		id,
+		status,
+		tools: [],
+		resources: [],
+		prompts: [],
+	};
+}
+
+describe('MCP critical fix verification', () => {
+	it('loadConfigs does NOT destroy a client that is currently connecting', () => {
+		const manager = new McpManager();
+		const base = makeConfig('srv');
+		manager.loadConfigs([base]);
+
+		let destroyed = false;
+		(manager as any).clients.set('srv', {
+			config: base,
+			destroy() {
+				destroyed = true;
+			},
+			getServerStatus() {
+				return makeStatus('srv', 'connecting');
+			},
+		});
+
+		// Try to load a config that disables srv1
+		manager.loadConfigs([{ ...base, enabled: false }]);
+
+		expect(destroyed).toBe(false);
+		expect((manager as any).clients.has('srv')).toBe(true);
+
+		// Now simulate connection finished (error state)
+		(manager as any).clients.get('srv').getServerStatus = () => makeStatus('srv', 'error');
+		manager.loadConfigs([{ ...base, enabled: false }]);
+
+		expect(destroyed).toBe(true);
+		expect((manager as any).clients.has('srv')).toBe(false);
+	});
+
+	it('restartServer awaits disconnect before connect', async () => {
+		const manager = new McpManager();
+		const base = makeConfig('srv');
+		manager.loadConfigs([base]);
+
+		const events: string[] = [];
+		(manager as any).clients.set('srv', {
+			config: base,
+			getServerStatus() {
+				return makeStatus('srv', 'connected');
+			},
+			async disconnect() {
+				await new Promise((r) => setTimeout(r, 10));
+				events.push('disconnect-done');
+			},
+			async connect() {
+				events.push('connect');
+			},
+		});
+
+		await manager.restartServer('srv');
+		expect(events).toEqual(['disconnect-done', 'connect']);
+	});
+
+	it('loadConfigs preserves unchanged clients across reloads', () => {
+		const manager = new McpManager();
+		const base = makeConfig('srv');
+		manager.loadConfigs([base]);
+
+		let destroyed = false;
+		(manager as any).clients.set('srv', {
+			config: base,
+			destroy() {
+				destroyed = true;
+			},
+			getServerStatus() {
+				return makeStatus('srv', 'connected');
+			},
+		});
+
+		// Reload identical config
+		manager.loadConfigs([base]);
+
+		expect(destroyed).toBe(false);
+		expect((manager as any).clients.has('srv')).toBe(true);
+	});
+});

--- a/main-src/mcp/mcpManager.test.ts
+++ b/main-src/mcp/mcpManager.test.ts
@@ -85,4 +85,71 @@ describe('McpManager', () => {
 		expect(destroyed).toEqual(['srv', 'srv:changed']);
 		expect((manager as any).clients.has('srv')).toBe(false);
 	});
+
+	it('does NOT destroy a client that is currently connecting', () => {
+		const manager = new McpManager();
+		const base = makeConfig('srv');
+		manager.loadConfigs([base]);
+
+		const destroyed: string[] = [];
+		(manager as any).clients.set('srv', {
+			config: base,
+			destroy: () => {
+				destroyed.push('srv');
+			},
+			getServerStatus: () => makeStatus('srv', 'connecting'),
+		});
+
+		// Even though we disable the config, the connecting client should be protected
+		manager.loadConfigs([{ ...base, enabled: false }]);
+		expect(destroyed).toEqual([]);
+		expect((manager as any).clients.has('srv')).toBe(true);
+	});
+
+	it('allows destroying a client once it leaves connecting state', () => {
+		const manager = new McpManager();
+		const base = makeConfig('srv');
+		manager.loadConfigs([base]);
+
+		const destroyed: string[] = [];
+		const mockClient = {
+			config: base,
+			destroy: () => {
+				destroyed.push('srv');
+			},
+			getServerStatus: () => makeStatus('srv', 'connecting'),
+		};
+		(manager as any).clients.set('srv', mockClient);
+
+		// Protected while connecting
+		manager.loadConfigs([{ ...base, enabled: false }]);
+		expect(destroyed).toEqual([]);
+
+		// Simulate connection finished (error)
+		mockClient.getServerStatus = () => makeStatus('srv', 'error');
+		manager.loadConfigs([{ ...base, enabled: false }]);
+		expect(destroyed).toEqual(['srv']);
+		expect((manager as any).clients.has('srv')).toBe(false);
+	});
+
+	it('restartServer stops then starts the server', async () => {
+		const manager = new McpManager();
+		const base = makeConfig('srv');
+		manager.loadConfigs([base]);
+
+		const events: string[] = [];
+		(manager as any).clients.set('srv', {
+			config: base,
+			getServerStatus: () => makeStatus('srv', 'connected'),
+			disconnect: async () => {
+				events.push('disconnect');
+			},
+			connect: async () => {
+				events.push('connect');
+			},
+		});
+
+		await manager.restartServer('srv');
+		expect(events).toEqual(['disconnect', 'connect']);
+	});
 });

--- a/main-src/mcp/mcpManager.ts
+++ b/main-src/mcp/mcpManager.ts
@@ -124,6 +124,11 @@ export class McpManager extends EventEmitter<McpManagerEvents> {
 				this.clients.delete(id);
 				continue;
 			}
+			const clientStatus = client.getServerStatus().status;
+			// 保护正在连接中的 client，避免并发操作导致状态混乱
+			if (clientStatus === 'connecting') {
+				continue;
+			}
 			if (!next.enabled || !mcpConfigsEquivalent(client.config, next)) {
 				client.destroy();
 				this.clients.delete(id);
@@ -176,16 +181,16 @@ export class McpManager extends EventEmitter<McpManagerEvents> {
 	}
 
 	/** 停止单个服务器 */
-	stopServer(id: string): void {
+	async stopServer(id: string): Promise<void> {
 		const client = this.clients.get(id);
 		if (client) {
-			client.disconnect();
+			await client.disconnect();
 		}
 	}
 
 	/** 重启服务器 */
 	async restartServer(id: string): Promise<void> {
-		this.stopServer(id);
+		await this.stopServer(id);
 		await this.startServer(id);
 	}
 

--- a/src/AgentChatPanel.tsx
+++ b/src/AgentChatPanel.tsx
@@ -1348,7 +1348,7 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 			turnOwnerUserIndex,
 			isTurnStart,
 			stickyUserIndex: isTurnStart ? messageIndex : null,
-			className: 'ref-msg-row-measure',
+			className: `ref-msg-row-measure${message.role === 'assistant' ? ' ref-msg-row-measure--assistant' : ''}`,
 			dataMsgIndex: messageIndex,
 			content: messageNodeAtIndex(messageIndex),
 		};
@@ -1702,16 +1702,67 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 			</div>
 		);
 	});
-	if (activeTurnSpacerPx > 0) {
-		renderedChatRowNodes.push(
+	const tailSpacerNode =
+		activeTurnSpacerPx > 0 ? (
 			<div
 				key={`row-${conversationRenderKey}-turn-focus-tail`}
 				className="ref-messages-tail-spacer"
 				style={{ height: `${activeTurnSpacerPx}px` }}
 				aria-hidden
 			/>
-		);
-	}
+		) : null;
+
+	/* 按 turn 分组：同一轮次的消息包在一个 ref-turn-container 内，
+	   容器之间用 padding-bottom 提供 assistant → 下一条 user 的安全距离。
+	   tail spacer 放在所有 turn 容器之后，不参与 turn 分组。
+	   滚动位置由 useMessagesScroll.ts 基于“最后内容行底部”计算，
+	   不受容器 padding 或 tail spacer 影响。 */
+	const renderTurnContainers = (): ReactNode[] => {
+		const containers: ReactNode[] = [];
+		let currentTurnNodes: ReactNode[] = [];
+		let currentTurnOwner: string | null = null;
+
+		for (const node of renderedChatRowNodes) {
+			const isTurnStart = (node as JSX.Element).props['data-turn-start'] === 'true';
+			const turnOwner = (node as JSX.Element).props['data-turn-owner'];
+
+			if (isTurnStart && currentTurnNodes.length > 0) {
+				containers.push(
+					<div
+						key={`turn-${currentTurnOwner}-${containers.length}`}
+						className="ref-turn-container"
+						data-turn-owner={currentTurnOwner ?? undefined}
+					>
+						{currentTurnNodes}
+					</div>
+				);
+				currentTurnNodes = [];
+			}
+
+			currentTurnNodes.push(node);
+			if (isTurnStart) {
+				currentTurnOwner = turnOwner ?? null;
+			}
+		}
+
+		if (currentTurnNodes.length > 0) {
+			containers.push(
+				<div
+					key={`turn-${currentTurnOwner}-${containers.length}`}
+					className="ref-turn-container"
+					data-turn-owner={currentTurnOwner ?? undefined}
+				>
+					{currentTurnNodes}
+				</div>
+			);
+		}
+
+		if (tailSpacerNode) {
+			containers.push(tailSpacerNode);
+		}
+
+		return containers;
+	};
 
 	const dataTransferHasFiles = (dt: DataTransfer | null): boolean => !!dt?.types?.includes('Files');
 
@@ -1779,7 +1830,7 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 						aria-hidden
 					/>
 				) : null}
-				{renderedChatRowNodes}
+				{renderTurnContainers()}
 			</div>
 		</div>
 	) : null;

--- a/src/AgentChatPanel.tsx
+++ b/src/AgentChatPanel.tsx
@@ -1,4 +1,5 @@
 import {
+	isValidElement,
 	memo,
 	useCallback,
 	useDeferredValue,
@@ -649,6 +650,7 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 		if (!viewport || !track) {
 			return [];
 		}
+		const viewportRect = viewport.getBoundingClientRect();
 		const rowsById = new Map(renderRowsRef.current.map((row) => [row.rowId, row]));
 		return Array.from(
 			track.querySelectorAll<HTMLElement>('.ref-msg-row-measure[data-row-id]')
@@ -659,16 +661,23 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 				if (!meta) {
 					return null;
 				}
-				const height = rowEl.offsetHeight || Math.ceil(rowEl.getBoundingClientRect().height);
+				/**
+				 * 不能用 offsetTop：在 editor-rail 下 offsetParent 可能是外层
+				 * .ref-chat-drop-zone（position:relative），不是 viewport/track，
+				 * 参考系会错乱，sticky user 选中就会在滚动过程中抖动甚至闪烁。
+				 */
+				const rowRect = rowEl.getBoundingClientRect();
+				const top = rowRect.top - viewportRect.top;
+				const height = Math.max(0, Math.ceil(rowRect.height) || rowEl.offsetHeight);
 				return {
 					rowId: meta.rowId,
 					messageIndex: meta.messageIndex,
 					turnOwnerUserIndex: meta.turnOwnerUserIndex,
 					isTurnStart: meta.isTurnStart,
 					stickyUserIndex: meta.stickyUserIndex,
-					top: rowEl.offsetTop - viewport.scrollTop,
-					height: Math.max(0, height),
-					offsetTop: rowEl.offsetTop,
+					top,
+					height,
+					offsetTop: Math.max(0, viewport.scrollTop + top),
 				};
 			})
 			.filter((row): row is MeasuredTurnFocusRow => row != null);
@@ -967,7 +976,7 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 		const renderedRows = collectMeasuredTurnRows();
 		const nextStickyIndex = findStickyUserIndexForViewport({
 			renderedRows,
-			stickyTopPx: 0,
+			stickyTopPx: stickyUserTopPx,
 			latestTurnStartUserIndex,
 			latestTurnSpacerPx: activeTurnSpacerPx,
 		});
@@ -1029,6 +1038,7 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 		hasConversation,
 		lastMessageLayoutSig,
 		activeTurnSpacerPx,
+		stickyUserTopPx,
 		latestTurnStartUserIndex,
 		messageStartIndex,
 		shouldUseStableTeamLiveLayout,
@@ -1721,10 +1731,19 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 		const containers: ReactNode[] = [];
 		let currentTurnNodes: ReactNode[] = [];
 		let currentTurnOwner: string | null = null;
+		type TurnContainerNodeProps = {
+			'data-turn-start'?: string;
+			'data-turn-owner'?: string;
+		};
 
 		for (const node of renderedChatRowNodes) {
-			const isTurnStart = (node as JSX.Element).props['data-turn-start'] === 'true';
-			const turnOwner = (node as JSX.Element).props['data-turn-owner'];
+			if (!isValidElement<TurnContainerNodeProps>(node)) {
+				currentTurnNodes.push(node);
+				continue;
+			}
+			const isTurnStart = node.props['data-turn-start'] === 'true';
+			const turnOwner =
+				typeof node.props['data-turn-owner'] === 'string' ? node.props['data-turn-owner'] : null;
 
 			if (isTurnStart && currentTurnNodes.length > 0) {
 				containers.push(

--- a/src/SettingsMcpJsonEditor.tsx
+++ b/src/SettingsMcpJsonEditor.tsx
@@ -1,0 +1,158 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useI18n } from './i18n';
+import type { McpServerConfig, McpServerTemplate } from './mcpTypes';
+import { exportMcpServersToJson, parseMcpServersJson } from './mcpJsonUtils';
+
+export type SettingsMcpJsonEditorProps = {
+	servers: McpServerConfig[];
+	onChangeServers: (servers: McpServerConfig[]) => void;
+	templates: McpServerTemplate[];
+};
+
+function templateToJsonSnippet(template: McpServerTemplate): string {
+	const server: Partial<McpServerConfig> = {
+		name: template.name,
+		transport: template.transport,
+		enabled: true,
+		autoStart: true,
+		timeout: 30000,
+	};
+	if (template.command) server.command = template.command;
+	if (template.args) server.args = template.args;
+	if (template.env) server.env = template.env;
+	if (template.url) server.url = template.url;
+	return JSON.stringify(server, null, 2);
+}
+
+export function SettingsMcpJsonEditor({ servers, onChangeServers, templates }: SettingsMcpJsonEditorProps) {
+	const { t } = useI18n();
+	const initialJson = useMemo(() => exportMcpServersToJson(servers), []);
+	const [jsonText, setJsonText] = useState(initialJson);
+	const [error, setError] = useState<string | null>(null);
+
+	const handleChange = useCallback((value: string) => {
+		setJsonText(value);
+		const result = parseMcpServersJson(value);
+		if (result.ok) {
+			setError(null);
+			onChangeServers(result.servers);
+		} else {
+			setError(result.error);
+		}
+	}, [onChangeServers]);
+
+	const handleExport = useCallback(() => {
+		const blob = new Blob([jsonText], { type: 'application/json' });
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement('a');
+		a.href = url;
+		a.download = 'mcp-servers.json';
+		a.click();
+		URL.revokeObjectURL(url);
+	}, [jsonText]);
+
+	const handleCopy = useCallback(async () => {
+		try {
+			await navigator.clipboard.writeText(jsonText);
+		} catch {
+			// ignore
+		}
+	}, [jsonText]);
+
+	const handleImport = useCallback(() => {
+		const input = document.createElement('input');
+		input.type = 'file';
+		input.accept = '.json,application/json';
+		input.onchange = async () => {
+			const file = input.files?.[0];
+			if (!file) return;
+			try {
+				const text = await file.text();
+				setJsonText(text);
+				const result = parseMcpServersJson(text);
+				if (result.ok) {
+					setError(null);
+					onChangeServers(result.servers);
+				} else {
+					setError(result.error);
+				}
+			} catch {
+				setError('Failed to read file');
+			}
+		};
+		input.click();
+	}, [onChangeServers]);
+
+	const insertTemplate = useCallback((template: McpServerTemplate) => {
+		const snippet = templateToJsonSnippet(template);
+		let nextText = jsonText.trim();
+		// 尝试以当前内容为基础插入；如果当前不是合法数组，则重置为单元素数组
+		const currentParse = parseMcpServersJson(nextText);
+		if (!currentParse.ok || nextText === '[]') {
+			nextText = `[\n  ${snippet.replace(/\n/g, '\n  ')}\n]`;
+		} else if (nextText.endsWith(']')) {
+			// 插入到数组末尾
+			const lastBracket = nextText.lastIndexOf(']');
+			const beforeLastBracket = nextText.slice(0, lastBracket);
+			const trimmed = beforeLastBracket.trimEnd();
+			const needsComma = trimmed.length > 1 && (trimmed.endsWith('}') || trimmed.endsWith(']'));
+			nextText = `${trimmed}${needsComma ? ',' : ''}\n  ${snippet.replace(/\n/g, '\n  ')}\n]`;
+		} else {
+			nextText = `[\n  ${snippet.replace(/\n/g, '\n  ')}\n]`;
+		}
+		setJsonText(nextText);
+		const result = parseMcpServersJson(nextText);
+		if (result.ok) {
+			setError(null);
+			onChangeServers(result.servers);
+		} else {
+			setError(result.error);
+		}
+	}, [jsonText, onChangeServers]);
+
+	return (
+		<div className="ref-mcp-json-editor">
+			<div className="ref-mcp-json-toolbar">
+				<div className="ref-mcp-json-actions">
+					<button type="button" className="ref-mcp-json-btn" onClick={handleImport}>
+						{t('mcp.importJson')}
+					</button>
+					<button type="button" className="ref-mcp-json-btn" onClick={handleCopy}>
+						{t('mcp.copyJson')}
+					</button>
+					<button type="button" className="ref-mcp-json-btn" onClick={handleExport}>
+						{t('mcp.exportJson')}
+					</button>
+				</div>
+				<div className="ref-mcp-json-templates">
+					<span className="ref-mcp-json-templates-label">{t('mcp.templates')}:</span>
+					{templates.map((templ) => (
+						<button
+							key={templ.id}
+							type="button"
+							className="ref-mcp-json-template-chip"
+							onClick={() => insertTemplate(templ)}
+							title={templ.description}
+						>
+							{templ.name}
+						</button>
+					))}
+				</div>
+			</div>
+			<textarea
+				className={`ref-mcp-json-textarea ${error ? 'ref-mcp-json-textarea--error' : ''}`}
+				value={jsonText}
+				onChange={(e) => handleChange(e.target.value)}
+				spellCheck={false}
+			/>
+			{error ? (
+				<div className="ref-mcp-json-error">
+					<span>{t('mcp.jsonInvalid')}: {error}</span>
+				</div>
+			) : null}
+			<div className="ref-mcp-json-hint">
+				<span>{t('mcp.jsonHint')}</span>
+			</div>
+		</div>
+	);
+}

--- a/src/SettingsMcpPanel.tsx
+++ b/src/SettingsMcpPanel.tsx
@@ -6,6 +6,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useI18n } from './i18n';
 import { formatMcpCommandPreview, serializeMcpArgs, serializeMcpKeyValueEntries } from './mcpFormUtils';
+import { SettingsMcpJsonEditor } from './SettingsMcpJsonEditor';
 import { VoidSelect } from './VoidSelect';
 import type { McpServerConfig, McpServerStatus, McpServerTemplate } from './mcpTypes';
 import { MCP_SERVER_TEMPLATES } from './mcpTypes';
@@ -567,9 +568,21 @@ type McpServerRowProps = {
 	onEdit?: () => void;
 	onDelete?: () => void;
 	readOnly?: boolean;
+	pendingAction?: 'start' | 'stop' | 'restart';
+	actionError?: string | null;
 };
 
-function deriveDisplayMcpStatus(config: McpServerConfig, status: McpServerStatus | null): DisplayMcpStatus {
+function deriveDisplayMcpStatus(
+	config: McpServerConfig,
+	status: McpServerStatus | null,
+	pendingAction?: 'start' | 'stop' | 'restart'
+): DisplayMcpStatus {
+	if (pendingAction === 'start' || pendingAction === 'restart') {
+		return 'connecting';
+	}
+	if (pendingAction === 'stop') {
+		return 'stopped';
+	}
 	if (!config.enabled) {
 		return 'disabled';
 	}
@@ -601,11 +614,13 @@ function McpServerRow({
 	toggleBusy = false,
 	onDelete,
 	readOnly = false,
+	pendingAction,
+	actionError,
 }: McpServerRowProps) {
 	const { t } = useI18n();
 	const [expanded, setExpanded] = useState(false);
 	
-	const currentStatus = deriveDisplayMcpStatus(config, status);
+	const currentStatus = deriveDisplayMcpStatus(config, status, pendingAction);
 	const tools = status?.tools ?? [];
 	
 	return (
@@ -628,13 +643,13 @@ function McpServerRow({
 							<input
 								type="checkbox"
 								checked={config.enabled}
-								disabled={toggleBusy}
+								disabled={toggleBusy || !!pendingAction}
 								onChange={(e) => onToggleEnabled(e.target.checked)}
 							/>
 							<span>{t('mcp.form.enabled')}</span>
 						</label>
 					) : null}
-					{config.enabled
+					{config.enabled && !pendingAction
 						? currentStatus === 'connected' ? (
 								<>
 									<button type="button" className="ref-mcp-server-action" onClick={onStop} title={t('mcp.action.stop')}>
@@ -671,6 +686,13 @@ function McpServerRow({
 					) : null}
 				</div>
 			</div>
+
+			{actionError ? (
+				<div className="ref-mcp-server-error">
+					<IconAlert />
+					<span>{actionError}</span>
+				</div>
+			) : null}
 			
 			{tools.length > 0 ? (
 				<div className="ref-mcp-server-tools">
@@ -734,9 +756,9 @@ export function SettingsMcpPanel({
 	statuses,
 	onChangeServers,
 	onRefreshStatuses,
-	onStartServer,
-	onStopServer,
-	onRestartServer,
+	onStartServer: _onStartServer,
+	onStopServer: _onStopServer,
+	onRestartServer: _onRestartServer,
 	shell,
 }: SettingsMcpPanelProps) {
 	const { t } = useI18n();
@@ -744,8 +766,11 @@ export function SettingsMcpPanel({
 	const [editingId, setEditingId] = useState<string | null>(null);
 	const [editingConfig, setEditingConfig] = useState<McpServerConfig | null>(null);
 	const [showTemplates, setShowTemplates] = useState(false);
+	const [editMode, setEditMode] = useState<'visual' | 'json'>('visual');
 	const [pluginServers, setPluginServers] = useState<McpServerConfig[]>([]);
 	const [pendingPluginToggleIds, setPendingPluginToggleIds] = useState<string[]>([]);
+	const [pendingActions, setPendingActions] = useState<Record<string, 'start' | 'stop' | 'restart'>>({});
+	const [actionErrors, setActionErrors] = useState<Record<string, string>>({});
 	
 	const statusMap = useMemo(() => {
 		const map = new Map<string, McpServerStatus>();
@@ -796,6 +821,77 @@ export function SettingsMcpPanel({
 	const deleteServer = useCallback((id: string) => {
 		onChangeServers(servers.filter(s => s.id !== id));
 	}, [servers, onChangeServers]);
+
+	const clearActionError = useCallback((id: string) => {
+		setActionErrors((prev) => {
+			const next = { ...prev };
+			delete next[id];
+			return next;
+		});
+	}, []);
+
+	const handleStartServer = useCallback(
+		async (id: string) => {
+			clearActionError(id);
+			setPendingActions((prev) => ({ ...prev, [id]: 'start' }));
+			try {
+				const result = (await shell?.invoke('mcp:startServer', id)) as { ok?: boolean; error?: string } | undefined;
+				if (result?.ok === false && result.error) {
+					setActionErrors((prev) => ({ ...prev, [id]: result.error! }));
+				}
+			} finally {
+				setPendingActions((prev) => {
+					const next = { ...prev };
+					delete next[id];
+					return next;
+				});
+				await onRefreshStatuses();
+			}
+		},
+		[shell, onRefreshStatuses, clearActionError]
+	);
+
+	const handleStopServer = useCallback(
+		async (id: string) => {
+			clearActionError(id);
+			setPendingActions((prev) => ({ ...prev, [id]: 'stop' }));
+			try {
+				const result = (await shell?.invoke('mcp:stopServer', id)) as { ok?: boolean; error?: string } | undefined;
+				if (result?.ok === false && result.error) {
+					setActionErrors((prev) => ({ ...prev, [id]: result.error! }));
+				}
+			} finally {
+				setPendingActions((prev) => {
+					const next = { ...prev };
+					delete next[id];
+					return next;
+				});
+				await onRefreshStatuses();
+			}
+		},
+		[shell, onRefreshStatuses, clearActionError]
+	);
+
+	const handleRestartServer = useCallback(
+		async (id: string) => {
+			clearActionError(id);
+			setPendingActions((prev) => ({ ...prev, [id]: 'restart' }));
+			try {
+				const result = (await shell?.invoke('mcp:restartServer', id)) as { ok?: boolean; error?: string } | undefined;
+				if (result?.ok === false && result.error) {
+					setActionErrors((prev) => ({ ...prev, [id]: result.error! }));
+				}
+			} finally {
+				setPendingActions((prev) => {
+					const next = { ...prev };
+					delete next[id];
+					return next;
+				});
+				await onRefreshStatuses();
+			}
+		},
+		[shell, onRefreshStatuses, clearActionError]
+	);
 	
 	const applyTemplate = useCallback((template: McpServerTemplate) => {
 		const newConfig: McpServerConfig = {
@@ -843,13 +939,13 @@ export function SettingsMcpPanel({
 			if (enabled) {
 				await onRefreshStatuses();
 			} else {
-				await onStopServer(config.id);
+				await handleStopServer(config.id);
 			}
 			setPluginServers(await listPluginServers());
 		} finally {
 			setPendingPluginToggleIds((prev) => prev.filter((id) => id !== config.id));
 		}
-	}, [listPluginServers, onRefreshStatuses, onStopServer, shell]);
+	}, [listPluginServers, onRefreshStatuses, handleStopServer, shell]);
 	
 	// Auto-refresh statuses on mount
 	useEffect(() => {
@@ -895,9 +991,25 @@ export function SettingsMcpPanel({
 				<button type="button" className="ref-settings-mcp-refresh" onClick={onRefreshStatuses} title={t('common.refresh')}>
 					<IconRefresh />
 				</button>
+				<div className="ref-settings-mcp-mode-switch">
+					<button
+						type="button"
+						className={editMode === 'visual' ? 'ref-settings-mcp-mode--active' : ''}
+						onClick={() => setEditMode('visual')}
+					>
+						{t('mcp.visualMode')}
+					</button>
+					<button
+						type="button"
+						className={editMode === 'json' ? 'ref-settings-mcp-mode--active' : ''}
+						onClick={() => setEditMode('json')}
+					>
+						{t('mcp.jsonMode')}
+					</button>
+				</div>
 			</div>
 			
-			{showTemplates ? (
+			{showTemplates && editMode === 'visual' ? (
 				<div className="ref-settings-mcp-templates-panel">
 					<p className="ref-settings-mcp-templates-hint">{t('mcp.templatesHint')}</p>
 					<ul className="ref-settings-mcp-templates-list">
@@ -916,8 +1028,16 @@ export function SettingsMcpPanel({
 					</ul>
 				</div>
 			) : null}
+
+			{editMode === 'json' ? (
+				<SettingsMcpJsonEditor
+					servers={servers}
+					onChangeServers={onChangeServers}
+					templates={MCP_SERVER_TEMPLATES}
+				/>
+			) : null}
 			
-			{editingId && editingConfig ? (
+			{editingId && editingConfig && editMode === 'visual' ? (
 				<div className="ref-settings-mcp-edit-wrap">
 					<h3 className="ref-settings-mcp-edit-title">
 						{servers.some(s => s.id === editingId) ? t('mcp.editServer') : t('mcp.newServer')}
@@ -936,28 +1056,32 @@ export function SettingsMcpPanel({
 				</div>
 			) : null}
 			
-			<section className="ref-settings-mcp-servers">
-				<h2 className="ref-settings-mcp-servers-title">{t('mcp.serversTitle')}</h2>
-				{servers.length === 0 ? (
-					<p className="ref-settings-mcp-empty">{t('mcp.noServers')}</p>
-				) : (
-					<ul className="ref-settings-mcp-servers-list">
-						{servers.map((config) => (
-							<li key={config.id}>
-								<McpServerRow
-									config={config}
-									status={statusMap.get(config.id) ?? null}
-									onEdit={() => startEdit(config)}
-									onStart={() => onStartServer(config.id)}
-									onStop={() => onStopServer(config.id)}
-									onRestart={() => onRestartServer(config.id)}
-									onDelete={() => deleteServer(config.id)}
-								/>
-							</li>
-						))}
-					</ul>
-				)}
-			</section>
+			{editMode === 'visual' ? (
+				<section className="ref-settings-mcp-servers">
+					<h2 className="ref-settings-mcp-servers-title">{t('mcp.serversTitle')}</h2>
+					{servers.length === 0 ? (
+						<p className="ref-settings-mcp-empty">{t('mcp.noServers')}</p>
+					) : (
+						<ul className="ref-settings-mcp-servers-list">
+							{servers.map((config) => (
+								<li key={config.id}>
+									<McpServerRow
+										config={config}
+										status={statusMap.get(config.id) ?? null}
+										onEdit={() => startEdit(config)}
+										onStart={() => handleStartServer(config.id)}
+										onStop={() => handleStopServer(config.id)}
+										onRestart={() => handleRestartServer(config.id)}
+										onDelete={() => deleteServer(config.id)}
+										pendingAction={pendingActions[config.id]}
+										actionError={actionErrors[config.id] ?? null}
+									/>
+								</li>
+							))}
+						</ul>
+					)}
+				</section>
+			) : null}
 
 			{pluginServers.length > 0 ? (
 				<section className="ref-settings-mcp-servers">
@@ -969,9 +1093,9 @@ export function SettingsMcpPanel({
 								<McpServerRow
 									config={config}
 									status={statusMap.get(config.id) ?? null}
-									onStart={() => onStartServer(config.id)}
-									onStop={() => onStopServer(config.id)}
-									onRestart={() => onRestartServer(config.id)}
+									onStart={() => handleStartServer(config.id)}
+									onStop={() => handleStopServer(config.id)}
+									onRestart={() => handleRestartServer(config.id)}
 									onToggleEnabled={(next) => void togglePluginServerEnabled(config, next)}
 									toggleBusy={pendingPluginToggleIds.includes(config.id)}
 									readOnly

--- a/src/agentTurnFocus.test.ts
+++ b/src/agentTurnFocus.test.ts
@@ -24,7 +24,7 @@ function row(params: Partial<MeasuredTurnFocusRow> & Pick<MeasuredTurnFocusRow, 
 }
 
 describe('agentTurnFocus', () => {
-	it('targets the latest user turn only when there is earlier replied history', () => {
+	it('targets the latest user turn so every new prompt becomes the active sticky anchor', () => {
 		const displayMessages: ChatMessage[] = [
 			{ role: 'user', content: '第一轮提问' },
 			{ role: 'assistant', content: '第一轮回复' },
@@ -57,7 +57,9 @@ describe('agentTurnFocus', () => {
 		).toBe(2);
 	});
 
-	it('does not enable turn focus for the first turn or team bootstrapping without supplemental rows', () => {
+	it('keeps the first non-team prompt anchored as soon as a user bubble exists', () => {
+		// 让第一轮也参与 spacer / sticky 机制：assistant 流式增长时不会再把
+		// 用户气泡推出视口或与气泡顶部叠加。
 		expect(
 			findLatestTurnStartUserIndex(
 				[
@@ -66,17 +68,7 @@ describe('agentTurnFocus', () => {
 				],
 				'ask'
 			)
-		).toBeNull();
-
-		expect(
-			findLatestTurnStartUserIndex(
-				[
-					{ role: 'user', content: 'team 消息' },
-					{ role: 'assistant', content: '流式中' },
-				],
-				'team'
-			)
-		).toBeNull();
+		).toBe(0);
 
 		expect(
 			findLatestTurnStartUserIndex(
@@ -85,6 +77,19 @@ describe('agentTurnFocus', () => {
 					{ role: 'assistant', content: '普通回复' },
 				],
 				'agent'
+			)
+		).toBe(0);
+	});
+
+	it('still skips turn focus for team bootstrapping when no supplemental row appeared yet', () => {
+		// team 模式下用户气泡之后会被 leader/plan 卡片接管布局，没有补充行时仍然不锚定。
+		expect(
+			findLatestTurnStartUserIndex(
+				[
+					{ role: 'user', content: 'team 消息' },
+					{ role: 'assistant', content: '流式中' },
+				],
+				'team'
 			)
 		).toBeNull();
 	});

--- a/src/agentTurnFocus.ts
+++ b/src/agentTurnFocus.ts
@@ -45,10 +45,13 @@ export function findLatestTurnStartUserIndex(
 	if (composerMode === 'team') {
 		return hasSupplementalContentAfterUser ? userIndex : null;
 	}
-	const hasEarlierAssistant = displayMessages
-		.slice(0, userIndex)
-		.some((message) => message.role === 'assistant');
-	return hasEarlierAssistant ? userIndex : null;
+	/**
+	 * 非 team 模式：始终把最新一条用户消息作为「轮次锚点」，让 spacer + sticky 机制
+	 * 即使在第一轮（没有更早的 assistant 历史）也能生效。这样每条新提问都会像 ChatGPT
+	 * 那样直接吸到视口顶部、回复在气泡正下方流出，而不会出现 assistant 长度超过
+	 * `clientHeight - paddings - bubbleHeight` 时被气泡的不透明背景盖住顶部的视觉 bug。
+	 */
+	return userIndex;
 }
 
 export function computeTurnSectionSpacerPx(params: {

--- a/src/hooks/useMessagesScroll.ts
+++ b/src/hooks/useMessagesScroll.ts
@@ -50,6 +50,26 @@ export type UseMessagesScrollResult = {
 	syncMessagesScrollIndicators: () => void;
 };
 
+/** 计算滚动位置时，以「最后一条内容行（带 data-msg-index）的底部」为准，
+ *  而不是 track 的 scrollHeight 底部。这样 turn 容器 padding、tail spacer 等
+ *  纯装饰性高度不会把视口顶下去，避免消息被 sticky bubble 遮挡。 */
+function resolveContentBottomScroll(
+	viewport: HTMLElement,
+	track: HTMLElement | null
+): number {
+	if (!track) {
+		return Math.max(0, viewport.scrollHeight - viewport.clientHeight);
+	}
+	const lastContentRow = track.querySelector<HTMLElement>(
+		'.ref-msg-row-measure[data-msg-index]:last-of-type'
+	);
+	if (!lastContentRow) {
+		return Math.max(0, viewport.scrollHeight - viewport.clientHeight);
+	}
+	const contentBottom = lastContentRow.offsetTop + lastContentRow.offsetHeight;
+	return Math.max(0, contentBottom - viewport.clientHeight);
+}
+
 export function measureMessagesScroll(
 	viewport: Pick<HTMLElement, 'scrollHeight' | 'clientHeight' | 'scrollTop'>
 ): MessagesScrollMetrics {
@@ -147,7 +167,18 @@ export function useMessagesScroll(params: UseMessagesScrollParams): UseMessagesS
 			if (!el) {
 				return;
 			}
-			const metrics = measureMessagesScroll(el);
+			const rawMetrics = measureMessagesScroll(el);
+			const track = messagesTrackRef.current;
+			const contentMaxScroll = resolveContentBottomScroll(el, track);
+			const metrics: MessagesScrollMetrics = {
+				maxScroll: contentMaxScroll,
+				clampedTop: rawMetrics.clampedTop,
+				distanceFromBottom: Math.max(0, contentMaxScroll - rawMetrics.clampedTop),
+				nearBottom:
+					Math.max(0, contentMaxScroll - rawMetrics.clampedTop) <
+					MESSAGES_FOLLOW_BOTTOM_BUFFER_PX,
+				canJumpToBottom: contentMaxScroll > MESSAGES_MIN_SCROLLABLE_OVERFLOW_PX,
+			};
 			pinMessagesToBottomRef.current = derivePinnedBottomIntent(
 				pinMessagesToBottomRef.current,
 				metrics,
@@ -177,7 +208,7 @@ export function useMessagesScroll(params: UseMessagesScrollParams): UseMessagesS
 				prev === shouldShowJumpButton ? prev : shouldShowJumpButton
 			);
 		},
-		[currentIdRef, messagesThreadIdRef, clearScrollToBottomButtonSuppression]
+		[currentIdRef, messagesThreadIdRef, clearScrollToBottomButtonSuppression, messagesTrackRef]
 	);
 
 	const syncMessagesScrollIndicators = useCallback(() => {
@@ -208,8 +239,9 @@ export function useMessagesScroll(params: UseMessagesScrollParams): UseMessagesS
 				clearScrollToBottomButtonSuppression();
 			}
 			setShowScrollToBottomButton(false);
-			const maxScroll = Math.max(0, el.scrollHeight - el.clientHeight);
-			el.scrollTo({ top: maxScroll, behavior });
+			const track = messagesTrackRef.current;
+			const targetScroll = resolveContentBottomScroll(el, track);
+			el.scrollTo({ top: targetScroll, behavior });
 			syncMessagesScrollState('programmatic');
 		},
 		[clearScrollToBottomButtonSuppression, syncMessagesScrollState]
@@ -228,8 +260,8 @@ export function useMessagesScroll(params: UseMessagesScrollParams): UseMessagesS
 			if (!el || !pinMessagesToBottomRef.current) {
 				return;
 			}
-			const maxScroll = Math.max(0, el.scrollHeight - el.clientHeight);
-			el.scrollTop = maxScroll;
+			const track = messagesTrackRef.current;
+			el.scrollTop = resolveContentBottomScroll(el, track);
 			syncMessagesScrollState('programmatic');
 		});
 	}, [syncMessagesScrollState]);
@@ -263,8 +295,8 @@ export function useMessagesScroll(params: UseMessagesScrollParams): UseMessagesS
 				return;
 			}
 			pinMessagesToBottomRef.current = true;
-			const maxScroll = Math.max(0, el.scrollHeight - el.clientHeight);
-			el.scrollTop = maxScroll;
+			const track = messagesTrackRef.current;
+			el.scrollTop = resolveContentBottomScroll(el, track);
 			pendingMessagesScrollRestoreRef.current = null;
 			syncMessagesScrollState('programmatic');
 		});
@@ -282,9 +314,24 @@ export function useMessagesScroll(params: UseMessagesScrollParams): UseMessagesS
 			messages[len - 1]?.role === 'user'
 		) {
 			pinMessagesToBottomRef.current = true;
+			/**
+			 * 「新提问后把气泡顶到视口顶部」依赖 AgentChatPanel 的 activeTurnSpacerPx：
+			 * 该 spacer 在另一个 useLayoutEffect 里通过 setState 计算，会触发 React 在
+			 * paint 之前的同步重渲。如果这里立即 scrollTo(maxScroll)，使用的还是「没有
+			 * spacer 时」的 scrollHeight，导致用户气泡先停在视口中部/底部、流式回复一冒
+			 * 出来就和气泡叠在同一行；气泡背景不透明（var(--void-bg-3)）+ z-index:8 会
+			 * 把回复的顶部完全盖住。
+			 *
+			 * 改为先调用 scheduleMessagesScrollToBottom（rAF 内读取最新 scrollHeight），
+			 * 再追加一帧补滚，覆盖 spacer 因 ResizeObserver/补测量而再度变化的情形。
+			 */
 			scrollMessagesToBottom('auto');
+			scheduleMessagesScrollToBottom();
+			window.requestAnimationFrame(() => {
+				scheduleMessagesScrollToBottom();
+			});
 		}
-	}, [messages, currentId, messagesThreadId, scrollMessagesToBottom]);
+	}, [messages, currentId, messagesThreadId, scrollMessagesToBottom, scheduleMessagesScrollToBottom]);
 
 	useLayoutEffect(() => {
 		if (!hasConversation || !pinMessagesToBottomRef.current) {

--- a/src/hooks/useMessagesScroll.ts
+++ b/src/hooks/useMessagesScroll.ts
@@ -66,8 +66,13 @@ function resolveContentBottomScroll(
 	if (!lastContentRow) {
 		return Math.max(0, viewport.scrollHeight - viewport.clientHeight);
 	}
-	const contentBottom = lastContentRow.offsetTop + lastContentRow.offsetHeight;
-	return Math.max(0, contentBottom - viewport.clientHeight);
+	/* 必须用 getBoundingClientRect 而非 offsetTop，因为 offsetParent
+	   在 editor-rail 等布局下可能是外层 ref-chat-drop-zone（position:relative），
+	   而不是 track 本身，导致参考系不一致。 */
+	const rowRect = lastContentRow.getBoundingClientRect();
+	const viewportRect = viewport.getBoundingClientRect();
+	const rowBottomInViewport = rowRect.bottom - viewportRect.top;
+	return Math.max(0, viewport.scrollTop + rowBottomInViewport - viewport.clientHeight);
 }
 
 export function measureMessagesScroll(

--- a/src/i18n/messages.en.ts
+++ b/src/i18n/messages.en.ts
@@ -2105,6 +2105,13 @@ export const messagesEn: Record<string, string> = {
 	'mcp.lastConnected': 'Last connected',
 	'mcp.neverConnected': 'Never connected',
 	'mcp.connectionError': 'Connection error',
+	'mcp.jsonMode': 'JSON',
+	'mcp.visualMode': 'Visual',
+	'mcp.jsonInvalid': 'Invalid JSON',
+	'mcp.importJson': 'Import JSON',
+	'mcp.exportJson': 'Export JSON',
+	'mcp.copyJson': 'Copy JSON',
+	'mcp.jsonHint': 'Edit the server array directly, or paste a Claude Desktop { mcpServers: {} } config to import.',
 
 	// common additions
 	'common.yes': 'Yes',

--- a/src/i18n/messages.zh-CN.ts
+++ b/src/i18n/messages.zh-CN.ts
@@ -2081,6 +2081,13 @@ export const messagesZhCN: Record<string, string> = {
 	'mcp.lastConnected': '上次连接',
 	'mcp.neverConnected': '从未连接',
 	'mcp.connectionError': '连接错误',
+	'mcp.jsonMode': 'JSON 模式',
+	'mcp.visualMode': '可视化',
+	'mcp.jsonInvalid': 'JSON 格式错误',
+	'mcp.importJson': '导入 JSON',
+	'mcp.exportJson': '导出 JSON',
+	'mcp.copyJson': '复制 JSON',
+	'mcp.jsonHint': '支持直接编辑配置数组，或粘贴 Claude Desktop 的 { mcpServers: {} } 格式进行导入。',
 
 	// common additions
 	'common.yes': '是',

--- a/src/index.css
+++ b/src/index.css
@@ -3378,6 +3378,20 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 	flex-shrink: 0;
 }
 
+
+
+.ref-turn-container {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 22px;
+	width: 100%;
+}
+
+.ref-turn-container:not(:last-child) {
+	padding-bottom: 50px;
+}
+
 .ref-messages-tail-spacer {
 	width: 100%;
 	flex-shrink: 0;
@@ -3411,7 +3425,19 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 	}
 }
 
-/* ?????????? .ref-messages ???????????????????? */
+/* sticky 用户气泡：保持在 .ref-messages 视口顶部。
+ *
+ * 注意：这里不能放任何 padding/margin（特别是 margin-top）。
+ * 父容器是 flex column + gap:22；如果给本 row 设 margin-top: -4，
+ * 整行的 flex outer-top 会随之上移 4px，下一条 row（user 气泡正下方
+ * 的 preflight「正在分析」容器）也会跟着上移 4px，导致：
+ *   - 第一条（无 sticky 包装）：气泡 ↔ preflight = gap22 + preflightMargin(-8) = 14px
+ *   - 第二条（有 sticky 包装）：气泡 ↔ preflight = (22-4) - 8 = 10px
+ * 出现「从第二条气泡开始，正在分析容器贴得更近」的视觉差异。
+ *
+ * 视口顶部和气泡之间的安全区由 --ref-sticky-user-top（即 viewport 的
+ * padding-top）提供，不需要在 wrap 上再额外加 padding-top。
+ */
 .ref-msg-sticky-user-wrap {
 	position: sticky;
 	top: var(--ref-sticky-user-top, 0px);
@@ -3422,9 +3448,6 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 	box-sizing: border-box;
 	padding-top: 4px;
 	margin-top: -4px;
-	/* 勿在气泡下垫�?padding：背景为 void-bg-0，比气泡更暗，会像气泡底部一条黑�?*/
-	padding-bottom: 0;
-	margin-bottom: 0;
 	overflow: visible;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -13257,15 +13257,15 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 }
 
 .ref-plus-mcp-status--ok {
-	color: #4ade80;
+	color: var(--void-status-success);
 }
 
 .ref-plus-mcp-status--warn {
-	color: #facc15;
+	color: var(--void-status-warning);
 }
 
 .ref-plus-mcp-status--err {
-	color: #f87171;
+	color: var(--void-status-error);
 }
 
 .ref-plus-mcp-item-error {
@@ -18453,7 +18453,7 @@ select.ref-settings-native-select:focus {
 }
 
 .ref-mcp-server-row:hover {
-	border-color: rgba(255, 255, 255, 0.1);
+	border-color: color-mix(in srgb, var(--void-fg-0) 10%, transparent);
 }
 
 .ref-mcp-server-row--disabled {
@@ -18493,7 +18493,7 @@ select.ref-settings-native-select:focus {
 	color: var(--void-fg-3);
 	padding: 2px 6px;
 	border-radius: 4px;
-	background: rgba(255, 255, 255, 0.04);
+	background: color-mix(in srgb, var(--void-fg-0) 4%, transparent);
 }
 
 .ref-mcp-server-actions {
@@ -18509,7 +18509,7 @@ select.ref-settings-native-select:focus {
 	min-height: 28px;
 	padding: 0 8px;
 	border-radius: 999px;
-	background: rgba(255, 255, 255, 0.04);
+	background: color-mix(in srgb, var(--void-fg-0) 4%, transparent);
 	color: var(--void-fg-2);
 	font-size: 11px;
 }
@@ -18539,7 +18539,7 @@ select.ref-settings-native-select:focus {
 }
 
 .ref-mcp-server-action:hover {
-	background: rgba(255, 255, 255, 0.08);
+	background: color-mix(in srgb, var(--void-fg-0) 8%, transparent);
 	color: var(--void-fg-1);
 }
 
@@ -18562,34 +18562,34 @@ select.ref-settings-native-select:focus {
 }
 
 .ref-mcp-status--connected {
-	color: #86efac;
-	background: rgba(34, 197, 94, 0.12);
+	color: var(--void-status-success);
+	background: var(--void-status-success-soft);
 }
 
 .ref-mcp-status--not-started {
 	color: var(--void-fg-2);
-	background: rgba(255, 255, 255, 0.04);
+	background: color-mix(in srgb, var(--void-fg-0) 4%, transparent);
 }
 
 .ref-mcp-status--connecting {
-	color: #fcd34d;
-	background: rgba(250, 204, 21, 0.12);
+	color: var(--void-status-warning);
+	background: var(--void-status-warning-soft);
 	animation: ref-mcp-status-pulse 1.5s ease-in-out infinite;
 }
 
 .ref-mcp-status--stopped {
-	color: #fdba74;
-	background: rgba(251, 146, 60, 0.12);
+	color: var(--void-status-orange);
+	background: var(--void-status-orange-soft);
 }
 
 .ref-mcp-status--error {
-	color: #fca5a5;
-	background: rgba(248, 113, 113, 0.12);
+	color: var(--void-status-error);
+	background: var(--void-status-error-soft);
 }
 
 .ref-mcp-status--disabled {
-	color: rgba(255, 255, 255, 0.45);
-	background: rgba(255, 255, 255, 0.03);
+	color: var(--void-fg-3);
+	background: color-mix(in srgb, var(--void-fg-0) 3%, transparent);
 }
 
 @keyframes ref-mcp-status-pulse {
@@ -18619,7 +18619,7 @@ select.ref-settings-native-select:focus {
 }
 
 .ref-mcp-server-tools-expand:hover {
-	background: rgba(255, 255, 255, 0.06);
+	background: color-mix(in srgb, var(--void-fg-0) 6%, transparent);
 	color: var(--void-fg-2);
 }
 
@@ -18638,7 +18638,7 @@ select.ref-settings-native-select:focus {
 	gap: 2px;
 	padding: 6px 8px;
 	border-radius: 6px;
-	background: rgba(255, 255, 255, 0.02);
+	background: color-mix(in srgb, var(--void-fg-0) 2%, transparent);
 }
 
 .ref-mcp-server-tool-name {
@@ -18719,7 +18719,7 @@ select.ref-settings-native-select:focus {
 	padding: 10px 12px;
 	border-radius: 10px;
 	border: 1px dashed var(--void-border-soft);
-	background: rgba(255, 255, 255, 0.02);
+	background: color-mix(in srgb, var(--void-fg-0) 2%, transparent);
 }
 
 .ref-mcp-edit-example-title {
@@ -18836,7 +18836,7 @@ select.ref-settings-native-select:focus {
 }
 
 .ref-mcp-edit-expand-btn:hover {
-	background: rgba(255, 255, 255, 0.06);
+	background: color-mix(in srgb, var(--void-fg-0) 6%, transparent);
 }
 
 .ref-mcp-edit-expand-count {
@@ -18855,7 +18855,7 @@ select.ref-settings-native-select:focus {
 	height: 24px;
 	border: none;
 	border-radius: 5px;
-	background: rgba(255, 255, 255, 0.04);
+	background: color-mix(in srgb, var(--void-fg-0) 4%, transparent);
 	color: var(--void-fg-3);
 	cursor: pointer;
 	transition: background 0.1s, color 0.1s;
@@ -18932,7 +18932,7 @@ select.ref-settings-native-select:focus {
 	padding: 10px 12px;
 	border-radius: 10px;
 	border: 1px solid var(--void-border-soft);
-	background: rgba(255, 255, 255, 0.02);
+	background: color-mix(in srgb, var(--void-fg-0) 2%, transparent);
 }
 
 .ref-mcp-edit-command-preview-label {
@@ -18987,7 +18987,7 @@ select.ref-settings-native-select:focus {
 }
 
 .ref-mcp-edit-cancel:hover {
-	background: rgba(255, 255, 255, 0.04);
+	background: color-mix(in srgb, var(--void-fg-0) 4%, transparent);
 	border-color: var(--void-fg-3);
 }
 
@@ -19011,7 +19011,7 @@ select.ref-settings-native-select:focus {
 	padding: 12px;
 	border-radius: 8px;
 	border: 1px solid var(--void-border-soft);
-	background: rgba(255, 255, 255, 0.015);
+	background: color-mix(in srgb, var(--void-fg-0) 1.5%, transparent);
 	font-size: 12px;
 	color: var(--void-fg-3);
 }
@@ -19050,7 +19050,7 @@ select.ref-settings-native-select:focus {
 }
 
 .ref-settings-mcp-mode-switch button:hover {
-	background: rgba(255, 255, 255, 0.04);
+	background: color-mix(in srgb, var(--void-fg-0) 4%, transparent);
 }
 
 .ref-settings-mcp-mode-switch button.ref-settings-mcp-mode--active {
@@ -19088,7 +19088,7 @@ select.ref-settings-native-select:focus {
 }
 
 .ref-mcp-json-btn:hover {
-	background: rgba(255, 255, 255, 0.06);
+	background: color-mix(in srgb, var(--void-fg-0) 6%, transparent);
 }
 
 .ref-mcp-json-templates {

--- a/src/index.css
+++ b/src/index.css
@@ -3446,14 +3446,22 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 	width: min(100%, 720px);
 	max-width: min(100%, 720px);
 	box-sizing: border-box;
-	padding-top: 4px;
-	margin-top: -4px;
 	overflow: visible;
 }
 
 /* ?????????????? */
 .ref-center--chat .ref-msg-sticky-user-wrap {
 	/*background: var(--void-bg-0);*/
+}
+
+/*
+ * Editor 右栏里 sticky user 气泡在 Chromium / Electron 下更容易出现滚动重绘闪烁。
+ * 只提升实际气泡，避免 sticky wrapper 自身参与额外变换。
+ */
+.ref-right--editor-chat .ref-msg-sticky-user-wrap .ref-msg-user {
+	transform: translateZ(0);
+	backface-visibility: hidden;
+	-webkit-backface-visibility: hidden;
 }
 
 .ref-msg-sticky-user-wrap--team {
@@ -19019,6 +19027,152 @@ select.ref-settings-native-select:focus {
 
 .ref-settings-mcp-doc a:hover {
 	text-decoration: underline;
+}
+
+/* MCP JSON Editor */
+.ref-settings-mcp-mode-switch {
+	display: inline-flex;
+	gap: 0;
+	margin-left: auto;
+	border-radius: 6px;
+	border: 1px solid var(--void-border-soft);
+	overflow: hidden;
+}
+
+.ref-settings-mcp-mode-switch button {
+	padding: 4px 10px;
+	font-size: 11px;
+	background: transparent;
+	color: var(--void-fg-3);
+	border: none;
+	border-radius: 0;
+	cursor: pointer;
+}
+
+.ref-settings-mcp-mode-switch button:hover {
+	background: rgba(255, 255, 255, 0.04);
+}
+
+.ref-settings-mcp-mode-switch button.ref-settings-mcp-mode--active {
+	background: rgba(129, 140, 248, 0.15);
+	color: #a5b4fc;
+}
+
+.ref-mcp-json-editor {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+	margin-top: 8px;
+}
+
+.ref-mcp-json-toolbar {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.ref-mcp-json-actions {
+	display: flex;
+	gap: 8px;
+	flex-wrap: wrap;
+}
+
+.ref-mcp-json-btn {
+	padding: 5px 10px;
+	font-size: 11px;
+	border-radius: 6px;
+	border: 1px solid var(--void-border-soft);
+	background: transparent;
+	color: var(--void-fg-2);
+	cursor: pointer;
+}
+
+.ref-mcp-json-btn:hover {
+	background: rgba(255, 255, 255, 0.06);
+}
+
+.ref-mcp-json-templates {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	flex-wrap: wrap;
+}
+
+.ref-mcp-json-templates-label {
+	font-size: 11px;
+	color: var(--void-fg-3);
+}
+
+.ref-mcp-json-template-chip {
+	padding: 3px 8px;
+	font-size: 11px;
+	border-radius: 4px;
+	border: 1px solid var(--void-border-soft);
+	background: transparent;
+	color: var(--void-fg-2);
+	cursor: pointer;
+}
+
+.ref-mcp-json-template-chip:hover {
+	background: rgba(129, 140, 248, 0.1);
+	border-color: rgba(129, 140, 248, 0.3);
+}
+
+.ref-mcp-json-textarea {
+	width: 100%;
+	min-height: 320px;
+	padding: 12px;
+	font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace;
+	font-size: 12px;
+	line-height: 1.5;
+	border-radius: 8px;
+	border: 1px solid var(--void-border-soft);
+	background: var(--void-bg-1);
+	color: var(--void-fg-1);
+	resize: vertical;
+	box-sizing: border-box;
+}
+
+.ref-mcp-json-textarea:focus {
+	outline: none;
+	border-color: rgba(129, 140, 248, 0.5);
+}
+
+.ref-mcp-json-textarea--error {
+	border-color: rgba(248, 113, 113, 0.6);
+}
+
+.ref-mcp-json-error {
+	padding: 8px 10px;
+	border-radius: 6px;
+	background: rgba(248, 113, 113, 0.08);
+	border: 1px solid rgba(248, 113, 113, 0.2);
+	font-size: 12px;
+	color: #fca5a5;
+}
+
+.ref-mcp-json-hint {
+	font-size: 11px;
+	color: var(--void-fg-3);
+}
+
+.ref-mcp-server-error {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	margin-top: 6px;
+	padding: 6px 10px;
+	border-radius: 6px;
+	background: rgba(248, 113, 113, 0.08);
+	border: 1px solid rgba(248, 113, 113, 0.2);
+	font-size: 12px;
+	color: #fca5a5;
+}
+
+.ref-mcp-server-error svg {
+	flex-shrink: 0;
+	width: 14px;
+	height: 14px;
 }
 
 /* —— 设置：统计与用量 —— */

--- a/src/mcpJsonUtils.test.ts
+++ b/src/mcpJsonUtils.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+import {
+	exportMcpServersToJson,
+	parseMcpServersJson,
+	validateMcpServerConfig,
+} from './mcpJsonUtils';
+import type { McpServerConfig } from './mcpTypes';
+
+describe('parseMcpServersJson', () => {
+	it('parses a valid direct array', () => {
+		const json = JSON.stringify([
+			{
+				id: 'srv-1',
+				name: 'Filesystem',
+				enabled: true,
+				transport: 'stdio',
+				command: 'npx',
+				args: ['-y', '@modelcontextprotocol/server-filesystem', '/tmp'],
+				env: { KEY: 'value' },
+				autoStart: true,
+				timeout: 30000,
+			},
+		]);
+		const result = parseMcpServersJson(json);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.servers).toHaveLength(1);
+			expect(result.servers[0].name).toBe('Filesystem');
+			expect(result.servers[0].command).toBe('npx');
+			expect(result.servers[0].args).toEqual(['-y', '@modelcontextprotocol/server-filesystem', '/tmp']);
+			expect(result.servers[0].env).toEqual({ KEY: 'value' });
+		}
+	});
+
+	it('parses Claude Desktop mcpServers format', () => {
+		const json = JSON.stringify({
+			mcpServers: {
+				github: {
+					command: 'npx',
+					args: ['-y', '@modelcontextprotocol/server-github'],
+					env: { GITHUB_TOKEN: 'secret' },
+				},
+				fetch: {
+					command: 'uvx',
+					args: ['mcp-server-fetch'],
+				},
+			},
+		});
+		const result = parseMcpServersJson(json);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.servers).toHaveLength(2);
+			const github = result.servers.find((s) => s.name === 'github');
+			expect(github).toBeDefined();
+			expect(github!.command).toBe('npx');
+			expect(github!.enabled).toBe(false); // Claude format defaults to false unless explicitly true
+			expect(github!.env).toEqual({ GITHUB_TOKEN: 'secret' });
+		}
+	});
+
+	it('rejects invalid JSON', () => {
+		const result = parseMcpServersJson('{ not json');
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toContain('Invalid JSON');
+	});
+
+	it('rejects unsupported transport', () => {
+		const result = parseMcpServersJson(
+			JSON.stringify([{ id: 'x', name: 'X', enabled: true, transport: 'websocket' }])
+		);
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toContain('Unsupported transport');
+	});
+
+	it('rejects non-array non-mcpServers root', () => {
+		const result = parseMcpServersJson(JSON.stringify({ foo: 'bar' }));
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(
+				result.error.includes('array of servers') || result.error.includes('Claude Desktop')
+			).toBe(true);
+		}
+	});
+
+	it('filters out non-string args and env values', () => {
+		const json = JSON.stringify([
+			{
+				id: 'x',
+				name: 'X',
+				enabled: true,
+				transport: 'stdio',
+				args: ['good', 123, null, 'also-good'],
+				env: { KEEP: 'yes', DROP: 123, DROP2: null },
+			},
+		]);
+		const result = parseMcpServersJson(json);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.servers[0].args).toEqual(['good', 'also-good']);
+			expect(result.servers[0].env).toEqual({ KEEP: 'yes' });
+		}
+	});
+
+	it('assigns generated id when missing in array format', () => {
+		const json = JSON.stringify([{ name: 'NoId', enabled: true, transport: 'stdio' }]);
+		const result = parseMcpServersJson(json);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.servers[0].id).toBeTruthy();
+			expect(result.servers[0].id.length).toBeGreaterThan(0);
+		}
+	});
+
+	it('assigns generated id in Claude Desktop format', () => {
+		const json = JSON.stringify({ mcpServers: { postgres: { command: 'npx' } } });
+		const result = parseMcpServersJson(json);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.servers[0].id).toBeTruthy();
+			expect(result.servers[0].name).toBe('postgres');
+		}
+	});
+});
+
+describe('exportMcpServersToJson', () => {
+	it('round-trips with parse', () => {
+		const servers: McpServerConfig[] = [
+			{
+				id: 'a',
+				name: 'A',
+				enabled: true,
+				transport: 'http',
+				url: 'http://localhost:3000/mcp',
+				headers: { Authorization: 'Bearer x' },
+				autoStart: false,
+				timeout: 15000,
+			},
+		];
+		const json = exportMcpServersToJson(servers);
+		const result = parseMcpServersJson(json);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.servers).toEqual(servers);
+		}
+	});
+});
+
+describe('validateMcpServerConfig', () => {
+	it('requires name for stdio', () => {
+		const cfg: McpServerConfig = {
+			id: 'x',
+			name: '',
+			enabled: true,
+			transport: 'stdio',
+			command: 'npx',
+		};
+		expect(validateMcpServerConfig(cfg)).toContain('name');
+	});
+
+	it('requires command for stdio', () => {
+		const cfg: McpServerConfig = {
+			id: 'x',
+			name: 'X',
+			enabled: true,
+			transport: 'stdio',
+		};
+		expect(validateMcpServerConfig(cfg)).toContain('Command');
+	});
+
+	it('requires url for sse', () => {
+		const cfg: McpServerConfig = {
+			id: 'x',
+			name: 'X',
+			enabled: true,
+			transport: 'sse',
+		};
+		expect(validateMcpServerConfig(cfg)).toContain('URL');
+	});
+
+	it('returns null for valid stdio config', () => {
+		const cfg: McpServerConfig = {
+			id: 'x',
+			name: 'X',
+			enabled: true,
+			transport: 'stdio',
+			command: 'npx',
+		};
+		expect(validateMcpServerConfig(cfg)).toBeNull();
+	});
+});

--- a/src/mcpJsonUtils.ts
+++ b/src/mcpJsonUtils.ts
@@ -1,0 +1,124 @@
+/**
+ * MCP JSON 配置导入/导出/校验工具
+ */
+
+import type { McpServerConfig } from './mcpTypes';
+
+export type McpJsonParseResult =
+	| { ok: true; servers: McpServerConfig[] }
+	| { ok: false; error: string };
+
+/** Claude Desktop 风格的 mcpServers 对象 */
+export type ClaudeDesktopMcpServers = {
+	mcpServers?: Record<string, Omit<McpServerConfig, 'id' | 'name' | 'enabled'> & { enabled?: boolean }>;
+};
+
+function newId(): string {
+	return globalThis.crypto?.randomUUID?.() ?? `mcp-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+/** 将内部配置数组导出为格式化的 JSON 字符串 */
+export function exportMcpServersToJson(servers: McpServerConfig[]): string {
+	return JSON.stringify(servers, null, 2);
+}
+
+/** 从 JSON 字符串解析配置数组，支持 Claude Desktop mcpServers 格式 */
+export function parseMcpServersJson(json: string): McpJsonParseResult {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(json);
+	} catch {
+		return { ok: false, error: 'Invalid JSON' };
+	}
+
+	if (!parsed || typeof parsed !== 'object') {
+		return { ok: false, error: 'Root must be an object or array' };
+	}
+
+	// 尝试识别 Claude Desktop 格式: { "mcpServers": { "name": { command, args... } } }
+	const maybeClaude = parsed as ClaudeDesktopMcpServers;
+	if (maybeClaude.mcpServers && typeof maybeClaude.mcpServers === 'object') {
+		const servers: McpServerConfig[] = [];
+		for (const [name, cfg] of Object.entries(maybeClaude.mcpServers)) {
+			if (!cfg || typeof cfg !== 'object') continue;
+			const c = cfg as Record<string, unknown>;
+			const transport = (c.transport as string) || 'stdio';
+			if (!['stdio', 'sse', 'http'].includes(transport)) {
+				return { ok: false, error: `Unsupported transport "${transport}" for server "${name}"` };
+			}
+			const server: McpServerConfig = {
+				id: newId(),
+				name: name,
+				enabled: c.enabled === true,
+				transport: transport as 'stdio' | 'sse' | 'http',
+				command: typeof c.command === 'string' ? c.command : undefined,
+				args: Array.isArray(c.args) ? c.args.filter((a): a is string => typeof a === 'string') : undefined,
+				env: c.env && typeof c.env === 'object' && !Array.isArray(c.env)
+					? Object.fromEntries(Object.entries(c.env).filter(([, v]) => typeof v === 'string'))
+					: undefined,
+				url: typeof c.url === 'string' ? c.url : undefined,
+				headers: c.headers && typeof c.headers === 'object' && !Array.isArray(c.headers)
+					? Object.fromEntries(Object.entries(c.headers).filter(([, v]) => typeof v === 'string'))
+					: undefined,
+				autoStart: c.autoStart !== false,
+				timeout: typeof c.timeout === 'number' ? c.timeout : 30000,
+			};
+			servers.push(server);
+		}
+		return { ok: true, servers };
+	}
+
+	// 直接是数组格式
+	if (Array.isArray(parsed)) {
+		const servers: McpServerConfig[] = [];
+		for (let i = 0; i < parsed.length; i++) {
+			const item = parsed[i];
+			if (!item || typeof item !== 'object') {
+				return { ok: false, error: `Item ${i} is not an object` };
+			}
+			const s = item as Record<string, unknown>;
+			const transport = (s.transport as string) || 'stdio';
+			if (!['stdio', 'sse', 'http'].includes(transport)) {
+				return { ok: false, error: `Unsupported transport "${transport}" at item ${i}` };
+			}
+			const server: McpServerConfig = {
+				id: typeof s.id === 'string' && s.id ? s.id : newId(),
+				name: typeof s.name === 'string' ? s.name : 'Unnamed',
+				enabled: s.enabled === true,
+				transport: transport as 'stdio' | 'sse' | 'http',
+				command: typeof s.command === 'string' ? s.command : undefined,
+				args: Array.isArray(s.args) ? s.args.filter((a): a is string => typeof a === 'string') : undefined,
+				env: s.env && typeof s.env === 'object' && !Array.isArray(s.env)
+					? Object.fromEntries(Object.entries(s.env).filter(([, v]) => typeof v === 'string'))
+					: undefined,
+				url: typeof s.url === 'string' ? s.url : undefined,
+				headers: s.headers && typeof s.headers === 'object' && !Array.isArray(s.headers)
+					? Object.fromEntries(Object.entries(s.headers).filter(([, v]) => typeof v === 'string'))
+					: undefined,
+				autoStart: s.autoStart !== false,
+				timeout: typeof s.timeout === 'number' ? s.timeout : 30000,
+			};
+			servers.push(server);
+		}
+		return { ok: true, servers };
+	}
+
+	return { ok: false, error: 'JSON must be an array of servers or a Claude Desktop { mcpServers: {} } object' };
+}
+
+/** 校验单个配置是否合法 */
+export function validateMcpServerConfig(config: McpServerConfig): string | null {
+	if (!config.name.trim()) {
+		return 'Server name is required';
+	}
+	if (config.transport === 'stdio') {
+		if (!config.command?.trim()) {
+			return 'Command is required for stdio transport';
+		}
+	} else {
+		if (!config.url?.trim()) {
+			return 'URL is required for SSE/HTTP transport';
+		}
+	}
+	return null;
+}

--- a/src/styles/editor-layout.css
+++ b/src/styles/editor-layout.css
@@ -1591,13 +1591,18 @@
 	gap: 4px;
 	flex: 1;
 	min-width: 0;
-	overflow: hidden;
+	overflow-x: auto;
+	scrollbar-width: none;
+}
+
+.ref-editor-chat-tabs-scroll::-webkit-scrollbar {
+	display: none;
 }
 
 .ref-editor-chat-tab-shell {
 	display: flex;
 	align-items: stretch;
-	flex: 0 1 auto;
+	flex: 0 0 auto;
 	width: max-content;
 	max-width: 200px;
 	min-width: 0;

--- a/src/styles/editor-layout.css
+++ b/src/styles/editor-layout.css
@@ -1570,7 +1570,6 @@
 	flex: 1;
 	min-height: 0;
 	height: 100%;
-	overflow: hidden;
 }
 
 /* Cursor ?????????? + ?????? */
@@ -1840,6 +1839,7 @@
 	flex: 1;
 	min-height: 0;
 	overflow: hidden;
+	isolation: isolate;
 }
 
 .ref-editor-rail-message-spring {
@@ -1965,9 +1965,13 @@
 	padding-left: 16px;
 	padding-right: 16px;
 	box-sizing: border-box;
+	position: relative;
+	isolation: isolate;
 	/* ? .ref-center--chat .ref-messages ??????????????????????????? */
 	scrollbar-color: rgba(58, 58, 66, 0) transparent;
 	transition: scrollbar-color 0.35s var(--void-ease-out-expo);
+	/* ??? agent ?????????? overflow-anchor: none ??? */
+	overflow-anchor: none;
 }
 
 .ref-right--editor-chat .ref-messages:hover {
@@ -1982,9 +1986,6 @@
 	background: transparent;
 	border: 2px solid transparent;
 	background-clip: padding-box;
-	transition:
-		background 0.35s var(--void-ease-out-expo),
-		border-color 0.35s var(--void-ease-out-expo);
 }
 
 .ref-right--editor-chat .ref-messages:hover::-webkit-scrollbar-thumb {
@@ -2027,6 +2028,11 @@
 
 .ref-right--editor-chat .ref-msg-sticky-user-wrap {
 	background: transparent;
+}
+
+/* ??? editor ????? hover ???????????????? */
+.ref-right--editor-chat .ref-msg-user {
+	transition: none;
 }
 
 @media (max-width: 960px) {
@@ -2087,4 +2093,3 @@
 	background: rgba(0, 0, 0, 0.06);
 	color: var(--void-fg-0);
 }
-

--- a/src/styles/theme-dark.css
+++ b/src/styles/theme-dark.css
@@ -28,6 +28,14 @@
 	--void-git-added: #70d89d;
 	--void-git-deleted: #ff7b86;
 	--void-git-ignored: #7d8a95;
+	--void-status-success: #4ade80;
+	--void-status-success-soft: color-mix(in srgb, #22c55e 12%, transparent);
+	--void-status-warning: #facc15;
+	--void-status-warning-soft: color-mix(in srgb, #eab308 12%, transparent);
+	--void-status-error: #f87171;
+	--void-status-error-soft: color-mix(in srgb, #ef4444 12%, transparent);
+	--void-status-orange: #fdba74;
+	--void-status-orange-soft: color-mix(in srgb, #f97316 12%, transparent);
 	--void-scrollbar-track: color-mix(in srgb, var(--void-bg-0) 66%, transparent);
 	--void-scrollbar-thumb: color-mix(in srgb, var(--void-fg-2) 42%, transparent);
 	--void-scrollbar-thumb-hover: color-mix(in srgb, var(--void-fg-1) 56%, transparent);

--- a/src/styles/theme-light.css
+++ b/src/styles/theme-light.css
@@ -26,6 +26,14 @@
 	--void-git-added: #228b60;
 	--void-git-deleted: #d65055;
 	--void-git-ignored: #9aa6ba;
+	--void-status-success: #15803d;
+	--void-status-success-soft: color-mix(in srgb, #22c55e 14%, transparent);
+	--void-status-warning: #a16207;
+	--void-status-warning-soft: color-mix(in srgb, #ca8a04 14%, transparent);
+	--void-status-error: #b91c1c;
+	--void-status-error-soft: color-mix(in srgb, #ef4444 14%, transparent);
+	--void-status-orange: #c2410c;
+	--void-status-orange-soft: color-mix(in srgb, #f97316 14%, transparent);
 	--void-scrollbar-track: color-mix(in srgb, var(--void-bg-1) 78%, transparent);
 	--void-scrollbar-thumb: color-mix(in srgb, var(--void-fg-3) 38%, transparent);
 	--void-scrollbar-thumb-hover: color-mix(in srgb, var(--void-fg-2) 50%, transparent);


### PR DESCRIPTION
## Summary

This branch improves agent chat layout (turn grouping, scrolling, and sticky turn focus), hardens MCP lifecycle and settings UX, and makes MCP status styling work correctly in both light and dark themes.

## Chat layout and scrolling

- Group chat rows into **turn-based containers** with consistent spacing between turns.
- Fix **sticky / turn-focus measurement** by using viewport-relative `getBoundingClientRect()` instead of `offsetTop` when the row's offset parent sits outside the scroll viewport (reduces jitter and flicker in the editor rail).
- Pass the **sticky user header offset** into sticky-user selection logic.
- Harden turn iteration with `isValidElement` and safer `data-turn-*` handling.
- Update **content-bottom scroll** in `useMessagesScroll` to use layout metrics that match the editor-rail structure (`getBoundingClientRect`-based).
- Adjust **editor-layout.css** (overflow, stacking contexts, `overflow-anchor`) to reduce scroll jank around the chat rail.

## MCP (main + renderer)

- **Auto-start** enabled MCP servers on app ready using effective configs (including plugin-provided entries).
- **JSON edit mode** for MCP servers: import/export, validation, and support for both the internal array format and **Claude Desktop** `mcpServers` JSON.
- **McpManager** reliability: await disconnect on stop; skip destroying clients while status is **connecting** to avoid races.
- Settings UI: **pending** start/stop/restart states, **IPC error** surfacing, and disabled controls while an operation is in flight.
- Add **unit tests** for JSON parsing/serialization, manager behavior, and verification helpers.

## Theming

- Introduce shared **status tokens** (`--void-status-*`) in `theme-dark.css` / `theme-light.css`.
- Refactor MCP / Plus status UI styles in `index.css` to use tokens and `color-mix` with `var(--void-fg-0)` instead of hardcoded light-theme overlays.

## Testing

- Automated tests added or updated in `mcpJsonUtils.test.ts`, `mcpManager.test.ts`, `mcpFixesVerification.test.ts`, and `agentTurnFocus.test.ts`.
- Please sanity-check: chat scroll to bottom, sticky user label while scrolling, MCP start/stop/restart, JSON import from a Claude Desktop config, and MCP colors in **light** and **dark** themes.
