### PR TITLE
Agent skills: disk library, home-dir resolution, import UI, and chat UX

### DIFF
--- a/main-src/agentSettingsTypes.ts
+++ b/main-src/agentSettingsTypes.ts
@@ -162,4 +162,6 @@ export type AgentCustomization = {
 	memoryExtraction?: AgentMemoryExtractionSettings;
 	/** 控制是否启用自动 Skill 创建及阈值 */
 	skillExtraction?: AgentSkillExtractionSettings;
+	/** 磁盘扫描 skill（工作区 + 全局）的启用/禁用覆盖（key 为 slug） */
+	diskSkillEnabledOverrides?: Record<string, boolean>;
 };

--- a/main-src/ipc/register.ts
+++ b/main-src/ipc/register.ts
@@ -153,7 +153,7 @@ import {
 	abortTeamPlanApprovalForThread,
 	resolveTeamPlanApproval,
 } from '../agent/teamPlanApprovalTool.js';
-import { loadClaudeWorkspaceSkills, prepareUserTurnForChat } from '../llm/agentMessagePrep.js';
+import { loadClaudeWorkspaceSkills, loadGlobalSkills, prepareUserTurnForChat } from '../llm/agentMessagePrep.js';
 import {
 	buildSkillCreatorSystemAppend,
 	formatSkillCreatorUserBubble,
@@ -2134,7 +2134,8 @@ export function registerIpc(): void {
 		if (!root) {
 			return { ok: true as const, skills: [] };
 		}
-		return { ok: true as const, skills: loadClaudeWorkspaceSkills(root) };
+		const globalSkills = loadGlobalSkills();
+			return { ok: true as const, skills: [...globalSkills, ...loadClaudeWorkspaceSkills(root)] };
 	});
 
 	/** 删除工作区内技能目录（`.cursor|claude|async/skills/<slug>/` 整夹），参数为其中 `SKILL.md` 的相对路径 */

--- a/main-src/llm/agentMessagePrep.ts
+++ b/main-src/llm/agentMessagePrep.ts
@@ -115,18 +115,19 @@ export function loadClaudeWorkspaceSkills(workspaceRoot: string | null): AgentSk
 
 /** 获取用户主目录路径（跨平台） */
 function getUserHomeDir(): string | null {
-	const home = process.env.HOME || process.env.USERPROFILE;
-	if (home) return home;
-	try {
-		// Windows fallback
-		if (process.platform === 'win32') {
+	// Windows: 优先 USERPROFILE（原生路径），避免 Git Bash 的 HOME（/c/Users/...）导致 fs 失败
+	if (process.platform === 'win32') {
+		const fromEnv = process.env.USERPROFILE || process.env.HOME;
+		if (fromEnv) return fromEnv;
+		try {
 			const { homedir } = require('node:os');
 			return homedir();
+		} catch {
+			/* ignore */
 		}
-	} catch {
-		/* ignore */
+		return null;
 	}
-	return null;
+	return process.env.HOME || null;
 }
 
 /**

--- a/main-src/llm/agentMessagePrep.ts
+++ b/main-src/llm/agentMessagePrep.ts
@@ -113,6 +113,46 @@ export function loadClaudeWorkspaceSkills(workspaceRoot: string | null): AgentSk
 	return [...claude, ...cursor, ...asyncShell];
 }
 
+/** 获取用户主目录路径（跨平台） */
+function getUserHomeDir(): string | null {
+	const home = process.env.HOME || process.env.USERPROFILE;
+	if (home) return home;
+	try {
+		// Windows fallback
+		if (process.platform === 'win32') {
+			const { homedir } = require('node:os');
+			return homedir();
+		}
+	} catch {
+		/* ignore */
+	}
+	return null;
+}
+
+/**
+ * 从全局目录加载磁盘技能（用户主目录级别）：
+ * - `~/.claude/skills/<slug>/SKILL.md`
+ * - `~/.async/skills/<slug>/SKILL.md`
+ * 优先级：`.async` > `.claude`
+ */
+export function loadGlobalSkills(): AgentSkill[] {
+	const home = getUserHomeDir();
+	if (!home) {
+		return [];
+	}
+	const claude = scanSkillsDirectory(home, ['.claude', 'skills'], 'claude');
+	const asyncShell = scanSkillsDirectory(home, ['.async', 'skills'], 'async');
+	// 标记为全局来源
+	const markGlobal = (skills: AgentSkill[], sourceLabel: string): AgentSkill[] =>
+		skills.map((s) => ({
+			...s,
+			id: `global-skill-${sourceLabel}:${s.slug}`,
+			origin: 'user' as const,
+			skillSourceRelPath: undefined,
+		}));
+	return [...markGlobal(claude, 'claude'), ...markGlobal(asyncShell, 'async')];
+}
+
 /**
  * 扫描磁盘子 Agent 配置（兼容 Claude Code `.claude/agents/<name>.md` 约定）：
  * - `.claude/agents/<name>.md`
@@ -514,7 +554,9 @@ export function prepareUserTurnForChat(
 	const { userText: afterCmd, slashSystemBlock } = applySlashCommands(rawText, agent?.commands);
 	const { userText: afterManual, manualBlocks } = applyManualRuleInvocations(afterCmd, agent?.rules);
 	const wsSkills = workspaceRoot ? loadClaudeWorkspaceSkills(workspaceRoot) : [];
-	const mergedSkills = mergeSkillsBySlug(agent?.skills, wsSkills);
+	const globalSkills = loadGlobalSkills();
+	const diskSkills = mergeSkillsBySlug(globalSkills, wsSkills);
+	const mergedSkills = mergeSkillsBySlug(agent?.skills, diskSkills);
 	const wsSubagents = workspaceRoot ? loadClaudeWorkspaceSubagents(workspaceRoot) : [];
 	const mergedSubagents = mergeSubagentsByName(agent?.subagents, wsSubagents);
 	const agentWithDisk: AgentCustomization | undefined = agent

--- a/src/AgentChatPanel.tsx
+++ b/src/AgentChatPanel.tsx
@@ -55,6 +55,7 @@ import {
 	findLatestTurnStartUserIndex,
 	findStickyUserIndexForViewport,
 	resolveStickyUserIndex,
+	shouldEnableLatestTurnSpacer,
 	type MeasuredTurnFocusRow,
 	type TurnFocusRow,
 } from './agentTurnFocus';
@@ -636,6 +637,11 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 		() => findLatestTurnStartUserIndex(displayMessages, composerMode, hasTeamSupplementalRows),
 		[displayMessages, composerMode, hasTeamSupplementalRows]
 	);
+	const latestTurnSpacerEnabled = useMemo(
+		() => shouldEnableLatestTurnSpacer(composerMode),
+		[composerMode]
+	);
+	const effectiveActiveTurnSpacerPx = latestTurnSpacerEnabled ? activeTurnSpacerPx : 0;
 	const lastDisplayedMessage = len > 0 ? displayMessages[len - 1] : undefined;
 	const lastMessageLayoutSig = useMemo(
 		() =>
@@ -668,7 +674,15 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 				 */
 				const rowRect = rowEl.getBoundingClientRect();
 				const top = rowRect.top - viewportRect.top;
-				const height = Math.max(0, Math.ceil(rowRect.height) || rowEl.offsetHeight);
+				const turnFocusFillPx = Array.from(
+					rowEl.querySelectorAll<HTMLElement>('[data-turn-focus-fill-px]')
+				).reduce((sum, el) => {
+					const raw = el.dataset.turnFocusFillPx;
+					const px = raw == null ? 0 : Number(raw);
+					return sum + (Number.isFinite(px) ? Math.max(0, px) : 0);
+				}, 0);
+				const rawHeight = Math.max(0, Math.ceil(rowRect.height) || rowEl.offsetHeight);
+				const height = Math.max(0, rawHeight - turnFocusFillPx);
 				return {
 					rowId: meta.rowId,
 					messageIndex: meta.messageIndex,
@@ -872,7 +886,12 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 	}, [messageStartIndex, displayMessages.length]);
 
 	useLayoutEffect(() => {
-		if (!hasConversation || latestTurnStartUserIndex == null || shouldUseStableTeamLiveLayout) {
+		if (
+			!hasConversation ||
+			!latestTurnSpacerEnabled ||
+			latestTurnStartUserIndex == null ||
+			shouldUseStableTeamLiveLayout
+		) {
 			setActiveTurnSpacerPx((prev) => (prev === 0 ? prev : 0));
 			return;
 		}
@@ -888,6 +907,7 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 			viewportHeight: viewport.clientHeight,
 			topPadding,
 			bottomPadding,
+			stickyTopPx: stickyUserTopPx,
 			renderedRows,
 			activeTurnStartUserIndex: latestTurnStartUserIndex,
 		});
@@ -895,6 +915,7 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 		setActiveTurnSpacerPx((prev) => (Math.abs(prev - nextSpacer) <= 1 ? prev : nextSpacer));
 	}, [
 		hasConversation,
+		latestTurnSpacerEnabled,
 		latestTurnStartUserIndex,
 		shouldUseStableTeamLiveLayout,
 		lastMessageLayoutSig,
@@ -902,6 +923,7 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 		conversationRenderKey,
 		collectMeasuredTurnRows,
 		messagesViewportRef,
+		stickyUserTopPx,
 	]);
 
 	/**
@@ -978,12 +1000,12 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 			renderedRows,
 			stickyTopPx: stickyUserTopPx,
 			latestTurnStartUserIndex,
-			latestTurnSpacerPx: activeTurnSpacerPx,
+			latestTurnSpacerPx: effectiveActiveTurnSpacerPx,
 		});
 		const shouldSuppressPinnedTeamSticky =
 			composerMode === 'team' &&
 			isAtBottom &&
-			activeTurnSpacerPx > 0 &&
+			effectiveActiveTurnSpacerPx > 0 &&
 			nextStickyIndex === latestTurnStartUserIndex;
 		const resolvedStickyIndex = resolveStickyUserIndex(
 			shouldSuppressPinnedTeamSticky ? null : nextStickyIndex
@@ -1037,7 +1059,7 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 	}, [
 		hasConversation,
 		lastMessageLayoutSig,
-		activeTurnSpacerPx,
+		effectiveActiveTurnSpacerPx,
 		stickyUserTopPx,
 		latestTurnStartUserIndex,
 		messageStartIndex,
@@ -1173,6 +1195,12 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 			}
 			const convoKey = conversationRenderKey;
 			const { isLast, agentOrPlanStreaming, liveThoughtMeta } = computeAssistantRuntime(i);
+			const assistantTurnFocusFillPx =
+				m.role === 'assistant' &&
+				i === lastAssistantMessageIndex &&
+				i === displayMessages.length - 1
+					? effectiveActiveTurnSpacerPx
+					: 0;
 
 			const pendingEmptyAssistant =
 				m.role === 'assistant' &&
@@ -1242,11 +1270,21 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 				<div key={`a-${convoKey}-${i}`} className="ref-msg-slot ref-msg-slot--assistant">
 					<div className="ref-msg-assistant-body">
 						{pendingEmptyAssistant ? (
-							<span className="ref-bubble-pending" aria-hidden>
-								<span className="ref-bubble-pending-dot" />
-								<span className="ref-bubble-pending-dot" />
-								<span className="ref-bubble-pending-dot" />
-							</span>
+							<>
+								<span className="ref-bubble-pending" aria-hidden>
+									<span className="ref-bubble-pending-dot" />
+									<span className="ref-bubble-pending-dot" />
+									<span className="ref-bubble-pending-dot" />
+								</span>
+								{assistantTurnFocusFillPx > 0 ? (
+									<div
+										className="ref-md-root ref-md-root--agent-chat"
+										data-turn-focus-fill-px={String(assistantTurnFocusFillPx)}
+										style={{ paddingBottom: `${assistantTurnFocusFillPx}px` }}
+										aria-hidden
+									/>
+								) : null}
+							</>
 						) : (
 							<ChatMarkdown
 								content={m.content}
@@ -1277,6 +1315,7 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 								skipPlanTodo
 								renderMode={chatRenderMode}
 								typewriter={isLast && awaitingReply}
+								turnFocusFillPx={assistantTurnFocusFillPx}
 							/>
 						)}
 					</div>
@@ -1712,21 +1751,10 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 			</div>
 		);
 	});
-	const tailSpacerNode =
-		activeTurnSpacerPx > 0 ? (
-			<div
-				key={`row-${conversationRenderKey}-turn-focus-tail`}
-				className="ref-messages-tail-spacer"
-				style={{ height: `${activeTurnSpacerPx}px` }}
-				aria-hidden
-			/>
-		) : null;
-
 	/* 按 turn 分组：同一轮次的消息包在一个 ref-turn-container 内，
 	   容器之间用 padding-bottom 提供 assistant → 下一条 user 的安全距离。
-	   tail spacer 放在所有 turn 容器之后，不参与 turn 分组。
-	   滚动位置由 useMessagesScroll.ts 基于“最后内容行底部”计算，
-	   不受容器 padding 或 tail spacer 影响。 */
+	   最新一轮若需要额外补高，会把空间补进最后一条 assistant 的内容容器内部，
+	   这样自动置底就以消息容器底部为准，而不是 track 尾部的额外空白。 */
 	const renderTurnContainers = (): ReactNode[] => {
 		const containers: ReactNode[] = [];
 		let currentTurnNodes: ReactNode[] = [];
@@ -1774,10 +1802,6 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 					{currentTurnNodes}
 				</div>
 			);
-		}
-
-		if (tailSpacerNode) {
-			containers.push(tailSpacerNode);
 		}
 
 		return containers;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3865,6 +3865,7 @@ function AppMainWorkspaceInner() {
 			onOpenSkillCreator: startSkillCreatorFlow,
 			onOpenWorkspaceSkillFile: handleOpenWorkspaceSkillFile,
 			onDeleteWorkspaceSkillDisk: handleDeleteWorkspaceSkillDisk,
+			onRefreshDiskSkills: refreshWorkspaceDiskSkills,
 			colorMode,
 			onChangeColorMode: (m, origin) => void onChangeColorMode(m, origin),
 			effectiveColorScheme: effectiveScheme,

--- a/src/ChatMarkdown.tsx
+++ b/src/ChatMarkdown.tsx
@@ -198,6 +198,8 @@ type Props = {
 	skipPlanTodo?: boolean;
 	/** 启用打字机效果：流式输出时对 markdown 文本做平滑逐字揭示 */
 	typewriter?: boolean;
+	/** 为最后一轮短回复补出的容器底部高度；挂在 markdown root 上，便于自动置底以容器底为准 */
+	turnFocusFillPx?: number;
 	/**
 	 * 渲染范围：
 	 * - `'all'`（默认，兼容老调用方）：preflight + outcome 都在本组件渲染（整段一起）。
@@ -399,6 +401,7 @@ export const ChatMarkdown = memo(function ChatMarkdown({
 	skipPlanTodo = false,
 	renderMode = 'all',
 	typewriter = false,
+	turnFocusFillPx = 0,
 }: Props) {
 	const { t } = useI18n();
 
@@ -518,6 +521,10 @@ export const ChatMarkdown = memo(function ChatMarkdown({
 			streamingToolPreview != null ||
 			(liveAgentBlocksState?.blocks.length ?? 0) > 0
 		);
+	const rootTurnFocusFillPxAttr =
+		turnFocusFillPx > 0 ? String(Math.max(0, turnFocusFillPx)) : undefined;
+	const rootTurnFocusFillStyle =
+		turnFocusFillPx > 0 ? { paddingBottom: `${Math.max(0, turnFocusFillPx)}px` } : undefined;
 
 	if (!agentMarkdown) {
 		const plainClass =
@@ -525,7 +532,11 @@ export const ChatMarkdown = memo(function ChatMarkdown({
 				? `ref-md-root ref-md-root--chat-error${agentUi ? ' ref-md-root--agent-chat' : ''}`
 				: 'ref-md-root';
 		return (
-			<div className={plainClass}>
+			<div
+				className={plainClass}
+				data-turn-focus-fill-px={rootTurnFocusFillPxAttr}
+				style={rootTurnFocusFillStyle}
+			>
 				<TypewriterMd text={content} enabled={typewriter} />
 			</div>
 		);
@@ -737,7 +748,11 @@ export const ChatMarkdown = memo(function ChatMarkdown({
 	if (renderMode === 'preflight') {
 		if (!hasPreflight) return null;
 		return (
-			<div className={agentRootClass}>
+			<div
+				className={agentRootClass}
+				data-turn-focus-fill-px={rootTurnFocusFillPxAttr}
+				style={rootTurnFocusFillStyle}
+			>
 				<AgentPreflightShell
 					liveTurn={showAgentWorking}
 					hasOutcome={hasOutcome}
@@ -752,17 +767,31 @@ export const ChatMarkdown = memo(function ChatMarkdown({
 
 	if (renderMode === 'outcome') {
 		if (!hasOutcome) {
-			return <div className={agentRootClass} />;
+			return (
+				<div
+					className={agentRootClass}
+					data-turn-focus-fill-px={rootTurnFocusFillPxAttr}
+					style={rootTurnFocusFillStyle}
+				/>
+			);
 		}
 		if (outcome.length === 1 && outcome[0]!.type === 'markdown') {
 			return (
-				<div className={agentRootClass}>
+				<div
+					className={agentRootClass}
+					data-turn-focus-fill-px={rootTurnFocusFillPxAttr}
+					style={rootTurnFocusFillStyle}
+				>
 					<TypewriterMd text={outcome[0]!.text} enabled={typewriter} />
 				</div>
 			);
 		}
 		return (
-			<div className={agentRootClass}>
+			<div
+				className={agentRootClass}
+				data-turn-focus-fill-px={rootTurnFocusFillPxAttr}
+				style={rootTurnFocusFillStyle}
+			>
 				{outcome.map((seg, i) => renderUnitNode(seg, i))}
 			</div>
 		);
@@ -771,22 +800,42 @@ export const ChatMarkdown = memo(function ChatMarkdown({
 	if (renderUnits.length === 0) {
 		if (content.trim()) {
 			return (
-				<div className={agentRootClass}>
+				<div
+					className={agentRootClass}
+					data-turn-focus-fill-px={rootTurnFocusFillPxAttr}
+					style={rootTurnFocusFillStyle}
+				>
 					<TypewriterMd text={content} enabled={typewriter} />
 				</div>
 			);
 		}
-		return <div className={agentRootClass} />;
+		return (
+			<div
+				className={agentRootClass}
+				data-turn-focus-fill-px={rootTurnFocusFillPxAttr}
+				style={rootTurnFocusFillStyle}
+			/>
+		);
 	}
 	if (renderUnits.length === 1 && renderUnits[0]!.type === 'markdown') {
 		return (
-			<div className={agentRootClass}>
+			<div
+				className={agentRootClass}
+				data-turn-focus-fill-px={rootTurnFocusFillPxAttr}
+				style={rootTurnFocusFillStyle}
+			>
 				<TypewriterMd text={renderUnits[0]!.text} enabled={typewriter} />
 			</div>
 		);
 	}
 
 	return (
-		<div className={agentRootClass}>{renderUnits.map((seg, i) => renderUnitNode(seg, i))}</div>
+		<div
+			className={agentRootClass}
+			data-turn-focus-fill-px={rootTurnFocusFillPxAttr}
+			style={rootTurnFocusFillStyle}
+		>
+			{renderUnits.map((seg, i) => renderUnitNode(seg, i))}
+		</div>
 	);
 });

--- a/src/SettingsAgentPanel.tsx
+++ b/src/SettingsAgentPanel.tsx
@@ -212,6 +212,8 @@ type Props = {
 	onOpenWorkspaceSkillFile?: (relPath: string) => void | Promise<void>;
 	/** 删除磁盘技能目录（整夹）；返回是否成功 */
 	onDeleteWorkspaceSkillDisk?: (skillMdRelPath: string) => Promise<boolean>;
+	/** 重新扫描磁盘技能 */
+	onRefreshDiskSkills?: () => void;
 };
 
 function itemMatchesLibraryFilter(item: { origin?: AgentItemOrigin }, filter: AgentLibraryFilter): boolean {
@@ -229,6 +231,7 @@ export function SettingsAgentPanel({
 	onOpenSkillCreator,
 	onOpenWorkspaceSkillFile,
 	onDeleteWorkspaceSkillDisk,
+	onRefreshDiskSkills,
 }: Props) {
 	const { t } = useI18n();
 	const v = { ...defaultAgentCustomization(), ...value };
@@ -728,6 +731,17 @@ export function SettingsAgentPanel({
 								>
 									{t('agentSettings.skillsImport')}
 								</button>
+									{onRefreshDiskSkills ? (
+										<button
+											type="button"
+											className="ref-settings-agent-new-btn ref-settings-agent-new-btn--secondary"
+											onClick={() => onRefreshDiskSkills()}
+											title={t("agentSettings.skillsRefreshTitle") || "Rescan disk skills"}
+										>
+											<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" style={{ marginRight: 4 }}><path d="M23 4v6h-6M1 20v-6h6" strokeLinecap="round" strokeLinejoin="round"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" strokeLinecap="round" strokeLinejoin="round"/></svg>
+											{t("agentSettings.skillsRefresh")}
+										</button>
+									) : null}
 							{onOpenSkillCreator ? (
 								<button type="button" className="ref-settings-agent-new-btn" onClick={() => void onOpenSkillCreator()}>
 									{t('agentSettings.skillsNew')}

--- a/src/SettingsAgentPanel.tsx
+++ b/src/SettingsAgentPanel.tsx
@@ -14,12 +14,102 @@ import type {
 import { createAutoReplyLanguageRule } from './autoReplyLanguageRule';
 import {
 	defaultAgentCustomization,
+	isAnyDiskImportedSkill,
+	isGlobalDiskImportedSkill,
 	isPluginImportedCommand,
 	isPluginImportedSkill,
 	isWorkspaceDiskImportedSkill,
 } from './agentSettingsTypes';
 import { VoidSelect } from './VoidSelect';
 import { buildSlashCommandListRows } from './composerSlashCommands';
+
+/** Skill 快速模板 */
+export type SkillTemplate = {
+	id: string;
+	name: string;
+	slug: string;
+	description: string;
+	content: string;
+};
+
+export const SKILL_TEMPLATES: SkillTemplate[] = [
+	{
+		id: 'review-pr',
+		name: 'Review PR',
+		slug: 'review-pr',
+		description: 'Review a pull request by analyzing diff, checking style, and providing feedback.',
+		content: `## Review Pull Request
+
+1. Read the PR description and linked issues
+2. Run git diff to see all changes
+3. For each changed file:
+   - Check code style and formatting
+   - Look for potential bugs or edge cases
+   - Verify test coverage
+   - Check for security issues
+4. Provide a summary with:
+   - Overall assessment (approve / request changes / comment)
+   - Key findings (positive and negative)
+   - Specific suggestions with line references
+   - Action items for the author`,
+	},
+	{
+		id: 'write-tests',
+		name: 'Write Tests',
+		slug: 'write-tests',
+		description: 'Generate comprehensive test cases for the given code or feature.',
+		content: `## Write Tests
+
+1. Read the target file(s) to understand the code
+2. Identify the public API surface (functions, classes, methods)
+3. For each public unit:
+   - Write happy path tests
+   - Write edge case tests (null, empty, boundary values)
+   - Write error case tests (exceptions, invalid inputs)
+4. Use the existing test framework and conventions in the project
+5. Ensure tests are independent and can run in any order
+6. Add descriptive test names that explain the scenario`,
+	},
+	{
+		id: 'refactor',
+		name: 'Refactor',
+		slug: 'refactor',
+		description: 'Refactor code to improve readability, performance, and maintainability.',
+		content: `## Refactor Code
+
+1. Read the target file(s) carefully
+2. Identify code smells:
+   - Long functions / classes
+   - Duplicate code
+   - Deep nesting
+   - Magic numbers / strings
+   - Tight coupling
+3. Apply appropriate refactorings:
+   - Extract functions / methods
+   - Rename for clarity
+   - Simplify conditionals
+   - Remove dead code
+4. Ensure all existing tests still pass
+5. Do NOT change behavior — only structure`,
+	},
+	{
+		id: 'commit-message',
+		name: 'Commit Message',
+		slug: 'commit',
+		description: 'Generate a conventional commit message from staged changes.',
+		content: `## Generate Commit Message
+
+1. Run git diff --staged to see the changes
+2. Analyze the scope and intent of the changes
+3. Write a commit message following conventional commits format:
+   - type(scope): subject
+   - Optional body explaining why and how
+   - Optional footer for breaking changes or issue references
+4. Types: feat, fix, docs, style, refactor, test, chore, perf, ci
+5. Keep the subject line under 72 characters
+6. Use imperative mood in the subject`,
+	},
+];
 
 function newId(): string {
 	return globalThis.crypto?.randomUUID?.() ?? `id-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
@@ -164,6 +254,9 @@ export function SettingsAgentPanel({
 	const [collapsedSubs, setCollapsedSubs] = useState<Set<string>>(new Set());
 	const [collapsedCmds, setCollapsedCmds] = useState<Set<string>>(new Set());
 	const [diskSkillDeletingId, setDiskSkillDeletingId] = useState<string | null>(null);
+	const [importOpen, setImportOpen] = useState(false);
+	const [importText, setImportText] = useState('');
+	const [importError, setImportError] = useState<string | null>(null);
 
 	const toggleCollapse = (set: Set<string>, setter: React.Dispatch<React.SetStateAction<Set<string>>>, id: string) => {
 		const next = new Set(set);
@@ -208,20 +301,71 @@ export function SettingsAgentPanel({
 		const cur = skills.find((x) => x.id === id);
 		if (cur && (isWorkspaceDiskImportedSkill(cur) || isPluginImportedSkill(cur))) return;
 		const nextEditable = editableSkills.map((x) => (x.id === id ? { ...x, ...p } : x));
-		patch({ skills: [...pluginSkills, ...diskSkillsInWorkspace, ...nextEditable] });
+		patch({ skills: [...pluginSkills, ...diskSkillsAll, ...nextEditable] });
 	};
 	const removeSkill = (id: string) => {
 		const cur = skills.find((x) => x.id === id);
 		if (cur && (isWorkspaceDiskImportedSkill(cur) || isPluginImportedSkill(cur))) return;
-		patch({ skills: [...pluginSkills, ...diskSkillsInWorkspace, ...editableSkills.filter((x) => x.id !== id)] });
+		patch({ skills: [...pluginSkills, ...diskSkillsAll, ...editableSkills.filter((x) => x.id !== id)] });
 	};
 
 	const pluginSkills = skills.filter((s) => isPluginImportedSkill(s));
-	const diskSkillsInWorkspace = skills.filter((s) => isWorkspaceDiskImportedSkill(s) && s.skillSourceRelPath);
-	const editableSkills = skills.filter((s) => !isWorkspaceDiskImportedSkill(s) && !isPluginImportedSkill(s));
+	const diskSkillsAll = skills.filter((s) => isAnyDiskImportedSkill(s));
+	const diskWorkspaceSkills = diskSkillsAll.filter((s) => isWorkspaceDiskImportedSkill(s));
+	const diskGlobalSkills = diskSkillsAll.filter((s) => isGlobalDiskImportedSkill(s));
+	const editableSkills = skills.filter((s) => !isAnyDiskImportedSkill(s) && !isPluginImportedSkill(s));
 	const skillsDrag = useDragReorder(editableSkills, (nextEditable) =>
-		patch({ skills: [...pluginSkills, ...diskSkillsInWorkspace, ...nextEditable] })
+		patch({ skills: [...pluginSkills, ...diskSkillsAll, ...nextEditable] })
 	);
+
+	const toggleDiskSkill = (s: AgentSkill) => {
+		const overrides = { ...(v.diskSkillEnabledOverrides ?? {}) };
+		const slug = s.slug.trim().toLowerCase();
+		const current = s.enabled !== false;
+		overrides[slug] = !current;
+		patch({ diskSkillEnabledOverrides: overrides });
+	};
+
+	const addSkillFromTemplate = (template: SkillTemplate) => {
+		const id = newId();
+		const s: AgentSkill = {
+			id,
+			name: template.name,
+			slug: template.slug,
+			description: template.description,
+			content: template.content,
+			enabled: true,
+			origin: originForNewItem(),
+		};
+		patch({ skills: [...skills, s] });
+	};
+
+	const importSkillFromMarkdown = (markdown: string) => {
+		const trimmed = markdown.trim();
+		if (!trimmed.startsWith('---')) return false;
+		const end = trimmed.indexOf('\n---', 3);
+		if (end < 0) return false;
+		const yaml = trimmed.slice(3, end).trim();
+		const body = trimmed.slice(end + 4).trim();
+		const meta: Record<string, string> = {};
+		for (const line of yaml.split('\n')) {
+			const m = line.match(/^([a-zA-Z0-9_-]+)\s*:\s*(.*)$/);
+			if (m) meta[m[1]] = (m[2] ?? '').replace(/^["']|["']$/g, '').trim();
+		}
+		const slug = (meta.slug ?? meta.name ?? 'unnamed').toLowerCase().replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '');
+		if (!slug) return false;
+		const s: AgentSkill = {
+			id: newId(),
+			name: meta.name || slug,
+			slug,
+			description: meta.description || '',
+			content: body,
+			enabled: true,
+			origin: originForNewItem(),
+		};
+		patch({ skills: [...skills, s] });
+		return true;
+	};
 
 	const deleteDiskSkill = async (s: AgentSkill) => {
 		const rel = s.skillSourceRelPath;
@@ -555,18 +699,86 @@ export function SettingsAgentPanel({
 							<IconInfo />
 						</span>
 					</h2>
-					<div className="ref-settings-agent-head-actions">
-						{onOpenSkillCreator ? (
-							<button type="button" className="ref-settings-agent-new-btn" onClick={() => void onOpenSkillCreator()}>
-								{t('agentSettings.skillsNew')}
-							</button>
-						) : null}
-					</div>
+						<div className="ref-settings-agent-head-actions">
+							<div className="ref-settings-agent-template-dropdown">
+								<button type="button" className="ref-settings-agent-new-btn ref-settings-agent-new-btn--secondary" title="From template">
+									{t('agentSettings.skillsTemplate')}
+								</button>
+								<div className="ref-settings-agent-template-menu">
+									{SKILL_TEMPLATES.map((tmpl) => (
+										<button
+											key={tmpl.id}
+											type="button"
+											onClick={() => addSkillFromTemplate(tmpl)}
+											className="ref-settings-agent-template-item"
+										>
+											<div className="ref-settings-agent-template-name">{tmpl.name}</div>
+											<div className="ref-settings-agent-template-desc">{tmpl.description}</div>
+										</button>
+									))}
+								</div>
+							</div>
+							<button
+								type="button"
+								className="ref-settings-agent-new-btn ref-settings-agent-new-btn--secondary"
+								onClick={() => {
+									setImportOpen((v) => !v);
+									setImportError(null);
+								}}
+								>
+									{t('agentSettings.skillsImport')}
+								</button>
+							{onOpenSkillCreator ? (
+								<button type="button" className="ref-settings-agent-new-btn" onClick={() => void onOpenSkillCreator()}>
+									{t('agentSettings.skillsNew')}
+								</button>
+							) : null}
+						</div>
 				</div>
 				<p className="ref-settings-agent-section-desc">{t('agentSettings.skillsDesc')}</p>
+				{importOpen && (
+					<div className="ref-settings-agent-import-box">
+						<label className="ref-settings-field">
+							<span>{t('agentSettings.skillsImportPrompt')}</span>
+							<textarea
+								rows={6}
+								value={importText}
+								onChange={(e) => { setImportText(e.target.value); setImportError(null); }}
+								placeholder="---\nname: My Skill\nslug: my-skill\ndescription: ...\n---\n\n## Steps\n1. ..."
+							/>
+						</label>
+						{importError ? (
+							<p className="ref-settings-agent-import-error">{importError}</p>
+						) : null}
+						<div className="ref-settings-agent-import-actions">
+							<button
+								type="button"
+								className="ref-settings-agent-new-btn"
+								onClick={() => {
+									if (importSkillFromMarkdown(importText)) {
+										setImportOpen(false);
+										setImportText('');
+										setImportError(null);
+									} else {
+										setImportError(t('agentSettings.skillsImportError') || 'Failed to parse SKILL.md, please check format');
+									}
+								}}
+								>
+									{t('common.confirm')}
+								</button>
+							<button
+								type="button"
+								className="ref-settings-agent-new-btn ref-settings-agent-new-btn--secondary"
+								onClick={() => { setImportOpen(false); setImportText(''); setImportError(null); }}
+								>
+									{t('common.cancel')}
+								</button>
+						</div>
+					</div>
+				)}
 				{(() => {
 					const pluginFiltered = pluginSkills.filter((s) => itemMatchesLibraryFilter(s, libraryFilter));
-					const diskFiltered = diskSkillsInWorkspace.filter((s) => itemMatchesLibraryFilter(s, libraryFilter));
+					const diskFiltered = diskSkillsAll.filter((s) => itemMatchesLibraryFilter(s, libraryFilter));
 					const editableFiltered = editableSkills.filter((s) => itemMatchesLibraryFilter(s, libraryFilter));
 					const visibleSkillCount = pluginFiltered.length + diskFiltered.length + editableFiltered.length;
 					return (
@@ -603,35 +815,61 @@ export function SettingsAgentPanel({
 								<>
 									<ul className="ref-settings-agent-skill-disk-list">
 										{diskFiltered.map((s) => {
-											const rel = s.skillSourceRelPath!;
+											const rel = s.skillSourceRelPath;
 											const busy = diskSkillDeletingId === s.id;
-											const canOpen = !!onOpenWorkspaceSkillFile;
+											const canOpen = !!onOpenWorkspaceSkillFile && !!rel;
+											const enabled = s.enabled !== false;
 											return (
-												<li key={s.id} className="ref-settings-agent-skill-disk-card">
-													<button
-														type="button"
-														className={`ref-settings-agent-skill-disk-main ${canOpen ? 'is-clickable' : ''}`}
-														disabled={!canOpen || busy}
-														onClick={() => onDiskCardOpenClick(rel)}
-														aria-label={t('agentSettings.skillDiskOpenAria', { name: s.name })}
-													>
-														<div className="ref-settings-agent-skill-disk-title">{s.name}</div>
-														<div className="ref-settings-agent-skill-disk-desc">{s.description}</div>
-														<div className="ref-settings-agent-skill-disk-path" title={rel}>
-															{rel}
-														</div>
-													</button>
-													<button
-														type="button"
-														className="ref-settings-agent-skill-disk-trash"
-														disabled={busy || !onDeleteWorkspaceSkillDisk}
-														title={t('agentSettings.skillDiskDeleteTitle')}
-														aria-label={t('agentSettings.skillDiskDeleteTitle')}
-														onClick={() => void deleteDiskSkill(s)}
-													>
-														<IconTrash />
-													</button>
-												</li>
+															<li key={s.id} className="ref-settings-agent-skill-disk-card">
+																<button
+																	type="button"
+																	className={`ref-settings-agent-skill-disk-main ${canOpen ? 'is-clickable' : ''}`}
+																	disabled={!canOpen || busy}
+																	onClick={() => rel && onDiskCardOpenClick(rel)}
+																	aria-label={t('agentSettings.skillDiskOpenAria', { name: s.name })}
+																>
+																	<div className="ref-settings-agent-skill-disk-title">
+																		{s.name}
+																		{isGlobalDiskImportedSkill(s) ? (
+																			<span className="ref-settings-agent-origin-badge ref-settings-agent-origin-badge--user">
+																				{t('agentSettings.originUser')}
+																			</span>
+																		) : (
+																			<span className="ref-settings-agent-origin-badge ref-settings-agent-origin-badge--project">
+																				{t('agentSettings.originProject')}
+																			</span>
+																		)}
+																	</div>
+																	<div className="ref-settings-agent-skill-disk-desc">{s.description}</div>
+																	<div className="ref-settings-agent-skill-disk-path" title={rel ?? (isGlobalDiskImportedSkill(s) ? '~/.claude/skills/' : '')}>
+																		{rel ?? (isGlobalDiskImportedSkill(s) ? '~/.claude/skills/' : '')}
+																	</div>
+																</button>
+																<div className="ref-settings-agent-skill-disk-actions">
+																	<button
+																		type="button"
+																		className={`ref-settings-toggle ref-settings-toggle--sm ${enabled ? 'is-on' : ''}`}
+																		role="switch"
+																		aria-checked={enabled}
+																		title={enabled ? t('settings.enabled') : t('settings.disabled')}
+																		onClick={() => toggleDiskSkill(s)}
+																	>
+																		<span className="ref-settings-toggle-knob" />
+																	</button>
+																	{!isGlobalDiskImportedSkill(s) && (
+																		<button
+																			type="button"
+																			className="ref-settings-agent-skill-disk-trash"
+																			disabled={busy || !onDeleteWorkspaceSkillDisk}
+																			title={t('agentSettings.skillDiskDeleteTitle')}
+																			aria-label={t('agentSettings.skillDiskDeleteTitle')}
+																			onClick={() => void deleteDiskSkill(s)}
+																		>
+																			<IconTrash />
+																		</button>
+																	)}
+																</div>
+															</li>
 											);
 										})}
 									</ul>

--- a/src/SettingsPage.tsx
+++ b/src/SettingsPage.tsx
@@ -359,6 +359,8 @@ type Props = {
 	onOpenWorkspaceSkillFile?: (relPath: string) => void | Promise<void>;
 	/** 删除磁盘上的技能目录（SKILL.md 相对路径）；成功返回 true */
 	onDeleteWorkspaceSkillDisk?: (skillMdRelPath: string) => Promise<boolean>;
+	/** 重新扫描磁盘技能（工作区 + 全局） */
+	onRefreshDiskSkills?: () => void;
 	editorSettings: EditorSettings;
 	onChangeEditorSettings: (v: EditorSettings) => void;
 	/** 语言切换后立即持久化（与关闭设置页时的全量保存配合） */
@@ -403,6 +405,7 @@ export function SettingsPage({
 	onOpenSkillCreator,
 	onOpenWorkspaceSkillFile,
 	onDeleteWorkspaceSkillDisk,
+	onRefreshDiskSkills,
 	editorSettings,
 	onChangeEditorSettings,
 	onPersistLanguage,
@@ -1279,6 +1282,7 @@ export function SettingsPage({
 									onOpenSkillCreator={onOpenSkillCreator}
 									onOpenWorkspaceSkillFile={onOpenWorkspaceSkillFile}
 									onDeleteWorkspaceSkillDisk={onDeleteWorkspaceSkillDisk}
+									onRefreshDiskSkills={onRefreshDiskSkills}
 								/>
 							</Suspense>
 						) : null}

--- a/src/agentSettingsTypes.ts
+++ b/src/agentSettingsTypes.ts
@@ -163,6 +163,8 @@ export type AgentCustomization = {
 	toolPermissionRules?: AgentToolPermissionRule[];
 	shouldAvoidPermissionPrompts?: boolean;
 	memoryExtraction?: AgentMemoryExtractionSettings;
+	/** 磁盘扫描 skill（工作区 + 全局）的启用/禁用覆盖（key 为 slug） */
+	diskSkillEnabledOverrides?: Record<string, boolean>;
 };
 
 export const defaultAgentCustomization = (): AgentCustomization => ({
@@ -181,6 +183,16 @@ export const defaultAgentCustomization = (): AgentCustomization => ({
 /** 主进程从 `.claude` / `.cursor` / `.async` 的 skills 目录扫描出的项，id 形如 `ws-skill-*`；不应写入 settings 或 `.async/agent.json`。 */
 export function isWorkspaceDiskImportedSkill(s: { id: string }): boolean {
 	return s.id.startsWith('ws-skill-');
+}
+
+/** 从用户主目录 `~/.claude/skills/`、`~/.async/skills/` 扫描出的全局 skill，id 形如 `global-skill-*`；不应写入 settings 或 `.async/agent.json`。 */
+export function isGlobalDiskImportedSkill(s: { id: string }): boolean {
+	return s.id.startsWith('global-skill-');
+}
+
+/** 任何从磁盘扫描导入的 skill（工作区或全局） */
+export function isAnyDiskImportedSkill(s: { id: string }): boolean {
+	return isWorkspaceDiskImportedSkill(s) || isGlobalDiskImportedSkill(s);
 }
 
 export function isPluginImportedSkill(s: { id: string } | null | undefined): boolean {

--- a/src/agentTurnFocus.test.ts
+++ b/src/agentTurnFocus.test.ts
@@ -6,6 +6,7 @@ import {
 	findLatestTurnStartUserIndex,
 	findStickyUserIndexForViewport,
 	resolveStickyUserIndex,
+	shouldEnableLatestTurnSpacer,
 	type MeasuredTurnFocusRow,
 } from './agentTurnFocus';
 import type { ChatMessage } from './threadTypes';
@@ -41,6 +42,13 @@ describe('agentTurnFocus', () => {
 		expect(buildConversationRenderKey('thread-1', 'agent')).not.toBe(
 			buildConversationRenderKey('thread-1', 'team')
 		);
+	});
+
+	it('allows the latest turn spacer whenever non-team mode may need geometric补高', () => {
+		expect(shouldEnableLatestTurnSpacer('agent')).toBe(true);
+		expect(shouldEnableLatestTurnSpacer('plan')).toBe(true);
+		expect(shouldEnableLatestTurnSpacer('ask')).toBe(true);
+		expect(shouldEnableLatestTurnSpacer('team')).toBe(false);
 	});
 
 	it('keeps turn focus on the latest user message even after a short assistant reply finishes', () => {
@@ -112,6 +120,7 @@ describe('agentTurnFocus', () => {
 			viewportHeight: 600,
 			topPadding: 8,
 			bottomPadding: 100,
+			stickyTopPx: 8,
 			activeTurnStartUserIndex: 2,
 			renderedRows: [
 				row({
@@ -149,7 +158,7 @@ describe('agentTurnFocus', () => {
 			],
 		});
 
-		expect(spacer).toBe(350);
+		expect(spacer).toBe(342);
 	});
 
 	it('includes team rows in the active turn section height', () => {
@@ -157,6 +166,7 @@ describe('agentTurnFocus', () => {
 			viewportHeight: 600,
 			topPadding: 8,
 			bottomPadding: 100,
+			stickyTopPx: 8,
 			activeTurnStartUserIndex: 2,
 			renderedRows: [
 				row({
@@ -183,7 +193,7 @@ describe('agentTurnFocus', () => {
 			],
 		});
 
-		expect(spacer).toBe(70);
+		expect(spacer).toBe(62);
 	});
 
 	it('returns zero when the active turn already fills the available viewport height', () => {
@@ -191,6 +201,7 @@ describe('agentTurnFocus', () => {
 			viewportHeight: 600,
 			topPadding: 8,
 			bottomPadding: 100,
+			stickyTopPx: 8,
 			activeTurnStartUserIndex: 2,
 			renderedRows: [
 				row({
@@ -432,6 +443,50 @@ describe('agentTurnFocus', () => {
 				latestTurnSpacerPx: 320,
 			})
 		).toBe(0);
+	});
+
+	it('releases sticky when the latest turn row has fully scrolled out of viewport', () => {
+		expect(
+			findStickyUserIndexForViewport({
+				renderedRows: [
+					row({
+						rowId: 'u1',
+						messageIndex: 0,
+						turnOwnerUserIndex: 0,
+						isTurnStart: true,
+						stickyUserIndex: 0,
+						top: -200,
+						height: 50,
+					}),
+					row({
+						rowId: 'a1',
+						messageIndex: 1,
+						turnOwnerUserIndex: 0,
+						top: -120,
+						height: 60,
+					}),
+					row({
+						rowId: 'u2',
+						messageIndex: 2,
+						turnOwnerUserIndex: 2,
+						isTurnStart: true,
+						stickyUserIndex: 2,
+						top: -100,
+						height: 48,
+					}),
+					row({
+						rowId: 'a2',
+						messageIndex: 3,
+						turnOwnerUserIndex: 2,
+						top: -30,
+						height: 20,
+					}),
+				],
+				stickyTopPx: 0,
+				latestTurnStartUserIndex: 2,
+				latestTurnSpacerPx: 400,
+			})
+		).toBeNull();
 	});
 
 	it('keeps sticky output after candidate selection', () => {

--- a/src/agentTurnFocus.ts
+++ b/src/agentTurnFocus.ts
@@ -24,6 +24,17 @@ export function buildConversationRenderKey(
 	return `${threadId ?? 'no-thread'}:${composerMode}`;
 }
 
+/**
+ * 是否允许最新一轮使用 tail spacer。
+ * 真正是否补高度由 computeTurnSectionSpacerPx 的几何结果决定：
+ * 只有当最后一轮内容过短、无法把最新 user 气泡推到置顶位时，才会得到正值 spacer。
+ */
+export function shouldEnableLatestTurnSpacer(
+	composerMode: ComposerMode
+): boolean {
+	return composerMode !== 'team';
+}
+
 export function findLatestTurnStartUserIndex(
 	displayMessages: ChatMessage[],
 	composerMode: ComposerMode,
@@ -58,6 +69,7 @@ export function computeTurnSectionSpacerPx(params: {
 	viewportHeight: number;
 	topPadding: number;
 	bottomPadding: number;
+	stickyTopPx: number;
 	renderedRows: MeasuredTurnFocusRow[];
 	activeTurnStartUserIndex: number | null;
 }): number {
@@ -65,6 +77,7 @@ export function computeTurnSectionSpacerPx(params: {
 		viewportHeight,
 		topPadding,
 		bottomPadding,
+		stickyTopPx,
 		renderedRows,
 		activeTurnStartUserIndex,
 	} = params;
@@ -89,6 +102,7 @@ export function computeTurnSectionSpacerPx(params: {
 			viewportHeight -
 				Math.max(0, topPadding) -
 				Math.max(0, bottomPadding) -
+				Math.max(0, stickyTopPx) -
 				activeRowHeight -
 				belowContentHeight
 		)
@@ -116,7 +130,8 @@ export function findStickyUserIndexForViewport(params: {
 	 * 只有当它还没有自然到达顶部之前，才短暂抑制旧轮次接管。
 	 */
 	if (latestTurnSpacerPx > 0 && latestTurnRow) {
-		if (latestTurnRow.top <= stickyBoundaryPx) {
+		const latestTurnBottom = latestTurnRow.top + Math.max(0, latestTurnRow.height);
+		if (latestTurnRow.top <= stickyBoundaryPx && latestTurnBottom > stickyBoundaryPx) {
 			return latestTurnRow.stickyUserIndex;
 		}
 		if (latestTurnRow.top < stickyBoundaryPx + Math.max(0, latestTurnRow.height)) {

--- a/src/composerSkillInvocations.ts
+++ b/src/composerSkillInvocations.ts
@@ -20,14 +20,18 @@ export function filterSkillInvokeMenuItems(
 }
 
 /**
- * 首段为 `./...` 且光标仍在「skill slug」内时返回查询词（不含 `./`）。
+ * 首段为 `./...` 或 `/...` 且光标仍在「skill slug」内时返回查询词（不含前缀）。
  * plainPrefix：caret 前由 DOM 采样的纯文本前缀，须与首段文本对齐。
  */
 export function getLeadingSkillInvokeQuery(firstSegmentText: string, plainPrefix: string): string | null {
-	if (!firstSegmentText.startsWith('./') || plainPrefix.length === 0 || !firstSegmentText.startsWith(plainPrefix)) {
+	const isDotSlash = firstSegmentText.startsWith('./');
+	const isSlash = firstSegmentText.startsWith('/') && !firstSegmentText.startsWith('//');
+	if ((!isDotSlash && !isSlash) || plainPrefix.length === 0 || !firstSegmentText.startsWith(plainPrefix)) {
 		return null;
 	}
-	const skillToken = firstSegmentText.match(/^\.\/(\S*)/);
+	const prefixLen = isDotSlash ? 2 : 1;
+	const pattern = isDotSlash ? /^\.\/(\S*)/ : /^\/(\S*)/;
+	const skillToken = firstSegmentText.match(pattern);
 	if (!skillToken) {
 		return null;
 	}
@@ -35,7 +39,7 @@ export function getLeadingSkillInvokeQuery(firstSegmentText: string, plainPrefix
 	if (plainPrefix.length > tokenEnd) {
 		return null;
 	}
-	const afterPrefix = plainPrefix.slice(2);
+	const afterPrefix = plainPrefix.slice(prefixLen);
 	if (/\s/u.test(afterPrefix)) {
 		return null;
 	}

--- a/src/hooks/useMessagesScroll.test.ts
+++ b/src/hooks/useMessagesScroll.test.ts
@@ -4,6 +4,7 @@ import {
 	derivePinnedBottomIntent,
 	deriveShowScrollToBottomButton,
 	measureMessagesScroll,
+	resolveContentBottomScroll,
 } from './useMessagesScroll';
 
 describe('useMessagesScroll helpers', () => {
@@ -58,5 +59,30 @@ describe('useMessagesScroll helpers', () => {
 			nearBottom: true,
 			canJumpToBottom: true,
 		});
+	});
+
+	it('resolves the bottom scroll target from the last rendered message row', () => {
+		const viewport = {
+			scrollHeight: 2000,
+			clientHeight: 400,
+			scrollTop: 120,
+			ownerDocument: {
+				defaultView: {
+					getComputedStyle: () => ({
+						paddingBottom: '96px',
+					}),
+				},
+			},
+			getBoundingClientRect: () => ({ top: 100 } as DOMRect),
+		} as unknown as HTMLElement;
+		const track = {
+			querySelectorAll: () =>
+				[
+					{ getBoundingClientRect: () => ({ bottom: 360 } as DOMRect) },
+					{ getBoundingClientRect: () => ({ bottom: 940 } as DOMRect) },
+				] as unknown as NodeListOf<HTMLElement>,
+		} as unknown as HTMLElement;
+
+		expect(resolveContentBottomScroll(viewport, track)).toBe(656);
 	});
 });

--- a/src/hooks/useMessagesScroll.ts
+++ b/src/hooks/useMessagesScroll.ts
@@ -12,6 +12,8 @@ import type { ChatMessage } from '../threadTypes';
 export const MESSAGES_FOLLOW_BOTTOM_BUFFER_PX = 120;
 const MESSAGES_MIN_SCROLLABLE_OVERFLOW_PX = 120;
 export const MESSAGES_SCROLL_TO_BOTTOM_BUTTON_DISTANCE_PX = 180;
+const MESSAGES_THREAD_OPEN_SETTLE_DELAY_MS = 420;
+const MESSAGES_THREAD_OPEN_SETTLE_MID_DELAY_MS = 180;
 
 export type MessagesScrollSnapshot = {
 	scrollTop: number;
@@ -52,19 +54,30 @@ export type UseMessagesScrollResult = {
 
 /** 计算滚动位置时，以「最后一条内容行（带 data-msg-index）的底部」为准，
  *  而不是 track 的 scrollHeight 底部。这样 turn 容器 padding、tail spacer 等
- *  纯装饰性高度不会把视口顶下去，避免消息被 sticky bubble 遮挡。 */
-function resolveContentBottomScroll(
+ *  纯装饰性高度不会把视口顶下去；同时保留 messages viewport 自己的
+ *  padding-bottom，让最后一条消息与底部输入区之间仍有安全呼吸感。 */
+function resolveViewportBottomInset(viewport: HTMLElement): number {
+	const view = viewport.ownerDocument?.defaultView;
+	if (!view?.getComputedStyle) {
+		return 0;
+	}
+	const styles = view.getComputedStyle(viewport);
+	const paddingBottom = Number.parseFloat(styles.paddingBottom || '0') || 0;
+	return Math.max(0, Math.min(paddingBottom, Math.max(0, viewport.clientHeight - 1)));
+}
+
+export function resolveContentBottomScroll(
 	viewport: HTMLElement,
 	track: HTMLElement | null
 ): number {
+	const bottomInset = resolveViewportBottomInset(viewport);
 	if (!track) {
-		return Math.max(0, viewport.scrollHeight - viewport.clientHeight);
+		return Math.max(0, viewport.scrollHeight - viewport.clientHeight - bottomInset);
 	}
-	const lastContentRow = track.querySelector<HTMLElement>(
-		'.ref-msg-row-measure[data-msg-index]:last-of-type'
-	);
+	const messageRows = track.querySelectorAll<HTMLElement>('.ref-msg-row-measure[data-msg-index]');
+	const lastContentRow = messageRows[messageRows.length - 1] ?? null;
 	if (!lastContentRow) {
-		return Math.max(0, viewport.scrollHeight - viewport.clientHeight);
+		return Math.max(0, viewport.scrollHeight - viewport.clientHeight - bottomInset);
 	}
 	/* 必须用 getBoundingClientRect 而非 offsetTop，因为 offsetParent
 	   在 editor-rail 等布局下可能是外层 ref-chat-drop-zone（position:relative），
@@ -72,7 +85,10 @@ function resolveContentBottomScroll(
 	const rowRect = lastContentRow.getBoundingClientRect();
 	const viewportRect = viewport.getBoundingClientRect();
 	const rowBottomInViewport = rowRect.bottom - viewportRect.top;
-	return Math.max(0, viewport.scrollTop + rowBottomInViewport - viewport.clientHeight);
+	return Math.max(
+		0,
+		viewport.scrollTop + rowBottomInViewport - (viewport.clientHeight - bottomInset)
+	);
 }
 
 export function measureMessagesScroll(
@@ -220,6 +236,25 @@ export function useMessagesScroll(params: UseMessagesScrollParams): UseMessagesS
 		syncMessagesScrollState('layout');
 	}, [syncMessagesScrollState]);
 
+	const applyResolvedBottomScroll = useCallback(
+		(behavior: ScrollBehavior = 'auto') => {
+			const el = messagesViewportRef.current;
+			if (!el) {
+				return false;
+			}
+			const track = messagesTrackRef.current;
+			const targetScroll = resolveContentBottomScroll(el, track);
+			if (behavior === 'auto') {
+				el.scrollTop = targetScroll;
+			} else {
+				el.scrollTo({ top: targetScroll, behavior });
+			}
+			syncMessagesScrollState('programmatic');
+			return true;
+		},
+		[syncMessagesScrollState]
+	);
+
 	const onMessagesScroll = useCallback(() => {
 		syncMessagesScrollState('user');
 	}, [syncMessagesScrollState]);
@@ -244,12 +279,9 @@ export function useMessagesScroll(params: UseMessagesScrollParams): UseMessagesS
 				clearScrollToBottomButtonSuppression();
 			}
 			setShowScrollToBottomButton(false);
-			const track = messagesTrackRef.current;
-			const targetScroll = resolveContentBottomScroll(el, track);
-			el.scrollTo({ top: targetScroll, behavior });
-			syncMessagesScrollState('programmatic');
+			applyResolvedBottomScroll(behavior);
 		},
-		[clearScrollToBottomButtonSuppression, syncMessagesScrollState]
+		[applyResolvedBottomScroll, clearScrollToBottomButtonSuppression]
 	);
 
 	const scheduleMessagesScrollToBottom = useCallback(() => {
@@ -261,15 +293,12 @@ export function useMessagesScroll(params: UseMessagesScrollParams): UseMessagesS
 		}
 		messagesScrollToBottomRafRef.current = requestAnimationFrame(() => {
 			messagesScrollToBottomRafRef.current = null;
-			const el = messagesViewportRef.current;
-			if (!el || !pinMessagesToBottomRef.current) {
+			if (!pinMessagesToBottomRef.current) {
 				return;
 			}
-			const track = messagesTrackRef.current;
-			el.scrollTop = resolveContentBottomScroll(el, track);
-			syncMessagesScrollState('programmatic');
+			applyResolvedBottomScroll('auto');
 		});
-	}, [syncMessagesScrollState]);
+	}, [applyResolvedBottomScroll]);
 
 	useLayoutEffect(() => {
 		pendingMessagesScrollRestoreRef.current = currentId;
@@ -291,22 +320,78 @@ export function useMessagesScroll(params: UseMessagesScrollParams): UseMessagesS
 		if (pendingMessagesScrollRestoreRef.current !== currentId) {
 			return;
 		}
-		const rafId = requestAnimationFrame(() => {
-			if (pendingMessagesScrollRestoreRef.current !== currentId) {
-				return;
+		let rafId1 = 0;
+		let rafId2 = 0;
+		let rafId3 = 0;
+		let timeoutId1 = 0;
+		let timeoutId2 = 0;
+		const restoreBottom = (clearPending = false) => {
+			if (
+				pendingMessagesScrollRestoreRef.current !== currentId &&
+				currentIdRef.current !== currentId
+			) {
+				return false;
 			}
-			const el = messagesViewportRef.current;
-			if (!el) {
-				return;
+			if (
+				currentIdRef.current !== currentId ||
+				messagesThreadIdRef.current !== currentId
+			) {
+				return false;
 			}
 			pinMessagesToBottomRef.current = true;
-			const track = messagesTrackRef.current;
-			el.scrollTop = resolveContentBottomScroll(el, track);
-			pendingMessagesScrollRestoreRef.current = null;
-			syncMessagesScrollState('programmatic');
+			const didScroll = applyResolvedBottomScroll('auto');
+			if (didScroll && clearPending) {
+				pendingMessagesScrollRestoreRef.current = null;
+			}
+			return didScroll;
+		};
+		rafId1 = requestAnimationFrame(() => {
+			if (!restoreBottom(true)) {
+				return;
+			}
+			rafId2 = requestAnimationFrame(() => {
+				if (!pinMessagesToBottomRef.current) {
+					return;
+				}
+				if (!restoreBottom()) {
+					return;
+				}
+				rafId3 = requestAnimationFrame(() => {
+					if (!pinMessagesToBottomRef.current) {
+						return;
+					}
+					restoreBottom();
+				});
+			});
 		});
-		return () => cancelAnimationFrame(rafId);
-	}, [hasConversation, currentId, messagesThreadId, messages.length, syncMessagesScrollState]);
+		timeoutId1 = window.setTimeout(() => {
+			if (!pinMessagesToBottomRef.current) {
+				return;
+			}
+			restoreBottom();
+		}, MESSAGES_THREAD_OPEN_SETTLE_MID_DELAY_MS);
+		timeoutId2 = window.setTimeout(() => {
+			if (!pinMessagesToBottomRef.current) {
+				return;
+			}
+			restoreBottom();
+		}, MESSAGES_THREAD_OPEN_SETTLE_DELAY_MS);
+		return () => {
+			cancelAnimationFrame(rafId1);
+			cancelAnimationFrame(rafId2);
+			cancelAnimationFrame(rafId3);
+			window.clearTimeout(timeoutId1);
+			window.clearTimeout(timeoutId2);
+		};
+	}, [
+		hasConversation,
+		currentId,
+		currentIdRef,
+		messages.length,
+		messagesThreadId,
+		messagesThreadIdRef,
+		applyResolvedBottomScroll,
+	]);
 
 	useLayoutEffect(() => {
 		const len = messages.length;
@@ -343,7 +428,7 @@ export function useMessagesScroll(params: UseMessagesScrollParams): UseMessagesS
 			return;
 		}
 		scheduleMessagesScrollToBottom();
-	}, [hasConversation, messages.length, currentId, scheduleMessagesScrollToBottom]);
+	}, [hasConversation, messages.length, currentId, messagesThreadId, scheduleMessagesScrollToBottom]);
 
 	useLayoutEffect(() => {
 		if (!hasConversation) {
@@ -354,7 +439,7 @@ export function useMessagesScroll(params: UseMessagesScrollParams): UseMessagesS
 			syncMessagesScrollState('layout');
 		});
 		return () => cancelAnimationFrame(rafId);
-	}, [hasConversation, messages.length, currentId, syncMessagesScrollState]);
+	}, [hasConversation, messages.length, currentId, messagesThreadId, syncMessagesScrollState]);
 
 	useEffect(() => {
 		if (!hasConversation) {
@@ -367,6 +452,10 @@ export function useMessagesScroll(params: UseMessagesScrollParams): UseMessagesS
 		}
 		messagesTrackScrollHeightRef.current = track.scrollHeight;
 		messagesViewportClientHeightRef.current = outer.clientHeight;
+		if (pinMessagesToBottomRef.current) {
+			scheduleMessagesScrollToBottom();
+		}
+		syncMessagesScrollState('layout');
 		const ro = new ResizeObserver(() => {
 			const nextTrackHeight = track.scrollHeight;
 			const nextViewportHeight = outer.clientHeight;
@@ -394,10 +483,40 @@ export function useMessagesScroll(params: UseMessagesScrollParams): UseMessagesS
 	}, [
 		hasConversation,
 		currentId,
+		messagesThreadId,
 		scheduleMessagesScrollToBottom,
 		syncMessagesScrollState,
 		clearScrollToBottomButtonSuppression,
 	]);
+
+	useEffect(() => {
+		if (!hasConversation) {
+			return;
+		}
+		const track = messagesTrackRef.current;
+		if (!track) {
+			return;
+		}
+		const onMessageAnimationEnd = (event: Event) => {
+			if (!pinMessagesToBottomRef.current) {
+				return;
+			}
+			const target = event.target;
+			if (
+				!(target instanceof HTMLElement) ||
+				!target.closest('.ref-msg-slot--user, .ref-msg-slot--assistant')
+			) {
+				return;
+			}
+			scheduleMessagesScrollToBottom();
+		};
+		track.addEventListener('animationend', onMessageAnimationEnd);
+		track.addEventListener('animationcancel', onMessageAnimationEnd);
+		return () => {
+			track.removeEventListener('animationend', onMessageAnimationEnd);
+			track.removeEventListener('animationcancel', onMessageAnimationEnd);
+		};
+	}, [hasConversation, currentId, messagesThreadId, messages.length, scheduleMessagesScrollToBottom]);
 
 	return {
 		messagesViewportRef,

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -17,9 +17,9 @@ import {
 } from '../providerIdentitySettings';
 import {
 	defaultAgentCustomization,
+	isAnyDiskImportedSkill,
 	isPluginImportedCommand,
 	isPluginImportedSkill,
-	isWorkspaceDiskImportedSkill,
 	mergeSkillsBySlug,
 	type TeamSettings,
 	type AgentCustomization,
@@ -108,10 +108,20 @@ export function useSettings(
 	const mergedAgentCustomization = useMemo((): AgentCustomization => {
 		const persistedSkills = [...(agentCustomization.skills ?? []), ...projectAgentSlice.skills];
 		const pluginThenPersistedSkills = mergeSkillsBySlug(pluginRuntimeState.skills, persistedSkills);
-		const skills =
+		const diskSkills =
 			workspaceDiskSkills.length > 0
 				? mergeSkillsBySlug(pluginThenPersistedSkills, workspaceDiskSkills)
 				: pluginThenPersistedSkills;
+		// 应用磁盘 skill 的启用/禁用覆盖
+		const overrides = agentCustomization.diskSkillEnabledOverrides ?? {};
+		const skills = diskSkills.map((s) => {
+			if (!isAnyDiskImportedSkill(s)) return s;
+			const slug = s.slug.trim().toLowerCase();
+			if (slug in overrides) {
+				return { ...s, enabled: overrides[slug] };
+			}
+			return s;
+		});
 		return {
 			...agentCustomization,
 			rules: [...(agentCustomization.rules ?? []), ...projectAgentSlice.rules],
@@ -126,7 +136,7 @@ export function useSettings(
 			const ur = next.rules?.filter((r) => (r.origin ?? 'user') !== 'project') ?? [];
 			const pr = next.rules?.filter((r) => r.origin === 'project') ?? [];
 			const skillsPersist = (next.skills ?? []).filter(
-				(s) => !isWorkspaceDiskImportedSkill(s) && !isPluginImportedSkill(s)
+				(s) => !isAnyDiskImportedSkill(s) && !isPluginImportedSkill(s)
 			);
 			const us = skillsPersist.filter((s) => (s.origin ?? 'user') !== 'project');
 			const ps = skillsPersist.filter((s) => s.origin === 'project');

--- a/src/i18n/messages.en.ts
+++ b/src/i18n/messages.en.ts
@@ -1643,6 +1643,8 @@ export const messagesEn: Record<string, string> = {
 	'agentSettings.skillsImportPrompt': 'Paste SKILL.md content (with frontmatter):',
 	'agentSettings.skillsImportSuccess': 'Skill imported successfully',
 	'agentSettings.skillsImportError': 'Failed to parse SKILL.md, please check format',
+	'agentSettings.skillsRefresh': 'Refresh',
+	'agentSettings.skillsRefreshTitle': 'Rescan disk skills',
 	'agentSettings.skillCreatorThreadTitle': 'Skill creator',
 	'agentSettings.skillCreatorHelp':
 		'The composer shows a blue `/create-skill` chip; type your request after it. Before send you pick scope, and the app injects a built-in system brief for SKILL.md-style output—no long prompt paste needed.',
@@ -1718,8 +1720,7 @@ export const messagesEn: Record<string, string> = {
 	'agentSettings.rulesTitle': 'Rules',
 	'agentSettings.rulesInfo': 'Inject by scope into system prompt',
 	'agentSettings.new': 'New',
-	'agentSettings.rulesDesc':
-		'Always: every chat. Glob: when @ paths match your pattern. Manual: when the message contains @rule:name or @rule:uuid (markers are stripped).',
+	'agentSettings.rulesDesc': 'Auto-injected into system prompt by scope.',
 	'agentSettings.ruleNameAria': 'Rule name',
 	'agentSettings.autoLanguageRuleBadge': 'Auto',
 	'agentSettings.autoLanguageRuleHint':
@@ -1734,8 +1735,7 @@ export const messagesEn: Record<string, string> = {
 	'agentSettings.rulesEmpty': 'No rules yet. Click New to add one.',
 	'agentSettings.skillsTitle': 'Skills',
 	'agentSettings.skillsInfo': 'Create in chat; or add SKILL.md on disk; ./slug in input',
-	'agentSettings.skillsDesc':
-		'Specialized capabilities. Use “+ New” to create in chat, or add `.cursor/skills/<name>/SKILL.md` (and the same under `.claude` / `.async`). You can also start a message with ./slug.',
+	'agentSettings.skillsDesc': 'Editable items merge with disk-scanned items by slug; enabled ones are injected into system prompt.',
 	'agentSettings.pluginSkillsTitle': 'Plugin skills',
 	'agentSettings.skillNameAria': 'Skill name',
 	'agentSettings.slugLabel': 'slug (without ./)',

--- a/src/i18n/messages.en.ts
+++ b/src/i18n/messages.en.ts
@@ -1637,6 +1637,12 @@ export const messagesEn: Record<string, string> = {
 	'agentSettings.newSkillChat': 'Create in chat',
 	'agentSettings.newSkillManual': 'Add manually',
 	'agentSettings.skillsNew': '+ New',
+	'agentSettings.skillsTemplate': 'Templates',
+	'agentSettings.skillsTemplateTitle': 'Create skill from template',
+	'agentSettings.skillsImport': 'Import',
+	'agentSettings.skillsImportPrompt': 'Paste SKILL.md content (with frontmatter):',
+	'agentSettings.skillsImportSuccess': 'Skill imported successfully',
+	'agentSettings.skillsImportError': 'Failed to parse SKILL.md, please check format',
 	'agentSettings.skillCreatorThreadTitle': 'Skill creator',
 	'agentSettings.skillCreatorHelp':
 		'The composer shows a blue `/create-skill` chip; type your request after it. Before send you pick scope, and the app injects a built-in system brief for SKILL.md-style output—no long prompt paste needed.',

--- a/src/i18n/messages.zh-CN.ts
+++ b/src/i18n/messages.zh-CN.ts
@@ -1619,6 +1619,12 @@ export const messagesZhCN: Record<string, string> = {
 	'agentSettings.newSkillChat': '对话创建',
 	'agentSettings.newSkillManual': '手动添加',
 	'agentSettings.skillsNew': '+ 新建',
+	'agentSettings.skillsTemplate': '模板',
+	'agentSettings.skillsTemplateTitle': '从模板快速创建 Skill',
+	'agentSettings.skillsImport': '导入',
+	'agentSettings.skillsImportPrompt': '粘贴 SKILL.md 内容（包含 frontmatter）：',
+	'agentSettings.skillsImportSuccess': 'Skill 导入成功',
+	'agentSettings.skillsImportError': '解析 SKILL.md 失败，请检查格式',
 	'agentSettings.skillCreatorThreadTitle': 'Skill 创建向导',
 	'agentSettings.skillCreatorHelp':
 		'输入框会显示蓝色 `/create-skill` 标签，其后填写说明；发送前会询问适用范围，内置系统提示会引导模型按 SKILL.md 规范输出（无需自行粘贴长提示词）。',

--- a/src/i18n/messages.zh-CN.ts
+++ b/src/i18n/messages.zh-CN.ts
@@ -1625,6 +1625,8 @@ export const messagesZhCN: Record<string, string> = {
 	'agentSettings.skillsImportPrompt': '粘贴 SKILL.md 内容（包含 frontmatter）：',
 	'agentSettings.skillsImportSuccess': 'Skill 导入成功',
 	'agentSettings.skillsImportError': '解析 SKILL.md 失败，请检查格式',
+	'agentSettings.skillsRefresh': '刷新',
+	'agentSettings.skillsRefreshTitle': '重新扫描磁盘上的 Skills',
 	'agentSettings.skillCreatorThreadTitle': 'Skill 创建向导',
 	'agentSettings.skillCreatorHelp':
 		'输入框会显示蓝色 `/create-skill` 标签，其后填写说明；发送前会询问适用范围，内置系统提示会引导模型按 SKILL.md 规范输出（无需自行粘贴长提示词）。',
@@ -1696,8 +1698,7 @@ export const messagesZhCN: Record<string, string> = {
 	'agentSettings.rulesTitle': '规则',
 	'agentSettings.rulesInfo': '按作用域注入系统提示',
 	'agentSettings.new': '新建',
-	'agentSettings.rulesDesc':
-		'Always：每轮对话；Glob：@ 路径匹配 glob 时；Manual：消息中含 @rule: 名称或 uuid 时注入（标记会从正文去掉）。',
+	'agentSettings.rulesDesc': '按作用域自动注入系统提示。',
 	'agentSettings.ruleNameAria': '规则名称',
 	'agentSettings.autoLanguageRuleBadge': '自动',
 	'agentSettings.autoLanguageRuleHint': '由「界面语言」自动生成，并会作为 Always 规则始终注入。',
@@ -1711,8 +1712,7 @@ export const messagesZhCN: Record<string, string> = {
 	'agentSettings.rulesEmpty': '暂无规则。点击「新建」添加。',
 	'agentSettings.skillsTitle': 'Skills',
 	'agentSettings.skillsInfo': '对话中创建；或在工作区放置 SKILL.md；输入框可用 ./slug',
-	'agentSettings.skillsDesc':
-		'专项能力说明。请用「+ 新建」在对话中创建；或在仓库中添加 `.cursor/skills/<名称>/SKILL.md`（及 `.claude` / `.async` 下同类路径）。对话里也可 `./slug` 触发。',
+	'agentSettings.skillsDesc': '可编辑项与磁盘扫描项按 slug 合并，启用后注入系统提示。',
 	'agentSettings.pluginSkillsTitle': '插件 Skills',
 	'agentSettings.skillNameAria': 'Skill 名称',
 	'agentSettings.slugLabel': 'slug（不含 ./）',

--- a/src/index.css
+++ b/src/index.css
@@ -4677,7 +4677,7 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 
 /* assistant 气泡中 ChatMarkdown(renderMode='outcome') 在 outcome 段尚为空时返回空容器；
  * 这里让其不占间距，避免气泡"空着"留白。 */
-.ref-msg-assistant-body > .ref-md-root--agent-chat:empty {
+.ref-msg-assistant-body > .ref-md-root--agent-chat:empty:not([data-turn-focus-fill-px]) {
 	display: none;
 }
 
@@ -15481,6 +15481,99 @@ select.ref-settings-native-select:focus {
 .ref-settings-agent-skill-disk-trash:disabled {
 	opacity: 0.4;
 	cursor: not-allowed;
+}
+
+.ref-settings-agent-skill-disk-actions {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 10px 14px;
+	border-top: 1px solid var(--void-border-soft);
+	background: var(--void-bg-1);
+}
+
+.ref-settings-agent-template-dropdown {
+	position: relative;
+	display: inline-block;
+}
+
+.ref-settings-agent-template-menu {
+	display: none;
+	position: absolute;
+	right: 0;
+	top: 100%;
+	margin-top: 4px;
+	min-width: 220px;
+	max-height: 280px;
+	overflow-y: auto;
+	background: var(--void-bg-1);
+	border: 1px solid var(--void-border-soft);
+	border-radius: 10px;
+	box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+	z-index: 100;
+	padding: 6px;
+}
+
+.ref-settings-agent-template-dropdown:hover .ref-settings-agent-template-menu,
+.ref-settings-agent-template-dropdown:focus-within .ref-settings-agent-template-menu {
+	display: block;
+}
+
+.ref-settings-agent-template-item {
+	width: 100%;
+	text-align: left;
+	padding: 8px 10px;
+	border-radius: 8px;
+	border: none;
+	background: transparent;
+	color: var(--void-fg-1);
+	cursor: pointer;
+	transition: background 0.15s;
+}
+
+.ref-settings-agent-template-item:hover {
+	background: var(--void-bg-2);
+}
+
+.ref-settings-agent-template-name {
+	font-weight: 600;
+	font-size: 13px;
+}
+
+.ref-settings-agent-template-desc {
+	font-size: 11px;
+	color: var(--void-fg-3);
+	margin-top: 2px;
+	line-height: 1.4;
+}
+
+.ref-settings-agent-new-btn--secondary {
+	background: var(--void-bg-2);
+	color: var(--void-fg-2);
+}
+
+.ref-settings-agent-new-btn--secondary:hover {
+	background: var(--void-bg-3);
+}
+
+.ref-settings-agent-import-box {
+	border: 1px solid var(--void-border-soft);
+	border-radius: 12px;
+	padding: 14px;
+	margin-bottom: 14px;
+	background: var(--void-bg-1);
+}
+
+.ref-settings-agent-import-error {
+	color: #ef4444;
+	font-size: 12px;
+	margin: 6px 0 0;
+}
+
+.ref-settings-agent-import-actions {
+	display: flex;
+	gap: 8px;
+	margin-top: 10px;
 }
 
 .ref-settings-agent-item {

--- a/src/index.css
+++ b/src/index.css
@@ -15039,17 +15039,27 @@ select.ref-settings-native-select:focus {
 
 .ref-settings-agent-origin-badge {
 	flex-shrink: 0;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
 	font-size: 10px;
 	font-weight: 600;
 	text-transform: uppercase;
 	letter-spacing: 0.04em;
-	padding: 3px 8px;
+	line-height: 1;
+	padding: 4px 9px;
 	border-radius: 6px;
 	border: 1px solid var(--void-border-soft);
 	max-width: 7rem;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+	vertical-align: middle;
+}
+
+/* 开关与来源徽章之间略增距，避免与左侧控件挤在一起 */
+.ref-settings-agent-item-head > .ref-settings-toggle + .ref-settings-agent-origin-badge {
+	margin-left: 6px;
 }
 
 .ref-settings-agent-origin-badge--user {
@@ -15425,11 +15435,20 @@ select.ref-settings-native-select:focus {
 }
 
 .ref-settings-agent-skill-disk-title {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	column-gap: 10px;
+	row-gap: 6px;
 	font-size: 14px;
 	font-weight: 700;
 	color: var(--void-fg-0);
 	line-height: 1.35;
 	margin: 0;
+}
+
+.ref-settings-agent-skill-disk-title > .ref-settings-agent-origin-badge {
+	flex-shrink: 0;
 }
 
 .ref-settings-agent-skill-disk-desc {

--- a/src/useComposerSkillInvoke.ts
+++ b/src/useComposerSkillInvoke.ts
@@ -60,11 +60,12 @@ export function useComposerSkillInvoke(
 		(root: HTMLElement, slot: AtComposerSlot) => {
 			skillSlotRef.current = slot;
 			const segs = readSegmentsFromRoot(root);
-			if (segs.length !== 1 || segs[0]?.kind !== 'text' || !segs[0].text.startsWith('./')) {
+			const firstText = segs[0]?.text ?? '';
+			const isSkillPrefix = firstText.startsWith('./') || (firstText.startsWith('/') && !firstText.startsWith('//'));
+			if (segs.length !== 1 || segs[0]?.kind !== 'text' || !isSkillPrefix) {
 				closeSkillMenu();
 				return;
 			}
-			const firstText = segs[0].text;
 			const plainPrefix = textBeforeCaretForAt(root);
 			const q = getLeadingSkillInvokeQuery(firstText, plainPrefix);
 			if (q === null) {
@@ -100,7 +101,9 @@ export function useComposerSkillInvoke(
 				return;
 			}
 			const segs = readSegmentsFromRoot(r);
-			if (segs.length !== 1 || segs[0]?.kind !== 'text' || !segs[0].text.startsWith('./')) {
+			const firstText2 = segs[0]?.text ?? '';
+				const isSkillPrefix2 = firstText2.startsWith('./') || (firstText2.startsWith('/') && !firstText2.startsWith('//'));
+				if (segs.length !== 1 || segs[0]?.kind !== 'text' || !isSkillPrefix2) {
 				closeSkillMenu();
 				return;
 			}
@@ -166,13 +169,15 @@ export function useComposerSkillInvoke(
 				return;
 			}
 			const segs = readSegmentsFromRoot(root);
-			if (segs.length !== 1 || segs[0]?.kind !== 'text' || !segs[0].text.startsWith('./')) {
+			const firstText2 = segs[0]?.text ?? '';
+				const isSkillPrefix2 = firstText2.startsWith('./') || (firstText2.startsWith('/') && !firstText2.startsWith('//'));
+				if (segs.length !== 1 || segs[0]?.kind !== 'text' || !isSkillPrefix2) {
 				closeSkillMenu();
 				return;
 			}
 			const t = segs[0].text;
-			const skillTok = t.match(/^\.\/\S*/);
-			const skillLen = skillTok ? skillTok[0]!.length : 2;
+			const skillTok = t.match(/^\.\/\S*/) || t.match(/^\/\S*/);
+			const skillLen = skillTok ? skillTok[0]!.length : (t.startsWith('./') ? 2 : 1);
 			const tail = t.slice(skillLen);
 			const setSeg = getSegmentsSetter(skillSlotRef.current);
 			setSeg([


### PR DESCRIPTION
## Summary

This branch improves agent skill handling end-to-end: workspace and user-level skills on disk, clearer settings UI, composer integration tweaks, and smoother chat scrolling around turn focus. It also includes a small CSS fix for origin badges in agent settings.

## Changes

### Skills and settings

- Extend agent settings types and `SettingsAgentPanel` for disk-based skills: library sourced from the workspace and user home (for example `~/.claude/skills`), with origin labeling and related copy in English and Chinese.
- Skill import UI and wiring through settings (`SettingsPage`, `useSettings`).
- IPC adjustments in `main-src/ipc/register.ts` to support the new flows.

### Composer and LLM

- `agentMessagePrep`: include home-directory skill paths and related message preparation so the model sees the right skill context.
- `composerSkillInvocations` / `useComposerSkillInvoke`: align invocation behavior with the updated skill model.
- `ChatMarkdown` / `AgentChatPanel`: `/skill`-style prefix handling and related chat UI behavior.

### Chat scroll and turn focus

- `useMessagesScroll`: refined scroll logic (with tests) for a better experience when focusing or following the active turn.
- `agentTurnFocus`: updates and expanded tests for turn-focused scrolling.

### Styling

- `index.css`: layout and spacing for `.ref-settings-agent-origin-badge` (including disk skill titles and item rows) so badges align with adjacent text and are not cramped against the toggle or title.

## Testing

- Unit tests updated or added for `agentTurnFocus` and `useMessagesScroll`.

## Commits

- `feat(agent): home-dir skills, disk overrides, skill import UI, turn-focus scroll and /skill prefix`
- `fix(css): vertically center origin badge in disk skill title`
