### PR TITLE
ref(chat): thread IPC, workspace UX, and preflight UI fixes

### DIFF
--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -63,6 +63,7 @@ const INVOKE_CHANNELS = new Set([
 	'usageStats:pickDirectory',
 	'theme:applyChrome',
 	'threads:list',
+	'threads:listLight',
 	'threads:listAgentSidebar',
 	'threads:messages',
 	'threads:fileStates',

--- a/main-src/ipc/register.ts
+++ b/main-src/ipc/register.ts
@@ -106,7 +106,7 @@ import {
 	getCurrentThreadId,
 	getThread,
 	listThreads,
-	threadHasUserMessages,
+	listThreadWorkspaceRoots,
 	replaceFromUserVisibleIndex,
 	selectThread,
 	setThreadGeneratedTitle,
@@ -129,6 +129,7 @@ import {
 	saveTeamSession,
 	getAgentSession,
 	type ChatMessage,
+	type ThreadRecord,
 } from '../threadStore.js';
 import { compressForSend } from '../agent/conversationCompress.js';
 import { flattenAssistantTextPartsForSearch } from '../../src/agentStructuredMessage.js';
@@ -205,7 +206,12 @@ import {
 	writeWorkspaceAgentProjectSlice,
 	type WorkspaceAgentProjectSlice,
 } from '../workspaceAgentStore.js';
-import { summarizeThreadForSidebar, isTimestampToday, pruneSummaryCache } from '../threadListSummary.js';
+import {
+	summarizeThreadForSidebarWithMeta,
+	isTimestampToday,
+	pruneSummaryCache,
+	type ThreadRowSummary,
+} from '../threadListSummary.js';
 import { registerTerminalSessionIpc } from '../terminalSessionIpc.js';
 
 import {
@@ -1364,7 +1370,17 @@ export function registerIpc(): void {
 
 	ipcMain.handle('workspace:listRecents', () => {
 		const t0 = performance.now();
-		const paths = getRecentWorkspaces().filter((p) => {
+		const seen = new Set<string>();
+		const candidates = [
+			...getRecentWorkspaces(),
+			...listThreadWorkspaceRoots({ onlyWithUserMessages: true }),
+		];
+		const paths = candidates.filter((p) => {
+			const key = path.resolve(p).replace(/\\/g, '/').toLowerCase();
+			if (seen.has(key)) {
+				return false;
+			}
+			seen.add(key);
 			try {
 				return fs.existsSync(p) && fs.statSync(p).isDirectory();
 			} catch {
@@ -2342,9 +2358,152 @@ export function registerIpc(): void {
 	// 防止 summarizeThreadForSidebar 对大量/长消息的 thread 进行批量 diff 扫描时
 	// 阻塞主进程，导致 Electron 窗口拖动等原生事件无法响应。
 	const THREAD_SUMMARIZE_BATCH = 8;
+	const THREAD_CACHED_ROW_BATCH = 64;
 	function yieldToEventLoop(): Promise<void> {
 		return new Promise((resolve) => setImmediate(resolve));
 	}
+
+	type ThreadListVersion = {
+		id: string;
+		updatedAt: number;
+	};
+
+	type ThreadSidebarLightRow = {
+		id: string;
+		title: string;
+		updatedAt: number;
+		createdAt: number;
+		previewCount: number;
+		hasUserMessages: boolean;
+		isToday: boolean;
+		tokenUsage: ThreadRecord['tokenUsage'];
+		fileStateCount: number;
+	};
+
+	type ThreadSidebarRow = {
+		id: string;
+		title: string;
+		updatedAt: number;
+		createdAt: number;
+		isToday: boolean;
+		tokenUsage: ThreadRecord['tokenUsage'];
+		fileStateCount: number;
+	} & ThreadRowSummary;
+
+	function collectThreadLightStats(t: ThreadRecord): { previewCount: number; hasUserMessages: boolean } {
+		let previewCount = 0;
+		let hasUserMessages = false;
+		for (const message of t.messages) {
+			if (message.role === 'system') {
+				continue;
+			}
+			previewCount += 1;
+			if (message.role === 'user' && !hasUserMessages && /\S/.test(message.content)) {
+				hasUserMessages = true;
+			}
+		}
+		return { previewCount, hasUserMessages };
+	}
+
+	function buildThreadSidebarLightRow(t: ThreadRecord, now: number): ThreadSidebarLightRow {
+		const stats = collectThreadLightStats(t);
+		return {
+			id: t.id,
+			title: t.title,
+			updatedAt: t.updatedAt,
+			createdAt: t.createdAt,
+			previewCount: stats.previewCount,
+			hasUserMessages: stats.hasUserMessages,
+			isToday: isTimestampToday(t.updatedAt, now),
+			tokenUsage: t.tokenUsage,
+			fileStateCount: t.fileStates ? Object.keys(t.fileStates).length : 0,
+		};
+	}
+
+	function buildThreadSidebarRow(
+		t: ThreadRecord,
+		now: number,
+		workspaceRoot: string | null | undefined
+	): { row: ThreadSidebarRow; cacheHit: boolean } {
+		const { summary, cacheHit } = summarizeThreadForSidebarWithMeta(t, workspaceRoot);
+		return {
+			cacheHit,
+			row: {
+				id: t.id,
+				title: t.title,
+				updatedAt: t.updatedAt,
+				createdAt: t.createdAt,
+				isToday: isTimestampToday(t.updatedAt, now),
+				tokenUsage: t.tokenUsage,
+				fileStateCount: t.fileStates ? Object.keys(t.fileStates).length : 0,
+				...summary,
+			},
+		};
+	}
+
+	function parseRequestedThreadVersions(rawVersions: unknown): Map<string, number> | null {
+		if (!Array.isArray(rawVersions) || rawVersions.length === 0) {
+			return null;
+		}
+		const versions = new Map<string, number>();
+		for (const item of rawVersions) {
+			if (!item || typeof item !== 'object') {
+				continue;
+			}
+			const rec = item as Partial<ThreadListVersion>;
+			const id = typeof rec.id === 'string' ? rec.id : '';
+			const updatedAt = typeof rec.updatedAt === 'number' ? rec.updatedAt : Number.NaN;
+			if (id && Number.isFinite(updatedAt)) {
+				versions.set(id, updatedAt);
+			}
+		}
+		return versions.size > 0 ? versions : null;
+	}
+
+	ipcMain.handle('threads:listLight', async (event) => {
+		const t0 = performance.now();
+		const scope = senderWorkspaceRoot(event);
+		ensureDefaultThread(scope);
+		const now = Date.now();
+		const raw = listThreads(scope);
+		const threads = raw.map((t) => buildThreadSidebarLightRow(t, now));
+		console.log(`[perf][main] threads:listLight total=${(performance.now() - t0).toFixed(1)}ms count=${threads.length}`);
+		return { threads, currentId: getCurrentThreadId(scope) };
+	});
+
+	ipcMain.handle('threads:listDetails', async (event, rawVersions: unknown) => {
+		const t0 = performance.now();
+		const scope = senderWorkspaceRoot(event);
+		ensureDefaultThread(scope);
+		const now = Date.now();
+		const raw = listThreads(scope);
+		const requestedVersions = parseRequestedThreadVersions(rawVersions);
+		console.log(`[perf][main] threads:listDetails listThreads=${(performance.now() - t0).toFixed(1)}ms count=${raw.length}`);
+		const threads = [];
+		let cacheHits = 0;
+		let cacheMissesSinceYield = 0;
+		let rowsSinceYield = 0;
+		for (let i = 0; i < raw.length; i++) {
+			const t = raw[i]!;
+			if (requestedVersions && requestedVersions.get(t.id) !== t.updatedAt) {
+				continue;
+			}
+			const { row, cacheHit } = buildThreadSidebarRow(t, now, scope);
+			threads.push(row);
+			cacheHits += cacheHit ? 1 : 0;
+			cacheMissesSinceYield += cacheHit ? 0 : 1;
+			rowsSinceYield += 1;
+			if (cacheMissesSinceYield >= THREAD_SUMMARIZE_BATCH || rowsSinceYield >= THREAD_CACHED_ROW_BATCH) {
+				cacheMissesSinceYield = 0;
+				rowsSinceYield = 0;
+				await yieldToEventLoop();
+			}
+		}
+		console.log(`[perf][main] threads:listDetails total=${(performance.now() - t0).toFixed(1)}ms summarized=${threads.length} cacheHits=${cacheHits}`);
+		// Prune cached summaries for threads that no longer exist in this workspace.
+		pruneSummaryCache(new Set(raw.map((t) => t.id)), scope);
+		return { threads, currentId: getCurrentThreadId(scope) };
+	});
 
 	ipcMain.handle('threads:list', async (event) => {
 		const t0 = performance.now();
@@ -2354,28 +2513,24 @@ export function registerIpc(): void {
 		const raw = listThreads(scope);
 		console.log(`[perf][main] threads:list listThreads=${(performance.now() - t0).toFixed(1)}ms count=${raw.length}`);
 		const threads = [];
+		let cacheHits = 0;
+		let cacheMissesSinceYield = 0;
+		let rowsSinceYield = 0;
 		for (let i = 0; i < raw.length; i++) {
 			const t = raw[i]!;
-			const sum = summarizeThreadForSidebar(t);
-			threads.push({
-				id: t.id,
-				title: t.title,
-				updatedAt: t.updatedAt,
-				createdAt: t.createdAt,
-				previewCount: t.messages.filter((m) => m.role !== 'system').length,
-				hasUserMessages: threadHasUserMessages(t),
-				isToday: isTimestampToday(t.updatedAt, now),
-				tokenUsage: t.tokenUsage,
-				fileStateCount: t.fileStates ? Object.keys(t.fileStates).length : 0,
-				...sum,
-			});
-			if ((i + 1) % THREAD_SUMMARIZE_BATCH === 0) {
+			const { row, cacheHit } = buildThreadSidebarRow(t, now, scope);
+			threads.push(row);
+			cacheHits += cacheHit ? 1 : 0;
+			cacheMissesSinceYield += cacheHit ? 0 : 1;
+			rowsSinceYield += 1;
+			if (cacheMissesSinceYield >= THREAD_SUMMARIZE_BATCH || rowsSinceYield >= THREAD_CACHED_ROW_BATCH) {
+				cacheMissesSinceYield = 0;
+				rowsSinceYield = 0;
 				await yieldToEventLoop();
 			}
 		}
-		console.log(`[perf][main] threads:list total=${(performance.now() - t0).toFixed(1)}ms summarized=${threads.length}`);
-		// Prune cached summaries for threads that no longer exist in this workspace.
-		pruneSummaryCache(new Set(raw.map((t) => t.id)));
+		console.log(`[perf][main] threads:list total=${(performance.now() - t0).toFixed(1)}ms summarized=${threads.length} cacheHits=${cacheHits}`);
+		pruneSummaryCache(new Set(raw.map((t) => t.id)), scope);
 		return { threads, currentId: getCurrentThreadId(scope) };
 	});
 
@@ -2403,25 +2558,21 @@ export function registerIpc(): void {
 			}
 			const raw = listThreads(resolved);
 			const threads = [];
+			let cacheMissesSinceYield = 0;
+			let rowsSinceYield = 0;
 			for (let i = 0; i < raw.length; i++) {
 				const t = raw[i]!;
-				const sum = summarizeThreadForSidebar(t);
-				threads.push({
-					id: t.id,
-					title: t.title,
-					updatedAt: t.updatedAt,
-					createdAt: t.createdAt,
-					previewCount: t.messages.filter((m) => m.role !== 'system').length,
-					hasUserMessages: threadHasUserMessages(t),
-					isToday: isTimestampToday(t.updatedAt, now),
-					tokenUsage: t.tokenUsage,
-					fileStateCount: t.fileStates ? Object.keys(t.fileStates).length : 0,
-					...sum,
-				});
-				if ((i + 1) % THREAD_SUMMARIZE_BATCH === 0) {
+				const { row, cacheHit } = buildThreadSidebarRow(t, now, resolved);
+				threads.push(row);
+				cacheMissesSinceYield += cacheHit ? 0 : 1;
+				rowsSinceYield += 1;
+				if (cacheMissesSinceYield >= THREAD_SUMMARIZE_BATCH || rowsSinceYield >= THREAD_CACHED_ROW_BATCH) {
+					cacheMissesSinceYield = 0;
+					rowsSinceYield = 0;
 					await yieldToEventLoop();
 				}
 			}
+			pruneSummaryCache(new Set(raw.map((t) => t.id)), resolved);
 			workspaces.push({ requestedPath: dirPath, resolvedPath: resolved, threads, currentId: getCurrentThreadId(resolved) });
 		}
 		return { workspaces };

--- a/main-src/ipc/register.ts
+++ b/main-src/ipc/register.ts
@@ -638,7 +638,9 @@ async function spawnDetachedLaunch(
 
 async function launchWorkspaceInExternalEditor(
 	tool: Extract<ExternalWorkspaceTool, 'vscode' | 'cursor' | 'antigravity'>,
-	workspaceRoot: string
+	workspaceRoot: string,
+	targetPath?: string,
+	revealLine?: number
 ): Promise<boolean> {
 	const commandCandidates = {
 		vscode: ['code'],
@@ -652,7 +654,9 @@ async function launchWorkspaceInExternalEditor(
 	if (!resolved) {
 		return false;
 	}
-	await spawnDetachedLaunch(resolved.command, ['-n', workspaceRoot], {
+	const target = targetPath ?? workspaceRoot;
+	const targetArg = targetPath && Number.isFinite(revealLine) && revealLine > 0 ? `${targetPath}:${Math.floor(revealLine)}` : target;
+	await spawnDetachedLaunch(resolved.command, ['-n', targetArg], {
 		cwd: workspaceRoot,
 		useShell: resolved.useShell,
 		windowsHide: true,
@@ -1312,13 +1316,29 @@ export function registerIpc(): void {
 		if (!root) {
 			return { ok: false as const, code: 'no-workspace' as const };
 		}
-		const tool = (payload as { tool?: unknown } | null | undefined)?.tool;
+		const input = payload as
+			| { tool?: unknown; relPath?: unknown; revealLine?: unknown; revealEndLine?: unknown }
+			| null
+			| undefined;
+		const tool = input?.tool;
 		if (!isExternalWorkspaceTool(tool)) {
 			return { ok: false as const, code: 'unsupported-tool' as const, error: 'unsupported tool' };
 		}
+		const relPath = typeof input?.relPath === 'string' ? input.relPath.trim() : '';
+		let targetPath: string | undefined;
+		if (relPath) {
+			const normalizedRel = relPath.replace(/\\/g, '/');
+			const resolvedTarget = path.resolve(root, normalizedRel);
+			const relativeToRoot = path.relative(root, resolvedTarget);
+			if (relativeToRoot.startsWith('..') || path.isAbsolute(relativeToRoot)) {
+				return { ok: false as const, code: 'outside-workspace' as const, error: 'path is outside workspace' };
+			}
+			targetPath = resolvedTarget;
+		}
+		const revealLine = typeof input?.revealLine === 'number' ? input.revealLine : undefined;
 		try {
 			if (tool === 'explorer') {
-				const err = await shell.openPath(root);
+				const err = await shell.openPath(targetPath ?? root);
 				return err
 					? ({ ok: false as const, code: 'launch-failed' as const, error: err } as const)
 					: ({ ok: true as const } as const);
@@ -1329,7 +1349,7 @@ export function registerIpc(): void {
 					? ({ ok: true as const } as const)
 					: ({ ok: false as const, code: 'tool-unavailable' as const } as const);
 			}
-			const ok = await launchWorkspaceInExternalEditor(tool, root);
+			const ok = await launchWorkspaceInExternalEditor(tool, root, targetPath, revealLine);
 			return ok
 				? ({ ok: true as const } as const)
 				: ({ ok: false as const, code: 'tool-unavailable' as const } as const);

--- a/main-src/threadListSummary.test.ts
+++ b/main-src/threadListSummary.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { ChatMessage } from './threadStore.js';
+import {
+	clearSummaryCacheForTests,
+	pruneSummaryCache,
+	summarizeThreadForSidebar,
+} from './threadListSummary.js';
+
+function thread(messages: ChatMessage[], options?: { id?: string; updatedAt?: number }) {
+	return {
+		id: options?.id ?? 'thread-1',
+		updatedAt: options?.updatedAt ?? 1,
+		messages,
+	};
+}
+
+function diffAssistant(addedLine: string): ChatMessage {
+	return {
+		role: 'assistant',
+		content: [
+			'Done.',
+			'```diff',
+			'diff --git a/file.txt b/file.txt',
+			'--- a/file.txt',
+			'+++ b/file.txt',
+			'@@ -1 +1 @@',
+			'-old',
+			`+${addedLine}`,
+			'```',
+		].join('\n'),
+	};
+}
+
+describe('summarizeThreadForSidebar', () => {
+	beforeEach(() => {
+		clearSummaryCacheForTests();
+	});
+
+	it('reuses the cached summary when only updatedAt changes', () => {
+		const messages: ChatMessage[] = [
+			{ role: 'system', content: 'hidden' },
+			{ role: 'user', content: 'Please edit file.txt' },
+			diffAssistant('new'),
+		];
+
+		const first = summarizeThreadForSidebar(thread(messages, { updatedAt: 1 }), 'D:/work/a');
+		const second = summarizeThreadForSidebar(thread(messages, { updatedAt: 2 }), 'D:/work/a');
+
+		expect(second).toBe(first);
+		expect(second.previewCount).toBe(2);
+		expect(second.hasUserMessages).toBe(true);
+	});
+
+	it('invalidates the cache when the assistant diff changes without updatedAt changing', () => {
+		const first = summarizeThreadForSidebar(
+			thread([
+				{ role: 'user', content: 'Please edit file.txt' },
+				diffAssistant('new'),
+			]),
+			'D:/work/a'
+		);
+		const second = summarizeThreadForSidebar(
+			thread([
+				{ role: 'user', content: 'Please edit file.txt' },
+				diffAssistant('newer'),
+			]),
+			'D:/work/a'
+		);
+
+		expect(second).not.toBe(first);
+		expect(second.hasAgentDiff).toBe(true);
+		expect(second.filePaths).toEqual(['file.txt']);
+	});
+
+	it('prunes only the requested workspace cache', () => {
+		const messages: ChatMessage[] = [
+			{ role: 'user', content: 'Hello' },
+			{ role: 'assistant', content: 'Hi' },
+		];
+		const wsA = 'D:/work/a';
+		const wsB = 'D:/work/b';
+
+		const firstA = summarizeThreadForSidebar(thread(messages), wsA);
+		const firstB = summarizeThreadForSidebar(thread(messages), wsB);
+		pruneSummaryCache(new Set(), wsA);
+
+		const secondA = summarizeThreadForSidebar(thread(messages), wsA);
+		const secondB = summarizeThreadForSidebar(thread(messages), wsB);
+
+		expect(secondA).not.toBe(firstA);
+		expect(secondB).toBe(firstB);
+	});
+});

--- a/main-src/threadListSummary.ts
+++ b/main-src/threadListSummary.ts
@@ -1,9 +1,12 @@
+import * as path from 'node:path';
 import type { ChatMessage } from './threadStore.js';
 import { listAgentDiffChunks } from './agent/applyAgentDiffs.js';
 import { flattenAssistantTextPartsForSearch } from '../src/agentStructuredMessage.js';
 import { countDiffLinesInChunk } from './diffLineCount.js';
 
 export type ThreadRowSummary = {
+	previewCount: number;
+	hasUserMessages: boolean;
 	/** 末条为用户且其后无助手回复 → 进行中 / 草稿样式 */
 	isAwaitingReply: boolean;
 	/** 末条助手是否含可解析的 diff */
@@ -17,8 +20,37 @@ export type ThreadRowSummary = {
 	subtitleFallback: string;
 };
 
-function visibleMessages(msgs: ChatMessage[]): ChatMessage[] {
-	return msgs.filter((m) => m.role !== 'system');
+type SidebarMessageContext = {
+	previewCount: number;
+	hasUserMessages: boolean;
+	lastVisible?: ChatMessage;
+	previousVisible?: ChatMessage;
+	lastAssistantRaw: string;
+};
+
+type SummaryCacheEntry = {
+	workspaceKey: string;
+	threadId: string;
+	signature: string;
+	summary: ThreadRowSummary;
+	accessedAt: number;
+};
+
+type SummaryResult = {
+	summary: ThreadRowSummary;
+	cacheHit: boolean;
+};
+
+function normalizeWorkspaceCacheKey(workspaceRoot: string | null | undefined): string {
+	const raw = String(workspaceRoot ?? '').trim();
+	if (!raw) {
+		return '__global__';
+	}
+	return path.resolve(raw).replace(/\\/g, '/').toLowerCase();
+}
+
+function summaryCacheKey(workspaceRoot: string | null | undefined, threadId: string): string {
+	return `${normalizeWorkspaceCacheKey(workspaceRoot)}::${threadId}`;
 }
 
 function firstLine(text: string, maxLen: number): string {
@@ -26,34 +58,134 @@ function firstLine(text: string, maxLen: number): string {
 	return line.length > maxLen ? `${line.slice(0, maxLen)}…` : line;
 }
 
-const summaryCache = new Map<string, { updatedAt: number; summary: ThreadRowSummary }>();
+const summaryCache = new Map<string, SummaryCacheEntry>();
 
-/** Maximum number of cached thread summaries to prevent unbounded memory growth. */
-const SUMMARY_CACHE_MAX = 500;
+/** Keep enough warm summaries for multiple open workspaces without unbounded growth. */
+const SUMMARY_CACHE_MAX = 2_000;
+let summaryCacheAccessClock = 0;
 
 // diff 扫描只看消息末尾 N 个字符：最近的 diff 在末尾，扫全文对长消息代价极高。
 const DIFF_SCAN_MAX_CHARS = 30_000;
 // subtitle 只取消息开头 N 个字符即可提取首行。
 const SUBTITLE_HEAD_MAX_CHARS = 2_000;
+const USER_SUBTITLE_SIGNATURE_CHARS = 512;
+const FNV_OFFSET = 0x811c9dc5;
+const FNV_PRIME = 0x01000193;
+const NON_WHITESPACE_RE = /\S/;
 
-function computeThreadRowSummary(thread: { messages: ChatMessage[] }): ThreadRowSummary {
-	const vis = visibleMessages(thread.messages);
-	const last = vis[vis.length - 1];
-	const prev = vis.length >= 2 ? vis[vis.length - 2] : undefined;
+function hasVisibleUserText(text: string): boolean {
+	return NON_WHITESPACE_RE.test(text);
+}
 
-	const isAwaitingReply = last?.role === 'user';
-
+function collectSidebarMessageContext(messages: ChatMessage[]): SidebarMessageContext {
+	let previewCount = 0;
+	let hasUserMessages = false;
+	let lastVisible: ChatMessage | undefined;
+	let previousVisible: ChatMessage | undefined;
 	let lastAssistantRaw = '';
-	for (let i = vis.length - 1; i >= 0; i--) {
-		if (vis[i]!.role === 'assistant') {
-			lastAssistantRaw = vis[i]!.content;
-			break;
+
+	for (const message of messages) {
+		if (message.role === 'system') {
+			continue;
+		}
+		previewCount += 1;
+		if (message.role === 'user' && !hasUserMessages && hasVisibleUserText(message.content)) {
+			hasUserMessages = true;
+		}
+		previousVisible = lastVisible;
+		lastVisible = message;
+		if (message.role === 'assistant') {
+			lastAssistantRaw = message.content;
 		}
 	}
 
+	return {
+		previewCount,
+		hasUserMessages,
+		lastVisible,
+		previousVisible,
+		lastAssistantRaw,
+	};
+}
+
+function updateFnvHash(hash: number, charCode: number): number {
+	hash ^= charCode;
+	return Math.imul(hash, FNV_PRIME) >>> 0;
+}
+
+function updateFnvHashWithSlice(hash: number, text: string, start: number, end: number): number {
+	for (let i = start; i < end; i++) {
+		hash = updateFnvHash(hash, text.charCodeAt(i));
+	}
+	return hash;
+}
+
+function boundedTextFingerprint(text: string, headChars: number, tailChars: number): string {
+	const len = text.length;
+	const safeHead = Math.max(0, Math.min(headChars, len));
+	const safeTail = Math.max(0, Math.min(tailChars, len));
+	let hash = FNV_OFFSET;
+
+	if (len <= safeHead + safeTail) {
+		hash = updateFnvHashWithSlice(hash, text, 0, len);
+	} else {
+		hash = updateFnvHashWithSlice(hash, text, 0, safeHead);
+		hash = updateFnvHash(hash, 0);
+		hash = updateFnvHashWithSlice(hash, text, len - safeTail, len);
+	}
+
+	return `${len}:${hash.toString(36)}`;
+}
+
+function userSubtitleFingerprint(message: ChatMessage | undefined): string {
+	if (!message || message.role !== 'user') {
+		return '';
+	}
+	return boundedTextFingerprint(message.content, USER_SUBTITLE_SIGNATURE_CHARS, 0);
+}
+
+function buildSummarySignature(context: SidebarMessageContext): string {
+	const last = context.lastVisible;
+	const prev = context.previousVisible;
+	const assistantFingerprint = context.lastAssistantRaw
+		? boundedTextFingerprint(context.lastAssistantRaw, SUBTITLE_HEAD_MAX_CHARS, DIFF_SCAN_MAX_CHARS)
+		: '';
+	return [
+		context.previewCount,
+		context.hasUserMessages ? 1 : 0,
+		last?.role ?? '',
+		userSubtitleFingerprint(last),
+		prev?.role ?? '',
+		userSubtitleFingerprint(prev),
+		assistantFingerprint,
+	].join('|');
+}
+
+function enforceSummaryCacheLimit(): void {
+	while (summaryCache.size > SUMMARY_CACHE_MAX) {
+		let oldestKey: string | null = null;
+		let oldestAccess = Number.POSITIVE_INFINITY;
+		for (const [key, entry] of summaryCache) {
+			if (entry.accessedAt < oldestAccess) {
+				oldestAccess = entry.accessedAt;
+				oldestKey = key;
+			}
+		}
+		if (!oldestKey) {
+			return;
+		}
+		summaryCache.delete(oldestKey);
+	}
+}
+
+function computeThreadRowSummary(context: SidebarMessageContext): ThreadRowSummary {
+	const last = context.lastVisible;
+	const prev = context.previousVisible;
+	const isAwaitingReply = last?.role === 'user';
+
 	// flattenAssistantTextPartsForSearch 需要完整 JSON 才能解析结构化消息，
 	// 截断放在 flatten 之后（已是纯文本）。
-	const lastAssistantText = flattenAssistantTextPartsForSearch(lastAssistantRaw);
+	const lastAssistantText = flattenAssistantTextPartsForSearch(context.lastAssistantRaw);
 
 	// 只扫末尾 30 KB 以检测 diff：防止超长消息阻塞主进程事件循环。
 	const textForDiff = lastAssistantText.length > DIFF_SCAN_MAX_CHARS
@@ -81,7 +213,7 @@ function computeThreadRowSummary(thread: { messages: ChatMessage[] }): ThreadRow
 	let subtitleFallback = '';
 	if (isAwaitingReply && last?.role === 'user') {
 		subtitleFallback = firstLine(last.content, 72);
-	} else if (lastAssistantRaw) {
+	} else if (context.lastAssistantRaw) {
 		const stripped = textForSubtitle.replace(/```[\s\S]*?```/g, ' ').trim();
 		subtitleFallback = firstLine(stripped, 72);
 	}
@@ -93,6 +225,8 @@ function computeThreadRowSummary(thread: { messages: ChatMessage[] }): ThreadRow
 	}
 
 	return {
+		previewCount: context.previewCount,
+		hasUserMessages: context.hasUserMessages,
 		isAwaitingReply,
 		hasAgentDiff,
 		additions,
@@ -103,35 +237,54 @@ function computeThreadRowSummary(thread: { messages: ChatMessage[] }): ThreadRow
 	};
 }
 
+export function summarizeThreadForSidebarWithMeta(thread: {
+	id: string;
+	messages: ChatMessage[];
+}, workspaceRoot?: string | null): SummaryResult {
+	const context = collectSidebarMessageContext(thread.messages);
+	const signature = buildSummarySignature(context);
+	const cacheKey = summaryCacheKey(workspaceRoot, thread.id);
+	const cached = summaryCache.get(cacheKey);
+	if (cached && cached.signature === signature) {
+		cached.accessedAt = ++summaryCacheAccessClock;
+		return { summary: cached.summary, cacheHit: true };
+	}
+
+	const summary = computeThreadRowSummary(context);
+	summaryCache.set(cacheKey, {
+		workspaceKey: normalizeWorkspaceCacheKey(workspaceRoot),
+		threadId: thread.id,
+		signature,
+		summary,
+		accessedAt: ++summaryCacheAccessClock,
+	});
+	enforceSummaryCacheLimit();
+	return { summary, cacheHit: false };
+}
+
 export function summarizeThreadForSidebar(thread: {
 	id: string;
-	updatedAt: number;
 	messages: ChatMessage[];
-}): ThreadRowSummary {
-	const cached = summaryCache.get(thread.id);
-	if (cached && cached.updatedAt === thread.updatedAt) {
-		return cached.summary;
-	}
-	const summary = computeThreadRowSummary(thread);
-	summaryCache.set(thread.id, { updatedAt: thread.updatedAt, summary });
-	// Evict oldest entries when cache exceeds max size (simple FIFO via Map insertion order).
-	if (summaryCache.size > SUMMARY_CACHE_MAX) {
-		const first = summaryCache.keys().next().value;
-		if (first !== undefined) summaryCache.delete(first);
-	}
-	return summary;
+}, workspaceRoot?: string | null): ThreadRowSummary {
+	return summarizeThreadForSidebarWithMeta(thread, workspaceRoot).summary;
 }
 
 /**
- * Remove cached summaries for thread IDs that no longer exist.
- * Call after listing threads to keep the cache consistent with storage.
+ * Remove cached summaries for thread IDs that no longer exist in one workspace.
+ * Other workspace caches stay warm so multi-workspace switching remains instant.
  */
-export function pruneSummaryCache(activeIds: ReadonlySet<string>): void {
-	for (const id of summaryCache.keys()) {
-		if (!activeIds.has(id)) {
-			summaryCache.delete(id);
+export function pruneSummaryCache(activeIds: ReadonlySet<string>, workspaceRoot?: string | null): void {
+	const workspaceKey = normalizeWorkspaceCacheKey(workspaceRoot);
+	for (const [key, entry] of summaryCache) {
+		if (entry.workspaceKey === workspaceKey && !activeIds.has(entry.threadId)) {
+			summaryCache.delete(key);
 		}
 	}
+}
+
+export function clearSummaryCacheForTests(): void {
+	summaryCache.clear();
+	summaryCacheAccessClock = 0;
 }
 
 export function isTimestampToday(ts: number, now = Date.now()): boolean {

--- a/main-src/threadStore.ts
+++ b/main-src/threadStore.ts
@@ -350,6 +350,25 @@ export function threadHasUserMessages(thread: ThreadRecord): boolean {
 	return thread.messages.some((message) => message.role === 'user' && message.content.trim().length > 0);
 }
 
+export function listThreadWorkspaceRoots(options?: { onlyWithUserMessages?: boolean }): string[] {
+	const roots = Object.entries(data.buckets)
+		.map(([bucketKey, bucket]) => {
+			const root = extractWorkspaceRootFromBucketKey(bucketKey);
+			if (!root) {
+				return null;
+			}
+			const threads = Object.values(bucket.threads);
+			if (options?.onlyWithUserMessages && !threads.some(threadHasUserMessages)) {
+				return null;
+			}
+			const latestUpdatedAt = threads.reduce((max, thread) => Math.max(max, thread.updatedAt), 0);
+			return { root, latestUpdatedAt };
+		})
+		.filter((item): item is { root: string; latestUpdatedAt: number } => item != null)
+		.sort((a, b) => b.latestUpdatedAt - a.latestUpdatedAt);
+	return roots.map((item) => item.root);
+}
+
 export function getCurrentThreadId(workspaceRoot: string | null | undefined = null): string | null {
 	return ensureBucket(workspaceRoot).currentThreadId;
 }

--- a/src/AgentChatPanel.tsx
+++ b/src/AgentChatPanel.tsx
@@ -708,6 +708,17 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 			});
 		});
 	}, [scheduleMessagesScrollToBottom]);
+	const notifyPreflightLayoutChange = useCallback(() => {
+		setLayoutMeasureVersion((version) => version + 1);
+		if (!pinnedToBottomRef.current) {
+			return;
+		}
+		scheduleMessagesScrollToBottom();
+		window.requestAnimationFrame(() => {
+			scheduleMessagesScrollToBottom();
+		});
+	}, [scheduleMessagesScrollToBottom]);
+	const shouldInstantTogglePreflight = useCallback(() => pinnedToBottomRef.current, []);
 
 	/**
 	 * 切换对话：清空测量并按视口高度预算重算起点。
@@ -998,6 +1009,24 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 	}, [hasConversation, conversationRenderKey, messagesViewportRef, messagesTrackRef]);
 
 	/**
+	 * 监听 preflight shell 的 CSS transition 结束，立即触发 spacer 重算。
+	 */
+	useEffect(() => {
+		if (!hasConversation) return;
+		const track = messagesTrackRef.current;
+		if (!track) return;
+		const onTransitionEnd = (e: TransitionEvent) => {
+			const target = e.target;
+			if (!(target instanceof HTMLElement)) return;
+			if (!target.closest('.ref-preflight-shell-collapse')) return;
+			if (e.propertyName !== 'max-height') return;
+			setLayoutMeasureVersion((v) => v + 1);
+		};
+		track.addEventListener('transitionend', onTransitionEnd);
+		return () => track.removeEventListener('transitionend', onTransitionEnd);
+	}, [hasConversation, conversationRenderKey, setLayoutMeasureVersion, messagesTrackRef]);
+
+	/**
 	 * sticky 同步逻辑：用 ref 持有最新闭包，让监听器订阅 effect 只在「会话级」变量变化时
 	 * 重订阅，避免流式 token 推送期间反复 add/removeEventListener 与 ResizeObserver 拆装。
 	 */
@@ -1108,8 +1137,9 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 		const update = () => {
 			rafId = 0;
 			const dist = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight;
-			bottomTodoAtBottomRef.current =
-				dist <= 16 || viewport.scrollHeight <= viewport.clientHeight + 16;
+			const isAtBottom = dist <= 16 || viewport.scrollHeight <= viewport.clientHeight + 16;
+			bottomTodoAtBottomRef.current = isAtBottom;
+			pinnedToBottomRef.current = isAtBottom;
 		};
 		const schedule = () => {
 			if (rafId !== 0) return;
@@ -1400,9 +1430,10 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 							revertedChangeKeys={revertedChangeKeys}
 							skipPlanTodo
 							renderMode="preflight"
-							preserveLivePreflight
+							preserveLivePreflight={agentOrPlanStreaming}
 							typewriter={agentOrPlanStreaming && awaitingReply}
-							preflightInstantToggle={pinnedToBottomRef.current}
+							shouldInstantTogglePreflight={shouldInstantTogglePreflight}
+							onPreflightLayoutChange={notifyPreflightLayoutChange}
 						/>
 					</div>
 				</div>

--- a/src/AgentChatPanel.tsx
+++ b/src/AgentChatPanel.tsx
@@ -618,6 +618,7 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 	const prevConversationForLenRef = useRef<string | null>(null);
 	const lastLayoutMeasureSigRef = useRef('');
 	const layoutMeasureSettleTimerRef = useRef<number | null>(null);
+	const pinnedToBottomRef = useRef(true);
 
 	const getRowHeightForBudget = useCallback(
 		(i: number) => messageRowHeightsRef.current.get(i) ?? ESTIMATED_MESSAGE_ROW_PX,
@@ -1017,6 +1018,7 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 		const isAtBottom =
 			distFromBottom <= 16 || viewport.scrollHeight <= viewport.clientHeight + 16;
 		bottomTodoAtBottomRef.current = isAtBottom;
+		pinnedToBottomRef.current = isAtBottom;
 		const renderedRows = collectMeasuredTurnRows();
 		const nextStickyIndex = findStickyUserIndexForViewport({
 			renderedRows,
@@ -1400,6 +1402,7 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 							renderMode="preflight"
 							preserveLivePreflight
 							typewriter={agentOrPlanStreaming && awaitingReply}
+							preflightInstantToggle={pinnedToBottomRef.current}
 						/>
 					</div>
 				</div>

--- a/src/AgentChatPanel.tsx
+++ b/src/AgentChatPanel.tsx
@@ -617,6 +617,7 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 	const prevDisplayMessagesLenRef = useRef(displayMessages.length);
 	const prevConversationForLenRef = useRef<string | null>(null);
 	const lastLayoutMeasureSigRef = useRef('');
+	const layoutMeasureSettleTimerRef = useRef<number | null>(null);
 
 	const getRowHeightForBudget = useCallback(
 		(i: number) => messageRowHeightsRef.current.get(i) ?? ESTIMATED_MESSAGE_ROW_PX,
@@ -934,6 +935,10 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 	useEffect(() => {
 		if (!hasConversation) {
 			lastLayoutMeasureSigRef.current = '';
+			if (layoutMeasureSettleTimerRef.current !== null) {
+				window.clearTimeout(layoutMeasureSettleTimerRef.current);
+				layoutMeasureSettleTimerRef.current = null;
+			}
 			return;
 		}
 		const viewport = messagesViewportRef.current;
@@ -942,6 +947,7 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 			return;
 		}
 		let rafId = 0;
+		let lastCommittedAt = 0;
 		const flush = () => {
 			rafId = 0;
 			const nextSig = [
@@ -954,7 +960,19 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 				return;
 			}
 			lastLayoutMeasureSigRef.current = nextSig;
-			setLayoutMeasureVersion((v) => v + 1);
+			const now = performance.now();
+			if (now - lastCommittedAt >= 120) {
+				lastCommittedAt = now;
+				setLayoutMeasureVersion((v) => v + 1);
+			}
+			if (layoutMeasureSettleTimerRef.current !== null) {
+				window.clearTimeout(layoutMeasureSettleTimerRef.current);
+			}
+			layoutMeasureSettleTimerRef.current = window.setTimeout(() => {
+				layoutMeasureSettleTimerRef.current = null;
+				lastCommittedAt = performance.now();
+				setLayoutMeasureVersion((v) => v + 1);
+			}, 140);
 		};
 		const schedule = () => {
 			if (rafId !== 0) {
@@ -970,6 +988,10 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 			resizeObserver.disconnect();
 			if (rafId !== 0) {
 				window.cancelAnimationFrame(rafId);
+			}
+			if (layoutMeasureSettleTimerRef.current !== null) {
+				window.clearTimeout(layoutMeasureSettleTimerRef.current);
+				layoutMeasureSettleTimerRef.current = null;
 			}
 		};
 	}, [hasConversation, conversationRenderKey, messagesViewportRef, messagesTrackRef]);

--- a/src/AgentChatPanel.tsx
+++ b/src/AgentChatPanel.tsx
@@ -762,13 +762,11 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 			setStickyUserTopPx((prev) => (prev === 0 ? prev : 0));
 			return;
 		}
-		const viewport = messagesViewportRef.current;
-		if (!viewport) {
-			return;
-		}
-		const viewportStyle = window.getComputedStyle(viewport);
-		const topPadding = Number.parseFloat(viewportStyle.paddingTop || '0') || 0;
-		setStickyUserTopPx((prev) => (Math.abs(prev - topPadding) <= 1 ? prev : topPadding));
+		/* sticky 元素的 top 已经是相对 viewport 的 padding-box 顶部,
+		   再叠加 padding-top 会把它二次下推,且 padding 任何变化都会
+		   触发 sticky 落点跳动(sidebar 展开/收起时尤其明显)。
+		   固定 0,让 sticky 视觉上正好停在 padding 内边沿。 */
+		setStickyUserTopPx((prev) => (prev === 0 ? prev : 0));
 	}, [hasConversation, conversationRenderKey, layoutMeasureVersion, messagesViewportRef]);
 
 	/** 顶部哨兵：再往上加载约「一整屏」高的内容（按已测/估算行高累计） */

--- a/src/AgentPreflightShell.tsx
+++ b/src/AgentPreflightShell.tsx
@@ -40,8 +40,12 @@ type Props = {
 	phase?: 'thinking' | 'streaming' | 'done';
 	/** done 阶段可在末尾展示 token 用量 */
 	tokenUsage?: TurnTokenUsage | null;
-	/** 快速折叠/展开时不使用 CSS transition，避免与 turn-focus spacer 竞争导致滚动条上移 */
+	/** 贴底时跳过高度动画，避免外层 follow-bottom 与 max-height transition 互相拉扯 */
 	instantToggle?: boolean;
+	/** 点击展开/收起时读取最新外层贴底状态，避免使用父级上一次 render 的旧快照 */
+	shouldInstantToggle?: () => boolean;
+	/** 展开/收起提交到 DOM 后通知父级同步重算外层补高 */
+	onLayoutChange?: () => void;
 };
 
 function defaultDisplayState(liveTurn: boolean, hasOutcome: boolean): DisplayState {
@@ -56,12 +60,15 @@ export const AgentPreflightShell = memo(function AgentPreflightShell({
 	phase = 'thinking',
 	tokenUsage,
 	instantToggle = false,
+	shouldInstantToggle,
+	onLayoutChange,
 }: Props) {
 	const { t } = useI18n();
 
 	const [displayState, setDisplayState] = useState<DisplayState>(() =>
 		defaultDisplayState(liveTurn, hasOutcome)
 	);
+	const [toggleInstantOverride, setToggleInstantOverride] = useState(false);
 	const userToggledRef = useRef(false);
 	const prevLiveTurnRef = useRef(liveTurn);
 
@@ -75,9 +82,12 @@ export const AgentPreflightShell = memo(function AgentPreflightShell({
 		if (userToggledRef.current) return;
 		// 回合结束的最后一帧 hasOutcome 决定默认态：有结果 → 收起聚焦答案；无结果 → 保持展开
 		const next = defaultDisplayState(false, hasOutcome);
-		const id = setTimeout(() => setDisplayState(next), 600);
+		const id = setTimeout(() => {
+			setToggleInstantOverride(shouldInstantToggle?.() ?? instantToggle);
+			setDisplayState(next);
+		}, 600);
 		return () => clearTimeout(id);
-	}, [liveTurn, hasOutcome]);
+	}, [liveTurn, hasOutcome, instantToggle, shouldInstantToggle]);
 
 	const bodyRef = useRef<HTMLDivElement>(null);
 	const pinnedToBottomRef = useRef(true);
@@ -95,6 +105,15 @@ export const AgentPreflightShell = memo(function AgentPreflightShell({
 		if (el) el.scrollTop = el.scrollHeight;
 	}, [children, displayState]);
 
+	const didMountLayoutRef = useRef(false);
+	useLayoutEffect(() => {
+		if (!didMountLayoutRef.current) {
+			didMountLayoutRef.current = true;
+			return;
+		}
+		onLayoutChange?.();
+	}, [displayState, onLayoutChange]);
+
 	useEffect(() => {
 		if (displayState === 'expanded') {
 			pinnedToBottomRef.current = true;
@@ -103,13 +122,26 @@ export const AgentPreflightShell = memo(function AgentPreflightShell({
 		}
 	}, [displayState]);
 
+	useLayoutEffect(() => {
+		if (!toggleInstantOverride) return;
+		const id = window.requestAnimationFrame(() => setToggleInstantOverride(false));
+		return () => window.cancelAnimationFrame(id);
+	}, [displayState, toggleInstantOverride]);
+
+	const resolveInstantToggle = useCallback(
+		() => shouldInstantToggle?.() ?? instantToggle,
+		[instantToggle, shouldInstantToggle]
+	);
+
 	/** 真正的二值取反：collapsed ↔ expanded。点击后锁定，自动逻辑不再生效。 */
 	const onToggle = useCallback(() => {
 		userToggledRef.current = true;
+		setToggleInstantOverride(resolveInstantToggle());
 		setDisplayState((s) => (s === 'expanded' ? 'collapsed' : 'expanded'));
-	}, []);
+	}, [resolveInstantToggle]);
 
 	const isOpen = displayState === 'expanded';
+	const useInstantToggle = instantToggle || toggleInstantOverride;
 	const isPending = liveTurn && phase !== 'done';
 	const headLabel = isPending
 		? t('agent.preflight.working')
@@ -141,7 +173,9 @@ export const AgentPreflightShell = memo(function AgentPreflightShell({
 				</span>
 			</button>
 
-			<div className={`ref-preflight-shell-collapse ${isOpen ? 'is-open' : ''}${instantToggle ? ' instant-toggle' : ''}`}>
+			<div
+				className={`ref-preflight-shell-collapse ${isOpen ? 'is-open' : ''}${useInstantToggle ? ' instant-toggle' : ''}`}
+			>
 				<div
 					ref={bodyRef}
 					className={`ref-preflight-shell-body ${isPending ? 'ref-preflight-shell-body--live' : ''}`}

--- a/src/AgentPreflightShell.tsx
+++ b/src/AgentPreflightShell.tsx
@@ -40,6 +40,8 @@ type Props = {
 	phase?: 'thinking' | 'streaming' | 'done';
 	/** done 阶段可在末尾展示 token 用量 */
 	tokenUsage?: TurnTokenUsage | null;
+	/** 快速折叠/展开时不使用 CSS transition，避免与 turn-focus spacer 竞争导致滚动条上移 */
+	instantToggle?: boolean;
 };
 
 function defaultDisplayState(liveTurn: boolean, hasOutcome: boolean): DisplayState {
@@ -53,6 +55,7 @@ export const AgentPreflightShell = memo(function AgentPreflightShell({
 	hasOutcome = false,
 	phase = 'thinking',
 	tokenUsage,
+	instantToggle = false,
 }: Props) {
 	const { t } = useI18n();
 
@@ -138,7 +141,7 @@ export const AgentPreflightShell = memo(function AgentPreflightShell({
 				</span>
 			</button>
 
-			<div className={`ref-preflight-shell-collapse ${isOpen ? 'is-open' : ''}`}>
+			<div className={`ref-preflight-shell-collapse ${isOpen ? 'is-open' : ''}${instantToggle ? ' instant-toggle' : ''}`}>
 				<div
 					ref={bodyRef}
 					className={`ref-preflight-shell-body ${isPending ? 'ref-preflight-shell-body--live' : ''}`}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -144,6 +144,7 @@ import { ShellWorkspaceGrid } from './app/ShellWorkspaceGrid';
 import { ThreadItem } from './app/ThreadItem';
 import { AgentSidebarThreadItem } from './app/AgentSidebarThreadItem';
 import {
+	readStoredWorkspaceLauncher,
 	type WorkspaceLauncherTool,
 	workspaceLauncherLabel,
 } from './app/workspaceLaunchers';
@@ -1741,13 +1742,21 @@ function AppMainWorkspaceInner() {
 	}, [layoutMode, toggleAgentRightSidebarView]);
 
 	const launchWorkspaceWithTool = useCallback(
-		async (tool: WorkspaceLauncherTool) => {
+		async (
+			tool: WorkspaceLauncherTool,
+			options?: { relPath?: string; revealLine?: number; revealEndLine?: number }
+		) => {
 			if (!shell || !workspace) {
 				flashComposerAttachErr(t('app.noWorkspace'));
 				return;
 			}
 			try {
-				const r = (await shell.invoke('workspace:openInExternalTool', { tool })) as {
+				const r = (await shell.invoke('workspace:openInExternalTool', {
+					tool,
+					relPath: options?.relPath,
+					revealLine: options?.revealLine,
+					revealEndLine: options?.revealEndLine,
+				})) as {
 					ok?: boolean;
 					code?: string;
 					error?: string;
@@ -1772,6 +1781,13 @@ function AppMainWorkspaceInner() {
 			}
 		},
 		[shell, workspace, flashComposerAttachErr, t]
+	);
+
+	const openAgentFilePreviewInWorkspaceLauncher = useCallback(
+		(relPath: string, revealLine?: number, revealEndLine?: number) => {
+			void launchWorkspaceWithTool(readStoredWorkspaceLauncher(), { relPath, revealLine, revealEndLine });
+		},
+		[launchWorkspaceWithTool]
 	);
 
 	const {
@@ -3588,7 +3604,7 @@ function AppMainWorkspaceInner() {
 		onPlanAddTodoCancel,
 		onPlanTodoToggle,
 		agentFilePreview,
-		openFileInTab,
+		openFileInTab: openAgentFilePreviewInWorkspaceLauncher,
 		onAcceptAgentFilePreviewHunk,
 		onRevertAgentFilePreviewHunk,
 		agentFilePreviewBusyPatch,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -512,6 +512,9 @@ function AppMainWorkspaceInner() {
 		refreshAgentSidebarThreads,
 		sidebarThreadsByPathKey,
 		loadMessages,
+		cacheThreadStateForWorkspace,
+		restoreThreadStateForWorkspace,
+		getCachedThreadsForWorkspace,
 		resetThreadState,
 	} = useThreads(shell);
 
@@ -1180,6 +1183,14 @@ function AppMainWorkspaceInner() {
 		[agentWorkspaceOrder, hiddenAgentWorkspacePathSet]
 	);
 
+	const agentSidebarThreadFetchPaths = useMemo(() => {
+		if (!workspace) {
+			return agentSidebarThreadPaths;
+		}
+		const currentKey = normWorkspaceRootKey(workspace);
+		return agentSidebarThreadPaths.filter((path) => normWorkspaceRootKey(path) !== currentKey);
+	}, [agentSidebarThreadPaths, workspace]);
+
 	useEffect(() => {
 		if (!shell) {
 			return;
@@ -1192,20 +1203,21 @@ function AppMainWorkspaceInner() {
 		const cancel = window.cancelIdleCallback ?? ((id: number) => window.clearTimeout(id));
 		const id = idle(
 			() => {
-				void refreshAgentSidebarThreads(agentSidebarThreadPaths);
+				void refreshAgentSidebarThreads(agentSidebarThreadFetchPaths);
 			},
 			{ timeout: 3000 }
 		);
 		return () => cancel(id);
-	}, [shell, layoutMode, agentSidebarThreadPaths, refreshAgentSidebarThreads]);
+	}, [shell, layoutMode, agentSidebarThreadFetchPaths, refreshAgentSidebarThreads]);
 
 	const agentSidebarWorkspaces = useMemo(() => {
 		const q = threadSearch.trim().toLowerCase();
 		return agentSidebarThreadPaths.map((path) => {
+			const pathKey = normWorkspaceRootKey(path);
 			const rowsSource =
-				workspace && normWorkspaceRootKey(path) === normWorkspaceRootKey(workspace)
+				workspace && pathKey === normWorkspaceRootKey(workspace)
 					? threads
-					: (sidebarThreadsByPathKey[normWorkspaceRootKey(path)] ?? []);
+					: (sidebarThreadsByPathKey[pathKey] ?? getCachedThreadsForWorkspace(path) ?? []);
 			const visible = rowsSource.filter((thread) => thread.hasUserMessages);
 			const list = q
 				? visible.filter(
@@ -1240,6 +1252,7 @@ function AppMainWorkspaceInner() {
 		workspace,
 		threads,
 		sidebarThreadsByPathKey,
+		getCachedThreadsForWorkspace,
 		threadSearch,
 		workspaceAliases,
 		collapsedAgentWorkspacePathSet,
@@ -1360,16 +1373,27 @@ function AppMainWorkspaceInner() {
 		[agentSidebarWorkspaces, workspaceMenuPath]
 	);
 
-	const clearWorkspaceConversationState = useCallback(() => {
+	const resetWorkspaceEphemeralState = useCallback(() => {
 		resetStreamingSession({ clearThread: true });
 		planBuildPendingMarkerRef.current = null;
-		resetThreadState();
 		resetAgentReviewState();
 		resetComposerState();
 		setLastTurnUsage(null);
 		resetPlanState();
 		cancelWorkspaceAliasEdit();
-	}, [resetStreamingSession, resetThreadState, resetAgentReviewState, resetComposerState, cancelWorkspaceAliasEdit]);
+	}, [
+		resetStreamingSession,
+		resetAgentReviewState,
+		resetComposerState,
+		setLastTurnUsage,
+		resetPlanState,
+		cancelWorkspaceAliasEdit,
+	]);
+
+	const clearWorkspaceConversationState = useCallback(() => {
+		resetWorkspaceEphemeralState();
+		resetThreadState();
+	}, [resetWorkspaceEphemeralState, resetThreadState]);
 
 	const {
 		executeSkillCreatorSend,
@@ -1630,26 +1654,54 @@ function AppMainWorkspaceInner() {
 			const t0 = performance.now();
 			console.log(`[perf][renderer] workspace switch START → ${next}`);
 			mark('start');
-			clearWorkspaceConversationState();
+			if (workspace && normWorkspaceRootKey(workspace) !== normWorkspaceRootKey(next)) {
+				cacheThreadStateForWorkspace(workspace);
+			}
+			resetWorkspaceEphemeralState();
+			const restoredFromCache = restoreThreadStateForWorkspace(next);
+			if (!restoredFromCache) {
+				resetThreadState({ keepSidebarThreads: true });
+			}
 			setWorkspace(next);
 			mark('workspace-set');
-			console.log(`[perf][renderer] workspace:openPath+setState done in ${(performance.now() - t0).toFixed(1)}ms`);
-			// 并行而非串行，且 refreshGit 由 workspace 变化的 effect 触发，此处不重复调用
-			const threadId = await refreshThreads();
-			mark('threads-done');
-			measure('void-ws:apply-path:threads', 'start', 'threads-done');
-			console.log(`[perf][renderer] refreshThreads IPC round-trip done in ${(performance.now() - t0).toFixed(1)}ms`);
-			// 直接调用 loadMessages，避免通过 effect (currentId 变化 → loadMessages)
-			// 间接触发导致多出一帧空白 render。去重 ref 确保 effect 不会发起重复 IPC。
-			if (threadId) {
-				await loadMessages(threadId, onMessagesLoaded);
-				restoreInFlightThreadUiIfNeeded(threadId);
-				mark('messages-done');
-				measure('void-ws:apply-path:messages', 'threads-done', 'messages-done');
-				console.log(`[perf][renderer] loadMessages done in ${(performance.now() - t0).toFixed(1)}ms`);
-			}
+			console.log(
+				`[perf][renderer] workspace:openPath+setState done in ${(performance.now() - t0).toFixed(1)}ms` +
+					(restoredFromCache ? ' (cache restored)' : '')
+			);
+			// 后台补齐线程/消息：打开工作区的交互先完成，慢 IPC 不再卡住 workspace 切换。
+			void (async () => {
+				const isLatestWorkspaceSwitch = () => workspaceSwitchSeqRef.current === seq;
+				const threadId = await refreshThreads({ shouldApply: isLatestWorkspaceSwitch });
+				if (!isLatestWorkspaceSwitch()) {
+					return;
+				}
+				mark('threads-done');
+				measure('void-ws:apply-path:threads', 'start', 'threads-done');
+				console.log(`[perf][renderer] refreshThreads IPC round-trip done in ${(performance.now() - t0).toFixed(1)}ms`);
+				if (threadId) {
+					await loadMessages(threadId, onMessagesLoaded);
+					if (!isLatestWorkspaceSwitch()) {
+						return;
+					}
+					restoreInFlightThreadUiIfNeeded(threadId);
+					mark('messages-done');
+					measure('void-ws:apply-path:messages', 'threads-done', 'messages-done');
+					console.log(`[perf][renderer] loadMessages done in ${(performance.now() - t0).toFixed(1)}ms`);
+				}
+			})();
 		},
-		[clearWorkspaceConversationState, refreshThreads, loadMessages, onMessagesLoaded, restoreInFlightThreadUiIfNeeded]
+		[
+			workspace,
+			cacheThreadStateForWorkspace,
+			resetWorkspaceEphemeralState,
+			restoreThreadStateForWorkspace,
+			resetThreadState,
+			setWorkspace,
+			refreshThreads,
+			loadMessages,
+			onMessagesLoaded,
+			restoreInFlightThreadUiIfNeeded,
+		]
 	);
 
 	const openWorkspaceByPath = useCallback(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -123,7 +123,6 @@ import {
 	DEFAULT_SIDEBAR_LAYOUT_KEY,
 	clampSidebarLayout,
 	readSidebarLayout,
-	readStoredShellLayoutModeFromKey,
 	type ShellLayoutMode,
 } from './app/shellLayoutStorage';
 import {
@@ -143,6 +142,10 @@ import type { ShellLeftRailGroupProps, ShellCenterRightGroupProps } from './app/
 import { ShellWorkspaceGrid } from './app/ShellWorkspaceGrid';
 import { ThreadItem } from './app/ThreadItem';
 import { AgentSidebarThreadItem } from './app/AgentSidebarThreadItem';
+import {
+	isAgentWorkspaceCollapsed,
+	selectAgentSidebarThreadPaths,
+} from './app/agentSidebarWorkspaceList';
 import {
 	readStoredWorkspaceLauncher,
 	type WorkspaceLauncherTool,
@@ -877,7 +880,7 @@ function AppMainWorkspaceInner() {
 	});
 
 	const [layoutMode, setLayoutMode] = useState<LayoutMode>(() =>
-		layoutPinnedBySurface && appSurface ? appSurface : readStoredShellLayoutModeFromKey(shellLayoutStorageKey)
+		layoutPinnedBySurface && appSurface ? appSurface : 'agent'
 	);
 	const [layoutWindowAvailability, setLayoutWindowAvailability] = useState<Record<LayoutMode, boolean>>({
 		agent: false,
@@ -1138,12 +1141,6 @@ function AppMainWorkspaceInner() {
 		[visibleThreads]
 	);
 
-	const hiddenAgentWorkspacePathSet = useMemo(() => new Set(hiddenAgentWorkspacePaths), [hiddenAgentWorkspacePaths]);
-	const collapsedAgentWorkspacePathSet = useMemo(
-		() => new Set(collapsedAgentWorkspacePaths),
-		[collapsedAgentWorkspacePaths]
-	);
-
 	const agentSidebarWorkspaceCandidates = useMemo(() => {
 		const seen = new Set<string>();
 		const ordered: string[] = [];
@@ -1177,19 +1174,15 @@ function AppMainWorkspaceInner() {
 
 	const agentSidebarThreadPaths = useMemo(
 		() =>
-			agentWorkspaceOrder
-				.filter((path) => !hiddenAgentWorkspacePathSet.has(path))
-				.slice(0, 8),
-		[agentWorkspaceOrder, hiddenAgentWorkspacePathSet]
+			selectAgentSidebarThreadPaths({
+				orderedPaths: agentWorkspaceOrder,
+				hiddenPaths: hiddenAgentWorkspacePaths,
+				currentWorkspace: workspace,
+			}),
+		[agentWorkspaceOrder, hiddenAgentWorkspacePaths, workspace]
 	);
 
-	const agentSidebarThreadFetchPaths = useMemo(() => {
-		if (!workspace) {
-			return agentSidebarThreadPaths;
-		}
-		const currentKey = normWorkspaceRootKey(workspace);
-		return agentSidebarThreadPaths.filter((path) => normWorkspaceRootKey(path) !== currentKey);
-	}, [agentSidebarThreadPaths, workspace]);
+	const agentSidebarThreadFetchPaths = agentSidebarThreadPaths;
 
 	useEffect(() => {
 		if (!shell) {
@@ -1199,25 +1192,22 @@ function AppMainWorkspaceInner() {
 			void refreshAgentSidebarThreads([]);
 			return;
 		}
-		const idle = window.requestIdleCallback ?? ((cb: IdleRequestCallback) => window.setTimeout(() => cb({ didTimeout: true, timeRemaining: () => 0 } as IdleDeadline), 1));
-		const cancel = window.cancelIdleCallback ?? ((id: number) => window.clearTimeout(id));
-		const id = idle(
-			() => {
-				void refreshAgentSidebarThreads(agentSidebarThreadFetchPaths);
-			},
-			{ timeout: 3000 }
-		);
-		return () => cancel(id);
+		void refreshAgentSidebarThreads(agentSidebarThreadFetchPaths);
 	}, [shell, layoutMode, agentSidebarThreadFetchPaths, refreshAgentSidebarThreads]);
 
 	const agentSidebarWorkspaces = useMemo(() => {
 		const q = threadSearch.trim().toLowerCase();
 		return agentSidebarThreadPaths.map((path) => {
 			const pathKey = normWorkspaceRootKey(path);
-			const rowsSource =
+			const sidebarRows = sidebarThreadsByPathKey[pathKey] ?? getCachedThreadsForWorkspace(path) ?? [];
+			const currentRows =
 				workspace && pathKey === normWorkspaceRootKey(workspace)
 					? threads
-					: (sidebarThreadsByPathKey[pathKey] ?? getCachedThreadsForWorkspace(path) ?? []);
+					: null;
+			const rowsSource =
+				currentRows && currentRows.some((thread) => thread.hasUserMessages)
+					? currentRows
+					: sidebarRows;
 			const visible = rowsSource.filter((thread) => thread.hasUserMessages);
 			const list = q
 				? visible.filter(
@@ -1239,9 +1229,8 @@ function AppMainWorkspaceInner() {
 				path,
 				name: workspaceAliases[path]?.trim() || workspacePathDisplayName(path),
 				parent: workspacePathParent(path),
-				isCurrent: path === workspace,
-				isCollapsed:
-					path === workspace ? collapsedAgentWorkspacePathSet.has(path) : !collapsedAgentWorkspacePathSet.has(path),
+				isCurrent: !!workspace && normWorkspaceRootKey(path) === normWorkspaceRootKey(workspace),
+				isCollapsed: isAgentWorkspaceCollapsed(path, collapsedAgentWorkspacePaths),
 				threadCount: list.length,
 				todayThreads: today,
 				archivedThreads: archived,
@@ -1255,7 +1244,7 @@ function AppMainWorkspaceInner() {
 		getCachedThreadsForWorkspace,
 		threadSearch,
 		workspaceAliases,
-		collapsedAgentWorkspacePathSet,
+		collapsedAgentWorkspacePaths,
 	]);
 
 	const hasConversation = messages.length > 0 || awaitingReply;

--- a/src/ChatMarkdown.tsx
+++ b/src/ChatMarkdown.tsx
@@ -209,6 +209,7 @@ type Props = {
 	 */
 	renderMode?: 'all' | 'preflight' | 'outcome';
 	preserveLivePreflight?: boolean;
+	preflightInstantToggle?: boolean;
 };
 
 function InlineChevron({ open }: { open: boolean }) {
@@ -405,6 +406,7 @@ export const ChatMarkdown = memo(function ChatMarkdown({
 	preserveLivePreflight = false,
 	typewriter = false,
 	turnFocusFillPx = 0,
+	preflightInstantToggle = false,
 }: Props) {
 	const { t } = useI18n();
 
@@ -762,6 +764,7 @@ export const ChatMarkdown = memo(function ChatMarkdown({
 					hasOutcome={hasOutcome}
 					phase={liveThoughtMeta?.phase ?? (showAgentWorking ? 'thinking' : 'done')}
 					tokenUsage={liveThoughtMeta?.tokenUsage ?? null}
+					instantToggle={preflightInstantToggle}
 				>
 					{preflight.map((seg, i) => renderUnitNode(seg, i, { insideShell: true }))}
 				</AgentPreflightShell>

--- a/src/ChatMarkdown.tsx
+++ b/src/ChatMarkdown.tsx
@@ -210,6 +210,8 @@ type Props = {
 	renderMode?: 'all' | 'preflight' | 'outcome';
 	preserveLivePreflight?: boolean;
 	preflightInstantToggle?: boolean;
+	shouldInstantTogglePreflight?: () => boolean;
+	onPreflightLayoutChange?: () => void;
 };
 
 function InlineChevron({ open }: { open: boolean }) {
@@ -404,9 +406,11 @@ export const ChatMarkdown = memo(function ChatMarkdown({
 	skipPlanTodo = false,
 	renderMode = 'all',
 	preserveLivePreflight = false,
+	preflightInstantToggle = false,
+	shouldInstantTogglePreflight,
+	onPreflightLayoutChange,
 	typewriter = false,
 	turnFocusFillPx = 0,
-	preflightInstantToggle = false,
 }: Props) {
 	const { t } = useI18n();
 
@@ -765,6 +769,8 @@ export const ChatMarkdown = memo(function ChatMarkdown({
 					phase={liveThoughtMeta?.phase ?? (showAgentWorking ? 'thinking' : 'done')}
 					tokenUsage={liveThoughtMeta?.tokenUsage ?? null}
 					instantToggle={preflightInstantToggle}
+					shouldInstantToggle={shouldInstantTogglePreflight}
+					onLayoutChange={onPreflightLayoutChange}
 				>
 					{preflight.map((seg, i) => renderUnitNode(seg, i, { insideShell: true }))}
 				</AgentPreflightShell>

--- a/src/app/agentSidebarWorkspaceList.test.ts
+++ b/src/app/agentSidebarWorkspaceList.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import {
+	isAgentWorkspaceCollapsed,
+	selectAgentSidebarThreadPaths,
+} from './agentSidebarWorkspaceList';
+
+describe('selectAgentSidebarThreadPaths', () => {
+	it('keeps non-current workspaces expanded unless explicitly collapsed elsewhere', () => {
+		expect(isAgentWorkspaceCollapsed('D:/work/A', [])).toBe(false);
+		expect(isAgentWorkspaceCollapsed('D:/work/A', ['D:/work/A'])).toBe(true);
+	});
+
+	it('always includes the current workspace even when it falls past the visible limit', () => {
+		const orderedPaths = [
+			'D:/work/one',
+			'D:/work/two',
+			'D:/work/three',
+			'D:/work/four',
+			'D:/work/current',
+		];
+
+		expect(
+			selectAgentSidebarThreadPaths({
+				orderedPaths,
+				hiddenPaths: [],
+				currentWorkspace: 'D:/work/current',
+				limit: 3,
+			})
+		).toEqual(['D:/work/one', 'D:/work/two', 'D:/work/current']);
+	});
+
+	it('returns every visible workspace when no explicit limit is provided', () => {
+		const orderedPaths = Array.from({ length: 12 }, (_, i) => `D:/work/${i + 1}`);
+
+		expect(
+			selectAgentSidebarThreadPaths({
+				orderedPaths,
+				hiddenPaths: [],
+				currentWorkspace: null,
+			})
+		).toHaveLength(12);
+	});
+
+	it('ignores stale hidden state so conversation workspaces remain visible', () => {
+		expect(
+			selectAgentSidebarThreadPaths({
+				orderedPaths: ['D:/work/A', 'D:/work/B'],
+				hiddenPaths: ['D:/work/B'],
+				currentWorkspace: null,
+				limit: 8,
+			})
+		).toEqual(['D:/work/A', 'D:/work/B']);
+	});
+});

--- a/src/app/agentSidebarWorkspaceList.ts
+++ b/src/app/agentSidebarWorkspaceList.ts
@@ -1,0 +1,51 @@
+import { normWorkspaceRootKey } from '../workspaceRootKey';
+
+function uniqueByWorkspaceKey(paths: string[]): string[] {
+	const seen = new Set<string>();
+	const out: string[] = [];
+	for (const path of paths) {
+		const key = normWorkspaceRootKey(path);
+		if (!key || seen.has(key)) {
+			continue;
+		}
+		seen.add(key);
+		out.push(path);
+	}
+	return out;
+}
+
+export function selectAgentSidebarThreadPaths(params: {
+	orderedPaths: string[];
+	hiddenPaths: Iterable<string>;
+	currentWorkspace: string | null;
+	limit?: number;
+}): string[] {
+	const currentKey = params.currentWorkspace ? normWorkspaceRootKey(params.currentWorkspace) : null;
+	const visible = uniqueByWorkspaceKey(params.orderedPaths);
+	if (params.limit == null) {
+		return visible;
+	}
+	const limit = Math.max(1, params.limit);
+	const selected = visible.slice(0, limit);
+	if (!currentKey || selected.some((path) => normWorkspaceRootKey(path) === currentKey)) {
+		return selected;
+	}
+	const currentPath = visible.find((path) => normWorkspaceRootKey(path) === currentKey) ?? params.currentWorkspace;
+	if (!currentPath) {
+		return selected;
+	}
+	if (selected.length < limit) {
+		return [...selected, currentPath];
+	}
+	return [...selected.slice(0, limit - 1), currentPath];
+}
+
+export function isAgentWorkspaceCollapsed(path: string, collapsedPaths: Iterable<string>): boolean {
+	const key = normWorkspaceRootKey(path);
+	for (const collapsedPath of collapsedPaths) {
+		if (normWorkspaceRootKey(collapsedPath) === key) {
+			return true;
+		}
+	}
+	return false;
+}

--- a/src/app/desktopShellInit.test.ts
+++ b/src/app/desktopShellInit.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TFunction } from '../i18n';
+
+vi.mock('../bootSplash', () => ({
+	hideBootSplash: vi.fn(),
+}));
+
+import { runDesktopShellInit } from './desktopShellInit';
+
+describe('runDesktopShellInit', () => {
+	const store: Record<string, string> = {};
+	let previousWindow: unknown;
+	let previousLocalStorage: unknown;
+	let previousRequestIdleCallback: unknown;
+
+	beforeEach(() => {
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+		vi.spyOn(console, 'warn').mockImplementation(() => {});
+		previousWindow = (globalThis as { window?: unknown }).window;
+		previousLocalStorage = (globalThis as { localStorage?: unknown }).localStorage;
+		previousRequestIdleCallback = (globalThis as { requestIdleCallback?: unknown }).requestIdleCallback;
+		for (const key of Object.keys(store)) {
+			delete store[key];
+		}
+		const memory: Storage = {
+			get length() {
+				return Object.keys(store).length;
+			},
+			clear() {
+				for (const key of Object.keys(store)) {
+					delete store[key];
+				}
+			},
+			getItem(key) {
+				return Object.prototype.hasOwnProperty.call(store, key) ? store[key]! : null;
+			},
+			key(index) {
+				return Object.keys(store)[index] ?? null;
+			},
+			removeItem(key) {
+				delete store[key];
+			},
+			setItem(key, value) {
+				store[key] = String(value);
+			},
+		};
+		Object.defineProperty(globalThis, 'localStorage', { value: memory, configurable: true });
+		Object.defineProperty(globalThis, 'window', {
+			value: {
+				innerWidth: 1280,
+				location: { search: '', hash: '' },
+				matchMedia: () => ({ matches: true }),
+				setTimeout,
+				clearTimeout,
+			},
+			configurable: true,
+		});
+		Object.defineProperty(globalThis, 'requestIdleCallback', {
+			value: (cb: IdleRequestCallback) => {
+				cb({ didTimeout: true, timeRemaining: () => 0 } as IdleDeadline);
+				return 1;
+			},
+			configurable: true,
+		});
+	});
+
+	afterEach(() => {
+		if (previousWindow === undefined) {
+			delete (globalThis as { window?: unknown }).window;
+		} else {
+			Object.defineProperty(globalThis, 'window', { value: previousWindow, configurable: true });
+		}
+		if (previousLocalStorage === undefined) {
+			delete (globalThis as { localStorage?: unknown }).localStorage;
+		} else {
+			Object.defineProperty(globalThis, 'localStorage', { value: previousLocalStorage, configurable: true });
+		}
+		if (previousRequestIdleCallback === undefined) {
+			delete (globalThis as { requestIdleCallback?: unknown }).requestIdleCallback;
+		} else {
+			Object.defineProperty(globalThis, 'requestIdleCallback', {
+				value: previousRequestIdleCallback,
+				configurable: true,
+			});
+		}
+		vi.restoreAllMocks();
+	});
+
+	it('still applies model settings when the initial thread refresh fails', async () => {
+		const settings = {
+			language: 'zh-CN',
+			defaultModel: 'model-1',
+			models: {
+				providers: [{ id: 'provider-1', displayName: 'Provider', paradigm: 'openai-compatible' }],
+				entries: [{ id: 'model-1', providerId: 'provider-1', displayName: 'Model 1', requestName: 'model-1' }],
+				enabledIds: ['model-1'],
+				thinkingByModelId: { 'model-1': 'medium' },
+			},
+			ui: { sidebarLayout: { left: 280, right: 360 }, colorMode: 'dark' },
+		};
+		const shell = {
+			invoke: vi.fn(async (channel: string) => {
+				if (channel === 'async-shell:ping') return { ok: true, message: 'pong' };
+				if (channel === 'workspace:get') return { root: 'D:/work/app' };
+				if (channel === 'app:getPaths') return { home: 'D:/Users/me' };
+				if (channel === 'settings:get') return settings;
+				if (channel === 'mcp:getServers') return { servers: [] };
+				if (channel === 'mcp:getStatuses') return { statuses: [] };
+				if (channel === 'settings:set') return settings;
+				return {};
+			}),
+		} as unknown as NonNullable<Window['asyncShell']>;
+		const applyLoadedSettings = vi.fn();
+		const refreshThreads = vi.fn(async () => {
+			throw new Error('thread list unavailable');
+		});
+
+		await runDesktopShellInit({
+			shell,
+			t: ((key: string, vars?: Record<string, unknown>) => String(vars?.message ?? key)) as TFunction,
+			layoutPinnedBySurface: false,
+			shellLayoutStorageKey: 'test-layout-mode',
+			sidebarLayoutStorageKey: 'test-sidebar-layout',
+			refreshThreads,
+			refreshGit: vi.fn(),
+			setLocale: vi.fn(),
+			setIpcOk: vi.fn(),
+			setWorkspace: vi.fn(),
+			setHomePath: vi.fn(),
+			setRailWidths: vi.fn(),
+			setLayoutMode: vi.fn(),
+			applyLoadedSettings,
+			setColorMode: vi.fn(),
+			setAppearanceSettings: vi.fn(),
+			setMcpServers: vi.fn(),
+			setMcpStatuses: vi.fn(),
+		});
+
+		expect(refreshThreads).toHaveBeenCalledTimes(1);
+		expect(applyLoadedSettings).toHaveBeenCalledWith(settings);
+	});
+});

--- a/src/app/desktopShellInit.ts
+++ b/src/app/desktopShellInit.ts
@@ -14,7 +14,6 @@ import type { McpServerConfig, McpServerStatus } from '../mcpTypes';
 import {
 	clampSidebarLayout,
 	readSidebarLayout,
-	readStoredShellLayoutModeFromKey,
 	syncDesktopShellLayoutMode,
 	syncDesktopSidebarLayout,
 	writeStoredShellLayoutMode,
@@ -104,9 +103,8 @@ export async function runDesktopShellInit(ctx: DesktopShellInitContext): Promise
 			: (shell.invoke('workspace:get') as Promise<{ root: string | null }>),
 		shell.invoke('app:getPaths') as Promise<{ home?: string }>,
 		shell.invoke('settings:get') as Promise<SettingsGetPayload>,
-		refreshThreads(),
 	]);
-	_lap('batch1 (ping/workspace/paths/settings/threads)');
+	_lap('batch1 (ping/workspace/paths/settings)');
 	setIpcOk(p.ok ? t('app.ipcReady', { message: p.message }) : t('app.ipcError'));
 	if (!isBlankWindow) {
 		setWorkspace(w.root);
@@ -132,15 +130,9 @@ export async function runDesktopShellInit(ctx: DesktopShellInitContext): Promise
 		syncDesktopSidebarLayout(shell, clampSidebarLayout(s0.left, s0.right));
 	}
 	if (!layoutPinnedBySurface) {
-		const lmRaw = st.ui?.layoutMode;
-		if (lmRaw === 'agent' || lmRaw === 'editor') {
-			setLayoutMode(lmRaw);
-			writeStoredShellLayoutMode(lmRaw, shellLayoutStorageKey);
-		} else {
-			const lm0 = readStoredShellLayoutModeFromKey(shellLayoutStorageKey);
-			setLayoutMode(lm0);
-			syncDesktopShellLayoutMode(shell, lm0);
-		}
+		setLayoutMode('agent');
+		writeStoredShellLayoutMode('agent', shellLayoutStorageKey);
+		syncDesktopShellLayoutMode(shell, 'agent');
 	}
 	applyLoadedSettings(st);
 	const cmRaw = st.ui?.colorMode;
@@ -151,6 +143,10 @@ export async function runDesktopShellInit(ctx: DesktopShellInitContext): Promise
 	const appearanceScheme = resolveEffectiveScheme(nextColorMode, readPrefersDark());
 	setAppearanceSettings(normalizeAppearanceSettings(st.ui, appearanceScheme));
 	_lap('settings state applied');
+
+	void refreshThreads().catch((err) => {
+		console.warn('[renderer-init] refreshThreads failed after settings load', err);
+	});
 
 	hideBootSplash();
 

--- a/src/hooks/useMessagesScroll.ts
+++ b/src/hooks/useMessagesScroll.ts
@@ -100,11 +100,16 @@ export function resolveContentBottomScroll(
 		viewport.scrollTop + maxBottomInViewport - (viewport.clientHeight - bottomInset);
 	/* 贴底时不能让"活动 preflight 行"的顶被推到 sticky user 后面 —— 否则
 	   header（"正在分析…"）会被钉在顶部的 user 气泡完全遮住。
-	   计算允许的最大 scrollTop:让 preflight 顶端至少落在 sticky 下沿。 */
+	   计算允许的最大 scrollTop:让 preflight 顶端至少落在 sticky 下沿,并额外
+	   预留 STICKY_USER_BOTTOM_GAP_PX 让 user 气泡视觉上不贴顶。 */
+	const STICKY_USER_BOTTOM_GAP_PX = 16;
 	const stickyEl = viewport.querySelector('.ref-msg-sticky-user-wrap') as HTMLElement | null;
 	const stickyH = stickyEl ? stickyEl.getBoundingClientRect().height : 0;
 	if (activePreflightTopInTrack != null && stickyH > 0) {
-		const maxAllowedScroll = Math.max(0, activePreflightTopInTrack - stickyH);
+		const maxAllowedScroll = Math.max(
+			0,
+			activePreflightTopInTrack - stickyH - STICKY_USER_BOTTOM_GAP_PX,
+		);
 		return Math.max(0, Math.min(rawTarget, maxAllowedScroll));
 	}
 	return Math.max(0, rawTarget);

--- a/src/hooks/useMessagesScroll.ts
+++ b/src/hooks/useMessagesScroll.ts
@@ -74,21 +74,40 @@ export function resolveContentBottomScroll(
 	if (!track) {
 		return Math.max(0, viewport.scrollHeight - viewport.clientHeight - bottomInset);
 	}
-	const messageRows = track.querySelectorAll<HTMLElement>('.ref-msg-row-measure[data-msg-index]');
-	const lastContentRow = messageRows[messageRows.length - 1] ?? null;
-	if (!lastContentRow) {
+	const messageRows = track.querySelectorAll<HTMLElement>(
+		'.ref-msg-row-measure[data-msg-index], .ref-msg-row-measure[data-preflight-for]'
+	);
+	if (messageRows.length === 0) {
 		return Math.max(0, viewport.scrollHeight - viewport.clientHeight - bottomInset);
 	}
-	/* 必须用 getBoundingClientRect 而非 offsetTop，因为 offsetParent
-	   在 editor-rail 等布局下可能是外层 ref-chat-drop-zone（position:relative），
-	   而不是 track 本身，导致参考系不一致。 */
-	const rowRect = lastContentRow.getBoundingClientRect();
 	const viewportRect = viewport.getBoundingClientRect();
-	const rowBottomInViewport = rowRect.bottom - viewportRect.top;
-	return Math.max(
-		0,
-		viewport.scrollTop + rowBottomInViewport - (viewport.clientHeight - bottomInset)
-	);
+	let maxBottomInViewport = -Infinity;
+	let activePreflightTopInTrack: number | null = null;
+	for (const row of Array.from(messageRows)) {
+		const rect = row.getBoundingClientRect();
+		const bottomInViewport = rect.bottom - viewportRect.top;
+		if (bottomInViewport > maxBottomInViewport) {
+			maxBottomInViewport = bottomInViewport;
+		}
+		if (row.dataset.preflightFor != null && rect.height > 0) {
+			activePreflightTopInTrack = viewport.scrollTop + (rect.top - viewportRect.top);
+		}
+	}
+	if (!Number.isFinite(maxBottomInViewport)) {
+		return Math.max(0, viewport.scrollHeight - viewport.clientHeight - bottomInset);
+	}
+	const rawTarget =
+		viewport.scrollTop + maxBottomInViewport - (viewport.clientHeight - bottomInset);
+	/* 贴底时不能让"活动 preflight 行"的顶被推到 sticky user 后面 —— 否则
+	   header（"正在分析…"）会被钉在顶部的 user 气泡完全遮住。
+	   计算允许的最大 scrollTop:让 preflight 顶端至少落在 sticky 下沿。 */
+	const stickyEl = viewport.querySelector('.ref-msg-sticky-user-wrap') as HTMLElement | null;
+	const stickyH = stickyEl ? stickyEl.getBoundingClientRect().height : 0;
+	if (activePreflightTopInTrack != null && stickyH > 0) {
+		const maxAllowedScroll = Math.max(0, activePreflightTopInTrack - stickyH);
+		return Math.max(0, Math.min(rawTarget, maxAllowedScroll));
+	}
+	return Math.max(0, rawTarget);
 }
 
 export function measureMessagesScroll(

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -44,6 +44,19 @@ export type ProjectAgentSliceState = {
 
 export const EMPTY_PROJECT_AGENT: ProjectAgentSliceState = { rules: [], skills: [], subagents: [] };
 
+function scheduleIdleWorkspaceLoad(fn: () => void): () => void {
+	if (typeof window === 'undefined') {
+		fn();
+		return () => {};
+	}
+	if (typeof window.requestIdleCallback === 'function') {
+		const id = window.requestIdleCallback(() => fn(), { timeout: 1500 });
+		return () => window.cancelIdleCallback?.(id);
+	}
+	const id = window.setTimeout(fn, 120);
+	return () => window.clearTimeout(id);
+}
+
 export type LoadedSettingsSnapshot = {
 	providerIdentity?: ProviderIdentitySettings;
 	defaultModel?: string;
@@ -307,23 +320,26 @@ export function useSettings(
 			return;
 		}
 		let cancelled = false;
-		void (async () => {
-			const r = (await shell.invoke('workspaceAgent:get')) as {
-				ok?: boolean;
-				slice?: { rules?: AgentRule[]; skills?: AgentSkill[]; subagents?: AgentSubagent[] };
-			};
-			if (cancelled) return;
-			const slice = r?.slice;
-			startTransition(() => {
-				setProjectAgentSlice({
-					rules: tagProjectOrigin(slice?.rules),
-					skills: tagProjectOrigin(slice?.skills),
-					subagents: tagProjectOrigin(slice?.subagents),
+		const cancelIdle = scheduleIdleWorkspaceLoad(() => {
+			void (async () => {
+				const r = (await shell.invoke('workspaceAgent:get')) as {
+					ok?: boolean;
+					slice?: { rules?: AgentRule[]; skills?: AgentSkill[]; subagents?: AgentSubagent[] };
+				};
+				if (cancelled) return;
+				const slice = r?.slice;
+				startTransition(() => {
+					setProjectAgentSlice({
+						rules: tagProjectOrigin(slice?.rules),
+						skills: tagProjectOrigin(slice?.skills),
+						subagents: tagProjectOrigin(slice?.subagents),
+					});
 				});
-			});
-		})();
+			})();
+		});
 		return () => {
 			cancelled = true;
+			cancelIdle();
 		};
 	}, [shell, workspace]);
 
@@ -333,21 +349,24 @@ export function useSettings(
 			return;
 		}
 		let cancelled = false;
-		void (async () => {
-			try {
-				const r = (await shell.invoke('workspace:listDiskSkills')) as { ok?: boolean; skills?: AgentSkill[] };
-				if (cancelled) return;
-				startTransition(() => {
-					setWorkspaceDiskSkills(Array.isArray(r?.skills) ? r.skills : []);
-				});
-			} catch {
-				if (!cancelled) {
-					setWorkspaceDiskSkills([]);
+		const cancelIdle = scheduleIdleWorkspaceLoad(() => {
+			void (async () => {
+				try {
+					const r = (await shell.invoke('workspace:listDiskSkills')) as { ok?: boolean; skills?: AgentSkill[] };
+					if (cancelled) return;
+					startTransition(() => {
+						setWorkspaceDiskSkills(Array.isArray(r?.skills) ? r.skills : []);
+					});
+				} catch {
+					if (!cancelled) {
+						setWorkspaceDiskSkills([]);
+					}
 				}
-			}
-		})();
+			})();
+		});
 		return () => {
 			cancelled = true;
+			cancelIdle();
 		};
 	}, [shell, workspace, diskSkillsRefreshTicker]);
 
@@ -357,23 +376,26 @@ export function useSettings(
 			return;
 		}
 		let cancelled = false;
-		void (async () => {
-			try {
-				const next = (await shell.invoke('plugins:getRuntimeState')) as PluginRuntimeState;
-				if (cancelled) {
-					return;
+		const cancelIdle = scheduleIdleWorkspaceLoad(() => {
+			void (async () => {
+				try {
+					const next = (await shell.invoke('plugins:getRuntimeState')) as PluginRuntimeState;
+					if (cancelled) {
+						return;
+					}
+					startTransition(() => {
+						setPluginRuntimeState(next && typeof next === 'object' ? next : EMPTY_PLUGIN_RUNTIME_STATE);
+					});
+				} catch {
+					if (!cancelled) {
+						setPluginRuntimeState(EMPTY_PLUGIN_RUNTIME_STATE);
+					}
 				}
-				startTransition(() => {
-					setPluginRuntimeState(next && typeof next === 'object' ? next : EMPTY_PLUGIN_RUNTIME_STATE);
-				});
-			} catch {
-				if (!cancelled) {
-					setPluginRuntimeState(EMPTY_PLUGIN_RUNTIME_STATE);
-				}
-			}
-		})();
+			})();
+		});
 		return () => {
 			cancelled = true;
+			cancelIdle();
 		};
 	}, [shell, workspace, pluginRuntimeRefreshTicker]);
 

--- a/src/hooks/useThreadActions.ts
+++ b/src/hooks/useThreadActions.ts
@@ -264,7 +264,10 @@ export function useThreadActions(params: UseThreadActionsParams): UseThreadActio
 				return;
 			}
 			if (workspacePath !== workspace) {
-				setHiddenAgentWorkspacePaths((prev) => prev.filter((item) => item !== workspacePath));
+				const workspaceKey = normWorkspaceRootKey(workspacePath);
+				setHiddenAgentWorkspacePaths((prev) =>
+					prev.filter((item) => normWorkspaceRootKey(item) !== workspaceKey)
+				);
 				const opened = await openWorkspaceByPath(workspacePath);
 				if (!opened) {
 					return;

--- a/src/hooks/useThreads.ts
+++ b/src/hooks/useThreads.ts
@@ -10,6 +10,23 @@ import { normWorkspaceRootKey } from '../workspaceRootKey';
 
 type Shell = NonNullable<Window['asyncShell']>;
 
+type RefreshThreadsOptions = {
+	shouldApply?: () => boolean;
+};
+
+type ThreadStateSnapshot = {
+	threads: ThreadInfo[];
+	currentId: string | null;
+	messages: ChatMessage[];
+	messagesThreadId: string | null;
+	threadNavigation: { history: string[]; index: number };
+};
+
+function workspaceSnapshotKey(root: string | null | undefined): string | null {
+	const raw = String(root ?? '').trim();
+	return raw ? normWorkspaceRootKey(raw) : null;
+}
+
 /** 仅在侧栏真实展示字段均相同时复用旧引用，避免标题/摘要/diff 统计更新被吞掉。 */
 function sameSidebarThreadsByPath(
 	prev: Record<string, ThreadInfo[]>,
@@ -72,6 +89,8 @@ function incomingMissesOnlyTrailingAssistantError(prev: ChatMessage[], incoming:
  */
 export function useThreads(shell: Shell | undefined) {
 	const [threads, setThreads] = useState<ThreadInfo[]>([]);
+	const threadsRef = useRef<ThreadInfo[]>([]);
+	threadsRef.current = threads;
 	const [threadSearch, setThreadSearch] = useState('');
 	const [currentId, setCurrentId] = useState<string | null>(null);
 	const currentIdRef = useRef<string | null>(null);
@@ -91,6 +110,8 @@ export function useThreads(shell: Shell | undefined) {
 	});
 	const messages = msgState.messages;
 	const messagesThreadId = msgState.threadId;
+	const msgStateRef = useRef(msgState);
+	msgStateRef.current = msgState;
 	const messagesRef = useRef(messages);
 	messagesRef.current = messages;
 
@@ -106,7 +127,10 @@ export function useThreads(shell: Shell | undefined) {
 		history: [],
 		index: -1,
 	});
+	const threadNavigationRef = useRef(threadNavigation);
+	threadNavigationRef.current = threadNavigation;
 	const skipThreadNavigationRecordRef = useRef(false);
+	const workspaceSnapshotsRef = useRef<Map<string, ThreadStateSnapshot>>(new Map());
 
 	// currentId 变化时更新导航历史
 	// 用 useLayoutEffect 而非 useEffect：commit 后立即同步执行，setState 触发的重渲在同一帧内
@@ -127,15 +151,22 @@ export function useThreads(shell: Shell | undefined) {
 
 	// ── 操作 ──────────────────────────────────────────────────────────────────
 
-	const refreshThreads = useCallback(async () => {
+	const refreshThreads = useCallback(async (options?: RefreshThreadsOptions) => {
 		if (!shell) return null;
 		const t0 = typeof performance !== 'undefined' ? performance.now() : 0;
 		const r = (await shell.invoke('threads:list')) as {
 			threads: ThreadInfo[];
 			currentId: string | null;
 		};
+		if (options?.shouldApply && !options.shouldApply()) {
+			if (t0 && typeof performance !== 'undefined') {
+				console.log(`[perf] refreshThreads: stale skipped after ${(performance.now() - t0).toFixed(1)}ms`);
+			}
+			return r.currentId;
+		}
 		// setCurrentId 必须紧急（触发 loadMessages effect 和导航历史更新）。
 		// setThreads 是侧栏列表，非紧急，用 transition 避免阻塞消息加载路径。
+		currentIdRef.current = r.currentId;
 		setCurrentId(r.currentId);
 		startTransition(() => setThreads((r.threads ?? []).map(normalizeThreadRow)));
 		if (t0 && typeof performance !== 'undefined') {
@@ -281,8 +312,51 @@ export function useThreads(shell: Shell | undefined) {
 		[shell]
 	);
 
-	/** 切换工作区时重置线程域的所有状态 */
-	const resetThreadState = useCallback(() => {
+	const cacheThreadStateForWorkspace = useCallback((workspaceRoot: string | null | undefined) => {
+		const key = workspaceSnapshotKey(workspaceRoot);
+		if (!key) {
+			return;
+		}
+		workspaceSnapshotsRef.current.set(key, {
+			threads: threadsRef.current,
+			currentId: currentIdRef.current,
+			messages: msgStateRef.current.messages,
+			messagesThreadId: msgStateRef.current.threadId,
+			threadNavigation: threadNavigationRef.current,
+		});
+	}, []);
+
+	const restoreThreadStateForWorkspace = useCallback((workspaceRoot: string | null | undefined) => {
+		const key = workspaceSnapshotKey(workspaceRoot);
+		const snapshot = key ? workspaceSnapshotsRef.current.get(key) : null;
+		if (!snapshot) {
+			return false;
+		}
+		currentIdRef.current = snapshot.currentId;
+		setThreads(snapshot.threads);
+		setCurrentId(snapshot.currentId);
+		setMsgState({
+			messages: snapshot.messages,
+			threadId: snapshot.messagesThreadId,
+		});
+		setResendFromUserIndex(null);
+		setConfirmDeleteId(null);
+		setEditingThreadId(null);
+		setEditingThreadTitleDraft('');
+		threadTitleDraftRef.current = '';
+		setThreadNavigation(snapshot.threadNavigation);
+		loadMessagesInflightByIdRef.current.clear();
+		return true;
+	}, []);
+
+	const getCachedThreadsForWorkspace = useCallback((workspaceRoot: string | null | undefined): ThreadInfo[] | null => {
+		const key = workspaceSnapshotKey(workspaceRoot);
+		const snapshot = key ? workspaceSnapshotsRef.current.get(key) : null;
+		return snapshot?.threads ?? null;
+	}, []);
+
+	/** 切换/关闭工作区时重置线程域的所有状态 */
+	const resetThreadState = useCallback((options?: { keepSidebarThreads?: boolean }) => {
 		currentIdRef.current = null;
 		setThreads([]);
 		setCurrentId(null);
@@ -293,8 +367,10 @@ export function useThreads(shell: Shell | undefined) {
 		setEditingThreadTitleDraft('');
 		threadTitleDraftRef.current = '';
 		setThreadNavigation({ history: [], index: -1 });
-		sidebarFetchGenRef.current++;
-		setSidebarThreadsByPathKey({});
+		if (!options?.keepSidebarThreads) {
+			sidebarFetchGenRef.current++;
+			setSidebarThreadsByPathKey({});
+		}
 		loadMessagesInflightByIdRef.current.clear();
 	}, []);
 
@@ -340,6 +416,9 @@ export function useThreads(shell: Shell | undefined) {
 		refreshAgentSidebarThreads,
 		sidebarThreadsByPathKey,
 		loadMessages,
+		cacheThreadStateForWorkspace,
+		restoreThreadStateForWorkspace,
+		getCachedThreadsForWorkspace,
 		resetThreadState,
 	};
 }

--- a/src/hooks/useThreads.ts
+++ b/src/hooks/useThreads.ts
@@ -2,9 +2,12 @@ import { useCallback, useLayoutEffect, useRef, useState, startTransition } from 
 import {
 	type ChatMessage,
 	type ThreadInfo,
+	applyThreadRowsPreservingDetails,
 	chatMessagesListEqual,
+	mergeThreadDetailRows,
 	normalizeThreadRow,
 	threadInfoListEqual,
+	threadListVersions,
 } from '../threadTypes';
 import { normWorkspaceRootKey } from '../workspaceRootKey';
 
@@ -131,6 +134,7 @@ export function useThreads(shell: Shell | undefined) {
 	threadNavigationRef.current = threadNavigation;
 	const skipThreadNavigationRecordRef = useRef(false);
 	const workspaceSnapshotsRef = useRef<Map<string, ThreadStateSnapshot>>(new Map());
+	const threadListFetchGenRef = useRef(0);
 
 	// currentId 变化时更新导航历史
 	// 用 useLayoutEffect 而非 useEffect：commit 后立即同步执行，setState 触发的重渲在同一帧内
@@ -153,25 +157,61 @@ export function useThreads(shell: Shell | undefined) {
 
 	const refreshThreads = useCallback(async (options?: RefreshThreadsOptions) => {
 		if (!shell) return null;
+		const gen = ++threadListFetchGenRef.current;
+		const shouldApply = () => gen === threadListFetchGenRef.current && (!options?.shouldApply || options.shouldApply());
 		const t0 = typeof performance !== 'undefined' ? performance.now() : 0;
-		const r = (await shell.invoke('threads:list')) as {
+		const r = (await shell.invoke('threads:listLight')) as {
 			threads: ThreadInfo[];
 			currentId: string | null;
 		};
-		if (options?.shouldApply && !options.shouldApply()) {
+		if (!shouldApply()) {
 			if (t0 && typeof performance !== 'undefined') {
 				console.log(`[perf] refreshThreads: stale skipped after ${(performance.now() - t0).toFixed(1)}ms`);
 			}
 			return r.currentId;
 		}
+		const lightRows = r.threads ?? [];
 		// setCurrentId 必须紧急（触发 loadMessages effect 和导航历史更新）。
 		// setThreads 是侧栏列表，非紧急，用 transition 避免阻塞消息加载路径。
 		currentIdRef.current = r.currentId;
 		setCurrentId(r.currentId);
-		startTransition(() => setThreads((r.threads ?? []).map(normalizeThreadRow)));
+		startTransition(() =>
+			setThreads((prev) => applyThreadRowsPreservingDetails(prev, lightRows))
+		);
 		if (t0 && typeof performance !== 'undefined') {
-			console.log(`[perf] refreshThreads: ${(performance.now() - t0).toFixed(1)}ms`);
+			console.log(`[perf] refreshThreads: light ${(performance.now() - t0).toFixed(1)}ms`);
 		}
+		void (async () => {
+			const tDetails = typeof performance !== 'undefined' ? performance.now() : 0;
+			try {
+				const detailResult = (await shell.invoke(
+					'threads:listDetails',
+					threadListVersions(lightRows)
+				)) as {
+					threads?: ThreadInfo[];
+					currentId?: string | null;
+				};
+				if (!shouldApply()) {
+					if (tDetails && typeof performance !== 'undefined') {
+						console.log(
+							`[perf] refreshThreads: detail stale skipped after ${(performance.now() - tDetails).toFixed(1)}ms`
+						);
+					}
+					return;
+				}
+				const detailRows = detailResult.threads ?? [];
+				startTransition(() =>
+					setThreads((prev) => mergeThreadDetailRows(prev, detailRows))
+				);
+				if (tDetails && typeof performance !== 'undefined') {
+					console.log(
+						`[perf] refreshThreads: details ${(performance.now() - tDetails).toFixed(1)}ms rows=${detailRows.length}`
+					);
+				}
+			} catch (err) {
+				console.warn('[perf] refreshThreads: details failed', err);
+			}
+		})();
 		return r.currentId;
 	}, [shell]);
 
@@ -332,6 +372,7 @@ export function useThreads(shell: Shell | undefined) {
 		if (!snapshot) {
 			return false;
 		}
+		threadListFetchGenRef.current++;
 		currentIdRef.current = snapshot.currentId;
 		setThreads(snapshot.threads);
 		setCurrentId(snapshot.currentId);
@@ -357,6 +398,7 @@ export function useThreads(shell: Shell | undefined) {
 
 	/** 切换/关闭工作区时重置线程域的所有状态 */
 	const resetThreadState = useCallback((options?: { keepSidebarThreads?: boolean }) => {
+		threadListFetchGenRef.current++;
 		currentIdRef.current = null;
 		setThreads([]);
 		setCurrentId(null);

--- a/src/hooks/useWorkspaceActions.ts
+++ b/src/hooks/useWorkspaceActions.ts
@@ -8,6 +8,7 @@ import {
 	type SetStateAction,
 } from 'react';
 import type { TFunction } from '../i18n';
+import { normWorkspaceRootKey } from '../workspaceRootKey';
 
 function workspacePathDisplayName(full: string): string {
 	const norm = full.replace(/\\/g, '/');
@@ -63,9 +64,13 @@ export function useWorkspaceActions(p: UseWorkspaceActionsParams) {
 	}, []);
 
 	const toggleWorkspaceCollapsed = useCallback((path: string) => {
-		setCollapsedAgentWorkspacePaths((prev) =>
-			prev.includes(path) ? prev.filter((item) => item !== path) : [...prev, path]
-		);
+		const key = normWorkspaceRootKey(path);
+		setCollapsedAgentWorkspacePaths((prev) => {
+			const exists = prev.some((item) => normWorkspaceRootKey(item) === key);
+			return exists
+				? prev.filter((item) => normWorkspaceRootKey(item) !== key)
+				: [...prev, path];
+		});
 	}, [setCollapsedAgentWorkspacePaths]);
 
 	const revealWorkspaceInOs = useCallback(
@@ -117,10 +122,13 @@ export function useWorkspaceActions(p: UseWorkspaceActionsParams) {
 				delete updated[path];
 				return updated;
 			});
-			setCollapsedAgentWorkspacePaths((prev) => prev.filter((item) => item !== path));
-			setHiddenAgentWorkspacePaths((prev) => (prev.includes(path) ? prev : [...prev, path]));
-			setFolderRecents((prev) => prev.filter((item) => item !== path));
-			setHomeRecents((prev) => prev.filter((item) => item !== path));
+			const key = normWorkspaceRootKey(path);
+			setCollapsedAgentWorkspacePaths((prev) => prev.filter((item) => normWorkspaceRootKey(item) !== key));
+			setHiddenAgentWorkspacePaths((prev) =>
+				prev.some((item) => normWorkspaceRootKey(item) === key) ? prev : [...prev, path]
+			);
+			setFolderRecents((prev) => prev.filter((item) => normWorkspaceRootKey(item) !== key));
+			setHomeRecents((prev) => prev.filter((item) => normWorkspaceRootKey(item) !== key));
 			if (editingWorkspacePath === path) {
 				setEditingWorkspacePath(null);
 				setEditingWorkspaceNameDraft('');

--- a/src/hooks/useWorkspaceManager.ts
+++ b/src/hooks/useWorkspaceManager.ts
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useRef, useState, type MutableRefObject } from 'react';
+import { normWorkspaceRootKey } from '../workspaceRootKey';
 
 type Shell = NonNullable<Window['asyncShell']>;
 
 const AGENT_WORKSPACE_ALIASES_KEY = 'async:agent-workspace-aliases-v1';
-const AGENT_WORKSPACE_HIDDEN_KEY = 'async:agent-workspace-hidden-v1';
-const AGENT_WORKSPACE_COLLAPSED_KEY = 'async:agent-workspace-collapsed-v1';
+const AGENT_WORKSPACE_HIDDEN_KEY = 'async:agent-workspace-hidden-v2';
+const AGENT_WORKSPACE_COLLAPSED_KEY = 'async:agent-workspace-collapsed-v2';
 
 function readJsonStorage<T>(key: string, fallback: T): T {
 	try {
@@ -142,7 +143,7 @@ export function useWorkspaceManager(shell: Shell | undefined) {
 				if (cancelled) return;
 				const paths = Array.isArray(r.paths) ? r.paths : [];
 				if (!workspace) setHomeRecents(paths);
-				setFolderRecents(paths.slice(0, 14));
+				setFolderRecents(paths);
 			} catch {
 				if (!cancelled) {
 					setHomeRecents([]);
@@ -155,11 +156,13 @@ export function useWorkspaceManager(shell: Shell | undefined) {
 		};
 	}, [shell, workspace]);
 
-	// 打开工作区后取消 hidden/collapsed 标记
+	// 兼容旧数据：当前工作区不能因为历史 hidden 标记从 Agent 全局侧栏消失。
 	useEffect(() => {
 		if (!workspace) return;
-		setHiddenAgentWorkspacePaths((prev) => prev.filter((item) => item !== workspace));
-		setCollapsedAgentWorkspacePaths((prev) => prev.filter((item) => item !== workspace));
+		const workspaceKey = normWorkspaceRootKey(workspace);
+		setHiddenAgentWorkspacePaths((prev) =>
+			prev.filter((item) => normWorkspaceRootKey(item) !== workspaceKey)
+		);
 	}, [workspace]);
 
 	// ── TS LSP ────────────────────────────────────────────────────────────────

--- a/src/index.css
+++ b/src/index.css
@@ -3407,7 +3407,7 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 	flex: 1 1 auto;
 	min-height: 0;
 	max-height: none;
-	padding-top: 0;
+	padding-top: 8px;
 	/* 缩短对话末尾与底部输入区之间的留白，但仍保留一点呼吸感 */
 	padding-bottom: calc(12px + var(--ref-chat-tail-space));
 	/* 消息高度在 Markdown/虚拟测量后会继续变化，关闭浏览器 scroll anchoring，避免把视口拉回中段。 */

--- a/src/index.css
+++ b/src/index.css
@@ -5085,6 +5085,10 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 	transition: max-height 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
+.ref-preflight-shell-collapse.instant-toggle {
+	transition: none !important;
+}
+
 .ref-preflight-shell-collapse.is-open {
 	max-height: 216px;
 }
@@ -5102,7 +5106,6 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 	/* 水平 padding 设为 0 让 body 内容与父 .ref-md-root--agent-chat 左右边缘对齐。
 	   首行（如「已思考 X.Xs」）需要与壳头部留出呼吸距离，否则在流式底部遮罩存在时容易被遮 */
 	padding: 10px 0 6px;
-	height: 200px;
 	max-height: 200px;
 	overflow-y: auto;
 	/* 细滚动条：默认完全透明，鼠标进入 body 时渐入；离开时渐出。

--- a/src/index.css
+++ b/src/index.css
@@ -4689,12 +4689,14 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 
 .ref-agent-activity-text {
 	min-width: 0;
-	white-space: pre-line;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 /* read_file ?????????????????????? Cursor Agent? */
 .ref-agent-activity-ref-link {
-	display: inline;
+	display: inline-block;
 	max-width: 100%;
 	margin: 0;
 	padding: 0;
@@ -4704,7 +4706,9 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 	font: inherit;
 	text-align: left;
 	cursor: pointer;
-	white-space: pre-line;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 	text-decoration: none;
 	border-radius: 4px;
 }

--- a/src/threadTypes.test.ts
+++ b/src/threadTypes.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { chatMessagesListEqual, type ChatMessage } from './threadTypes';
+import {
+	applyThreadRowsPreservingDetails,
+	chatMessagesListEqual,
+	mergeThreadDetailRows,
+	threadListVersions,
+	type ChatMessage,
+	type ThreadInfo,
+} from './threadTypes';
 
 describe('chatMessagesListEqual skill_invoke', () => {
 	it('相同 skill_invoke parts 视为相等', () => {
@@ -38,5 +45,78 @@ describe('chatMessagesListEqual skill_invoke', () => {
 		expect(
 			chatMessagesListEqual([base], [{ ...base, parts: [{ kind: 'skill_invoke', slug: 'a', name: 'B' }] }])
 		).toBe(false);
+	});
+});
+
+describe('layered thread rows', () => {
+	it('preserves existing summary details when a light row has the same version', () => {
+		const prev: ThreadInfo[] = [
+			{
+				id: 't1',
+				title: 'Old title',
+				updatedAt: 10,
+				previewCount: 2,
+				hasUserMessages: true,
+				hasAgentDiff: true,
+				filePaths: ['src/a.ts'],
+				fileCount: 1,
+				subtitleFallback: 'Edited src/a.ts',
+			},
+		];
+
+		const next = applyThreadRowsPreservingDetails(prev, [
+			{
+				id: 't1',
+				title: 'New title',
+				updatedAt: 10,
+				previewCount: 2,
+				hasUserMessages: true,
+			},
+		]);
+
+		expect(next[0]).toMatchObject({
+			title: 'New title',
+			hasAgentDiff: true,
+			filePaths: ['src/a.ts'],
+			subtitleFallback: 'Edited src/a.ts',
+		});
+	});
+
+	it('does not merge stale detail rows across updatedAt changes', () => {
+		const prev: ThreadInfo[] = [
+			{
+				id: 't1',
+				title: 'Current',
+				updatedAt: 20,
+				previewCount: 3,
+				hasUserMessages: true,
+			},
+		];
+
+		const next = mergeThreadDetailRows(prev, [
+			{
+				id: 't1',
+				title: 'Stale',
+				updatedAt: 10,
+				previewCount: 2,
+				hasUserMessages: true,
+				hasAgentDiff: true,
+				filePaths: ['stale.ts'],
+			},
+		]);
+
+		expect(next).toBe(prev);
+	});
+
+	it('returns id and updatedAt pairs for detail hydration requests', () => {
+		expect(
+			threadListVersions([
+				{ id: 'a', title: 'A', updatedAt: 1, previewCount: 0 },
+				{ id: 'b', title: 'B', updatedAt: 2, previewCount: 1 },
+			])
+		).toEqual([
+			{ id: 'a', updatedAt: 1 },
+			{ id: 'b', updatedAt: 2 },
+		]);
 	});
 });

--- a/src/threadTypes.ts
+++ b/src/threadTypes.ts
@@ -17,6 +17,11 @@ export type ThreadInfo = {
 	fileStateCount?: number;
 };
 
+export type ThreadListVersion = {
+	id: string;
+	updatedAt: number;
+};
+
 import type { UserMessagePart } from './messageParts';
 
 export type ChatMessage = {
@@ -163,4 +168,41 @@ export function normalizeThreadRow(t: ThreadInfo): ThreadInfo {
 		tokenUsage: t.tokenUsage,
 		fileStateCount: t.fileStateCount ?? 0,
 	};
+}
+
+export function threadListVersions(rows: ThreadInfo[]): ThreadListVersion[] {
+	return rows.map((row) => ({ id: row.id, updatedAt: row.updatedAt }));
+}
+
+export function applyThreadRowsPreservingDetails(prev: ThreadInfo[], incoming: ThreadInfo[]): ThreadInfo[] {
+	const prevById = new Map(prev.map((row) => [row.id, row]));
+	const next = incoming.map((row) => {
+		const existing = prevById.get(row.id);
+		const merged = existing && existing.updatedAt === row.updatedAt
+			? { ...existing, ...row }
+			: row;
+		return normalizeThreadRow(merged);
+	});
+	return threadInfoListEqual(prev, next) ? prev : next;
+}
+
+export function mergeThreadDetailRows(prev: ThreadInfo[], details: ThreadInfo[]): ThreadInfo[] {
+	if (prev.length === 0 || details.length === 0) {
+		return prev;
+	}
+	const detailsById = new Map(details.map((row) => [row.id, normalizeThreadRow(row)]));
+	let changed = false;
+	const next = prev.map((row) => {
+		const detail = detailsById.get(row.id);
+		if (!detail || detail.updatedAt !== row.updatedAt) {
+			return row;
+		}
+		const merged = normalizeThreadRow({ ...row, ...detail });
+		if (!threadInfoListEqual([row], [merged])) {
+			changed = true;
+			return merged;
+		}
+		return row;
+	});
+	return changed ? next : prev;
 }


### PR DESCRIPTION
## Summary

This branch improves the agent chat and desktop shell around thread list performance, workspace switching, and preflight UI behavior, with supporting tests and small preload / IPC adjustments.

## Changes

### Thread list and main process (`threadListSummary`, IPC, `threadStore`)

- Split **lightweight thread listing** from **versioned detail fetch** over IPC to reduce work when rendering the sidebar.
- Expand the main-process thread summary cache (workspace keys, higher cap, richer metadata) and preserve merged row fields across refreshes while discarding stale async results.
- Refine how the agent sidebar picks workspace/thread paths; default surface routes toward the agent layout where appropriate.

### Renderer: hooks and chat UI

- **`useThreads` / related hooks**: align with the new list/detail model and improve sidebar list behavior.
- **`AgentPreflightShell` / `AgentChatPanel`**: throttle preflight layout remeasurement and clamp long activity text to reduce jank; refine top UI.
- **Preflight markdown**: `preserveLivePreflight` follows streaming state so that after a turn finishes, the same markdown is not shown twice in preflight and the assistant bubble.
- **Scroll / sticky user**: on resend during a stream, clamp scroll so the preflight “analyzing” header stays below the sticky user bubble.
- **Workspace**: faster workspace switching; support opening a workspace from the UI flow.
- **Styles**: targeted `index.css` updates for the above.

### Other

- **`electron/preload.cjs`**: small chore addition for exposed APIs.
- **Tests**: `threadListSummary`, `threadTypes`, `agentSidebarWorkspaceList`, `desktopShellInit` coverage for new or changed behavior.

## Testing

- `main-src/threadListSummary.test.ts`, `src/threadTypes.test.ts`, `src/app/agentSidebarWorkspaceList.test.ts`, `src/app/desktopShellInit.test.ts` (run the project’s usual test command as applicable).

## Review notes

- Focus on IPC contract changes (light vs detail) and any regression risk in thread sidebar refresh and workspace switching.
