### PR TITLE
Fix packaged diagnostics and update IPC handling

### DIFF
--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -72,6 +72,7 @@ const INVOKE_CHANNELS = new Set([
 	'theme:applyChrome',
 	'threads:list',
 	'threads:listLight',
+	'threads:listDetails',
 	'threads:listAgentSidebar',
 	'threads:messages',
 	'threads:fileStates',

--- a/main-src/appWindow.ts
+++ b/main-src/appWindow.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, app, screen, type WebContents } from 'electron';
+import { BrowserWindow, app, screen, type Input, type WebContents } from 'electron';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import {
@@ -34,6 +34,40 @@ const surfaceByWebContentsId = new Map<number, AppWindowSurface>();
 function normalizeWorkspaceRoot(root: string | null | undefined): string | null {
 	const trimmed = typeof root === 'string' ? root.trim() : '';
 	return trimmed ? path.resolve(trimmed) : null;
+}
+
+function isDevToolsToggleInput(input: Input): boolean {
+	if (input.isAutoRepeat || (input.type !== 'keyDown' && input.type !== 'rawKeyDown')) {
+		return false;
+	}
+	const key = input.key.toLowerCase();
+	const code = input.code.toLowerCase();
+	if (key === 'f12' || code === 'f12') {
+		return true;
+	}
+	const isIKey = key === 'i' || code === 'keyi';
+	if (!isIKey || !input.shift) {
+		return false;
+	}
+	return process.platform === 'darwin' ? input.meta && input.alt : input.control;
+}
+
+function toggleDevTools(win: BrowserWindow): void {
+	if (win.webContents.isDevToolsOpened()) {
+		win.webContents.closeDevTools();
+	} else {
+		win.webContents.openDevTools({ mode: 'detach' });
+	}
+}
+
+function installDevToolsShortcut(win: BrowserWindow): void {
+	win.webContents.on('before-input-event', (event, input) => {
+		if (!isDevToolsToggleInput(input)) {
+			return;
+		}
+		event.preventDefault();
+		toggleDevTools(win);
+	});
 }
 
 export function getAppWindowSurfaceForWebContents(
@@ -143,6 +177,7 @@ export function createAppWindow(opts?: {
 		show: false,
 	});
 	applyThemeChromeToWindow(win, initialThemeChrome.scheme, initialThemeChrome.override);
+	installDevToolsShortcut(win);
 	let shown = false;
 	const revealWindow = (reason: string) => {
 		if (shown || win.isDestroyed()) {
@@ -209,12 +244,12 @@ export function createAppWindow(opts?: {
 
 	if (useViteDevServer) {
 		void win.loadURL(devUrl + urlSuffix);
-		if (openDevTools) {
-			win.webContents.openDevTools({ mode: 'detach' });
-		}
 	} else {
 		const fileUrl = pathToFileURL(htmlPath).href + urlSuffix;
 		void win.loadURL(fileUrl);
+	}
+	if (openDevTools) {
+		win.webContents.openDevTools({ mode: 'detach' });
 	}
 	return win;
 }

--- a/main-src/autoUpdate.ts
+++ b/main-src/autoUpdate.ts
@@ -43,6 +43,10 @@ function isDifferentialAllowed(): boolean {
 	return settings.autoUpdate?.allowDifferential !== false; // 默认允许
 }
 
+function syncDifferentialDownloadSetting(): void {
+	autoUpdater.disableDifferentialDownload = !isDifferentialAllowed();
+}
+
 /** 配置 autoUpdater */
 function configureUpdater(): void {
 	if (isConfigured) {
@@ -52,7 +56,8 @@ function configureUpdater(): void {
 
 	autoUpdater.autoDownload = true;
 	autoUpdater.autoInstallOnAppQuit = true;
-	
+	syncDifferentialDownloadSetting();
+
 	// 设置 GitHub 仓库（从 package.json 的 repository 或硬编码）
 	autoUpdater.setFeedURL({
 		provider: 'github',
@@ -137,6 +142,7 @@ export async function checkForUpdates(): Promise<AutoUpdateStatus> {
 	}
 
 	configureUpdater();
+	syncDifferentialDownloadSetting();
 
 	updateCheckPromise = (async () => {
 		try {
@@ -166,7 +172,7 @@ export async function downloadUpdate(): Promise<void> {
 	}
 
 	// 如果禁用差异化更新，强制全量下载；每次下载前同步，避免设置切回后沿用旧状态。
-	autoUpdater.disableDifferentialDownload = !isDifferentialAllowed();
+	syncDifferentialDownloadSetting();
 	await autoUpdater.downloadUpdate();
 }
 


### PR DESCRIPTION
## Summary
- Add packaged-window DevTools shortcuts for debugging production black screens
- Respect the differential update setting before automatic update downloads
- Allow the renderer to call the threads:listDetails IPC channel

## Verification
- npm run typecheck
- npm run build:main