### PR TITLE
Harden workspace recovery and SCM organization

### DIFF
--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -178,6 +178,7 @@ const INVOKE_CHANNELS = new Set([
 	'threads:getPlan',
 	'workspaceAgent:get',
 	'workspaceAgent:set',
+	'workspaceAgent:resetAsyncDir',
 	'workspace:closeFolder',
 	'workspace:removeRecent',
 	'app:newWindow',

--- a/main-src/ipc/register.ts
+++ b/main-src/ipc/register.ts
@@ -686,6 +686,26 @@ export function registerIpc(): void {
 		return { ok: true as const };
 	});
 
+	/** 把工作区 `.async/` 整个移动到 `.async.bak-<ts>/`，用于黑屏/启动异常时的应急恢复。
+	 *  保留备份而不直接删除，避免误删用户记忆/计划。 */
+	ipcMain.handle('workspaceAgent:resetAsyncDir', (event) => {
+		const root = senderWorkspaceRoot(event);
+		if (!root) {
+			return { ok: false as const, error: 'no-workspace' as const };
+		}
+		const dir = path.join(root, '.async');
+		try {
+			if (!fs.existsSync(dir)) {
+				return { ok: true as const, backupPath: null };
+			}
+			const backupPath = path.join(root, `.async.bak-${Date.now()}`);
+			fs.renameSync(dir, backupPath);
+			return { ok: true as const, backupPath };
+		} catch (e) {
+			return { ok: false as const, error: (e as Error)?.message ?? 'rename-failed' };
+		}
+	});
+
 	ipcMain.handle('workspace:listDiskSkills', (event) => {
 		const root = senderWorkspaceRoot(event);
 		if (!root) {

--- a/main-src/workspaceAgentStore.test.ts
+++ b/main-src/workspaceAgentStore.test.ts
@@ -1,0 +1,195 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	mergeAgentWithProjectSlice,
+	readWorkspaceAgentProjectSlice,
+	workspaceAgentJsonPath,
+	writeWorkspaceAgentProjectSlice,
+} from './workspaceAgentStore.js';
+
+function makeTmpRoot(): string {
+	return fs.mkdtempSync(path.join(os.tmpdir(), 'async-store-test-'));
+}
+
+function rmDirSafe(dir: string): void {
+	try {
+		fs.rmSync(dir, { recursive: true, force: true });
+	} catch {
+		/* ignore */
+	}
+}
+
+describe('workspaceAgentStore.readWorkspaceAgentProjectSlice', () => {
+	let root: string;
+	const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+	beforeEach(() => {
+		root = makeTmpRoot();
+		warnSpy.mockClear();
+	});
+
+	afterEach(() => {
+		rmDirSafe(root);
+	});
+
+	it('returns empty slice when root is null', () => {
+		expect(readWorkspaceAgentProjectSlice(null)).toEqual({});
+	});
+
+	it('returns empty slice when agent.json is missing', () => {
+		const slice = readWorkspaceAgentProjectSlice(root);
+		expect(slice).toEqual({});
+	});
+
+	it('returns empty slice when agent.json is a directory, not a file', () => {
+		fs.mkdirSync(path.join(root, '.async', 'agent.json'), { recursive: true });
+		expect(readWorkspaceAgentProjectSlice(root)).toEqual({});
+	});
+
+	it('quarantines invalid JSON to .corrupt-<ts>.bak and returns empty slice', () => {
+		const p = workspaceAgentJsonPath(root);
+		fs.mkdirSync(path.dirname(p), { recursive: true });
+		fs.writeFileSync(p, '{ this is not json', 'utf8');
+		const slice = readWorkspaceAgentProjectSlice(root);
+		expect(slice).toEqual({});
+		expect(fs.existsSync(p)).toBe(false);
+		const siblings = fs.readdirSync(path.dirname(p));
+		expect(siblings.some((n) => n.startsWith('agent.json.corrupt-') && n.endsWith('.bak'))).toBe(true);
+	});
+
+	it('returns empty slice when root is a JSON array (wrong shape)', () => {
+		const p = workspaceAgentJsonPath(root);
+		fs.mkdirSync(path.dirname(p), { recursive: true });
+		fs.writeFileSync(p, '[]', 'utf8');
+		expect(readWorkspaceAgentProjectSlice(root)).toEqual({});
+	});
+
+	it('returns empty arrays when fields are non-arrays', () => {
+		const p = workspaceAgentJsonPath(root);
+		fs.mkdirSync(path.dirname(p), { recursive: true });
+		fs.writeFileSync(p, JSON.stringify({ rules: 'oops', skills: null, subagents: 7 }), 'utf8');
+		const slice = readWorkspaceAgentProjectSlice(root);
+		expect(slice).toEqual({ rules: [], skills: [], subagents: [] });
+	});
+
+	it('drops malformed rule entries (missing id or name) and keeps valid ones', () => {
+		const p = workspaceAgentJsonPath(root);
+		fs.mkdirSync(path.dirname(p), { recursive: true });
+		fs.writeFileSync(
+			p,
+			JSON.stringify({
+				rules: [
+					{ id: 'r1', name: 'Good Rule', content: 'body', scope: 'always', enabled: true },
+					{ id: '', name: 'No ID' },
+					{ name: 'Missing id field', content: 'x' },
+					'not-an-object',
+					null,
+					{ id: 'r2', name: 'Glob Rule', scope: 'glob', globPattern: '*.ts', enabled: false },
+				],
+			}),
+			'utf8'
+		);
+		const slice = readWorkspaceAgentProjectSlice(root);
+		expect(slice.rules).toHaveLength(2);
+		expect(slice.rules![0]).toMatchObject({ id: 'r1', name: 'Good Rule', scope: 'always', enabled: true });
+		expect(slice.rules![1]).toMatchObject({
+			id: 'r2',
+			name: 'Glob Rule',
+			scope: 'glob',
+			globPattern: '*.ts',
+			enabled: false,
+		});
+	});
+
+	it('coerces unknown rule scope to "always" and provides default enabled=true', () => {
+		const p = workspaceAgentJsonPath(root);
+		fs.mkdirSync(path.dirname(p), { recursive: true });
+		fs.writeFileSync(p, JSON.stringify({ rules: [{ id: 'r', name: 'n', scope: 'bogus' }] }), 'utf8');
+		const slice = readWorkspaceAgentProjectSlice(root);
+		expect(slice.rules![0]).toMatchObject({ scope: 'always', enabled: true });
+	});
+
+	it('drops malformed skills (missing id/name/slug) and keeps valid ones', () => {
+		const p = workspaceAgentJsonPath(root);
+		fs.mkdirSync(path.dirname(p), { recursive: true });
+		fs.writeFileSync(
+			p,
+			JSON.stringify({
+				skills: [
+					{ id: 's1', name: 'Skill A', slug: 'a', description: 'desc', content: 'body' },
+					{ id: 's2', name: 'No slug' },
+					{ name: 'No id', slug: 'x' },
+					{ id: 's3', name: 'Skill C', slug: 'c', pluginSourceKind: 'invalid' },
+					{ id: 's4', name: 'Skill D', slug: 'd', pluginSourceKind: 'agent', enabled: true },
+				],
+			}),
+			'utf8'
+		);
+		const slice = readWorkspaceAgentProjectSlice(root);
+		expect(slice.skills!.map((s) => s.id)).toEqual(['s1', 's3', 's4']);
+		expect(slice.skills![1].pluginSourceKind).toBeUndefined();
+		expect(slice.skills![2].pluginSourceKind).toBe('agent');
+	});
+
+	it('drops malformed subagents and preserves valid ones', () => {
+		const p = workspaceAgentJsonPath(root);
+		fs.mkdirSync(path.dirname(p), { recursive: true });
+		fs.writeFileSync(
+			p,
+			JSON.stringify({
+				subagents: [
+					{ id: 'a1', name: 'Sub', description: 'd', instructions: 'do' },
+					{ id: 'a2', name: 'Bogus scope', memoryScope: 'foo' },
+					{ id: '', name: 'no id' },
+				],
+			}),
+			'utf8'
+		);
+		const slice = readWorkspaceAgentProjectSlice(root);
+		expect(slice.subagents!.map((s) => s.id)).toEqual(['a1', 'a2']);
+		expect(slice.subagents![1].memoryScope).toBeUndefined();
+	});
+
+	it('round-trips: write then read returns equivalent shape', () => {
+		writeWorkspaceAgentProjectSlice(root, {
+			rules: [{ id: 'r1', name: 'R', content: 'c', scope: 'always', enabled: true }],
+			skills: [{ id: 's1', name: 'S', slug: 'sl', description: 'd', content: 'c' }],
+			subagents: [{ id: 'a1', name: 'A', description: 'd', instructions: 'i' }],
+		});
+		const slice = readWorkspaceAgentProjectSlice(root);
+		expect(slice.rules![0].id).toBe('r1');
+		expect(slice.skills![0].slug).toBe('sl');
+		expect(slice.subagents![0].id).toBe('a1');
+	});
+});
+
+describe('workspaceAgentStore.mergeAgentWithProjectSlice', () => {
+	it('concatenates user and project arrays without dropping order', () => {
+		const merged = mergeAgentWithProjectSlice(
+			{
+				rules: [{ id: 'u-r', name: 'U', content: '', scope: 'always', enabled: true }],
+				skills: [{ id: 'u-s', name: 'U', slug: 'u', description: '', content: '' }],
+				subagents: [{ id: 'u-a', name: 'U', description: '', instructions: '' }],
+			},
+			{
+				rules: [{ id: 'p-r', name: 'P', content: '', scope: 'always', enabled: true }],
+				skills: [{ id: 'p-s', name: 'P', slug: 'p', description: '', content: '' }],
+				subagents: [{ id: 'p-a', name: 'P', description: '', instructions: '' }],
+			}
+		);
+		expect(merged.rules!.map((r) => r.id)).toEqual(['u-r', 'p-r']);
+		expect(merged.skills!.map((s) => s.id)).toEqual(['u-s', 'p-s']);
+		expect(merged.subagents!.map((a) => a.id)).toEqual(['u-a', 'p-a']);
+	});
+
+	it('handles undefined user agent gracefully', () => {
+		const merged = mergeAgentWithProjectSlice(undefined, {
+			rules: [{ id: 'p-r', name: 'P', content: '', scope: 'always', enabled: true }],
+		});
+		expect(merged.rules!.map((r) => r.id)).toEqual(['p-r']);
+		expect(merged.skills).toEqual([]);
+		expect(merged.subagents).toEqual([]);
+	});
+});

--- a/main-src/workspaceAgentStore.ts
+++ b/main-src/workspaceAgentStore.ts
@@ -19,28 +19,194 @@ export function workspaceAgentJsonPath(root: string): string {
 	return path.join(root, ...FILE_SEGMENTS);
 }
 
+function isPlainRecord(v: unknown): v is Record<string, unknown> {
+	return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+function asString(v: unknown, fallback = ''): string {
+	return typeof v === 'string' ? v : fallback;
+}
+
+function asOptString(v: unknown): string | undefined {
+	return typeof v === 'string' ? v : undefined;
+}
+
+function asOptBool(v: unknown): boolean | undefined {
+	return typeof v === 'boolean' ? v : undefined;
+}
+
+/** 仅在最小必要字段存在时通过，否则视为损坏条目并丢弃 */
+function normalizeRule(raw: unknown): AgentRule | null {
+	if (!isPlainRecord(raw)) {
+		return null;
+	}
+	const id = asString(raw.id);
+	const name = asString(raw.name);
+	if (!id || !name) {
+		return null;
+	}
+	const scope = raw.scope === 'glob' || raw.scope === 'manual' ? raw.scope : 'always';
+	const enabled = typeof raw.enabled === 'boolean' ? raw.enabled : true;
+	const out: AgentRule = {
+		id,
+		name,
+		content: asString(raw.content),
+		scope,
+		enabled,
+	};
+	const glob = asOptString(raw.globPattern);
+	if (glob !== undefined) {
+		out.globPattern = glob;
+	}
+	const origin = raw.origin === 'user' || raw.origin === 'project' ? raw.origin : undefined;
+	if (origin) {
+		out.origin = origin;
+	}
+	return out;
+}
+
+function normalizeSkill(raw: unknown): AgentSkill | null {
+	if (!isPlainRecord(raw)) {
+		return null;
+	}
+	const id = asString(raw.id);
+	const name = asString(raw.name);
+	const slug = asString(raw.slug);
+	if (!id || !name || !slug) {
+		return null;
+	}
+	const out: AgentSkill = {
+		id,
+		name,
+		description: asString(raw.description),
+		slug,
+		content: asString(raw.content),
+	};
+	const enabled = asOptBool(raw.enabled);
+	if (enabled !== undefined) {
+		out.enabled = enabled;
+	}
+	const origin = raw.origin === 'user' || raw.origin === 'project' ? raw.origin : undefined;
+	if (origin) {
+		out.origin = origin;
+	}
+	const ssrp = asOptString(raw.skillSourceRelPath);
+	if (ssrp !== undefined) {
+		out.skillSourceRelPath = ssrp;
+	}
+	const psn = asOptString(raw.pluginSourceName);
+	if (psn !== undefined) {
+		out.pluginSourceName = psn;
+	}
+	const psrp = asOptString(raw.pluginSourceRelPath);
+	if (psrp !== undefined) {
+		out.pluginSourceRelPath = psrp;
+	}
+	if (raw.pluginSourceKind === 'skill' || raw.pluginSourceKind === 'agent') {
+		out.pluginSourceKind = raw.pluginSourceKind;
+	}
+	return out;
+}
+
+function normalizeSubagent(raw: unknown): AgentSubagent | null {
+	if (!isPlainRecord(raw)) {
+		return null;
+	}
+	const id = asString(raw.id);
+	const name = asString(raw.name);
+	if (!id || !name) {
+		return null;
+	}
+	const out: AgentSubagent = {
+		id,
+		name,
+		description: asString(raw.description),
+		instructions: asString(raw.instructions),
+	};
+	if (raw.memoryScope === 'user' || raw.memoryScope === 'project' || raw.memoryScope === 'local') {
+		out.memoryScope = raw.memoryScope;
+	}
+	const enabled = asOptBool(raw.enabled);
+	if (enabled !== undefined) {
+		out.enabled = enabled;
+	}
+	const origin = raw.origin === 'user' || raw.origin === 'project' ? raw.origin : undefined;
+	if (origin) {
+		out.origin = origin;
+	}
+	const psn = asOptString(raw.pluginSourceName);
+	if (psn !== undefined) {
+		out.pluginSourceName = psn;
+	}
+	const psrp = asOptString(raw.pluginSourceRelPath);
+	if (psrp !== undefined) {
+		out.pluginSourceRelPath = psrp;
+	}
+	return out;
+}
+
+function normalizeArray<T>(raw: unknown, normalize: (item: unknown) => T | null, label: string, file: string): T[] {
+	if (!Array.isArray(raw)) {
+		return [];
+	}
+	const out: T[] = [];
+	let dropped = 0;
+	for (const item of raw) {
+		const norm = normalize(item);
+		if (norm) {
+			out.push(norm);
+		} else {
+			dropped += 1;
+		}
+	}
+	if (dropped > 0) {
+		console.warn(`[workspaceAgentStore] dropped ${dropped} malformed ${label} entries from ${file}`);
+	}
+	return out;
+}
+
 export function readWorkspaceAgentProjectSlice(root: string | null): WorkspaceAgentProjectSlice {
 	if (!root) {
 		return {};
 	}
 	const p = workspaceAgentJsonPath(root);
+	let raw: string;
 	try {
 		if (!fs.existsSync(p) || !fs.statSync(p).isFile()) {
 			return {};
 		}
-		const raw = fs.readFileSync(p, 'utf8');
-		const parsed = JSON.parse(raw) as unknown;
-		if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-			return {};
-		}
-		const o = parsed as Record<string, unknown>;
-		return {
-			rules: Array.isArray(o.rules) ? (o.rules as AgentRule[]) : [],
-			skills: Array.isArray(o.skills) ? (o.skills as AgentSkill[]) : [],
-			subagents: Array.isArray(o.subagents) ? (o.subagents as AgentSubagent[]) : [],
-		};
-	} catch {
+		raw = fs.readFileSync(p, 'utf8');
+	} catch (e) {
+		console.warn(`[workspaceAgentStore] failed to read ${p}: ${(e as Error)?.message ?? e}`);
 		return {};
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch (e) {
+		console.warn(`[workspaceAgentStore] ${p} is not valid JSON, ignoring: ${(e as Error)?.message ?? e}`);
+		quarantineCorruptFile(p, raw);
+		return {};
+	}
+	if (!isPlainRecord(parsed)) {
+		console.warn(`[workspaceAgentStore] ${p} root is not an object, ignoring`);
+		return {};
+	}
+	return {
+		rules: normalizeArray(parsed.rules, normalizeRule, 'rule', p),
+		skills: normalizeArray(parsed.skills, normalizeSkill, 'skill', p),
+		subagents: normalizeArray(parsed.subagents, normalizeSubagent, 'subagent', p),
+	};
+}
+
+/** 把无法解析的文件改名为 .corrupt-<ts>.bak，避免下次启动反复挂掉 */
+function quarantineCorruptFile(filePath: string, _raw: string): void {
+	try {
+		const backup = `${filePath}.corrupt-${Date.now()}.bak`;
+		fs.renameSync(filePath, backup);
+		console.warn(`[workspaceAgentStore] quarantined corrupt file to ${backup}`);
+	} catch (e) {
+		console.warn(`[workspaceAgentStore] could not quarantine ${filePath}: ${(e as Error)?.message ?? e}`);
 	}
 }
 

--- a/src/AgentRightSidebar.tsx
+++ b/src/AgentRightSidebar.tsx
@@ -23,6 +23,7 @@ import {
 	IconArrowRight,
 	IconCloseSmall,
 	IconDoc,
+	IconFolderOpen,
 	IconGitSCM,
 	IconGlobe,
 	IconPlus,
@@ -2616,6 +2617,30 @@ export const AgentBrowserWindowSurface = memo(function AgentBrowserWindowSurface
 });
 
 const COMMIT_PREV_BRANCH_KEY = 'voidShell.commitModal.prevBranch.v1';
+const SCM_GROUPED_KEY = 'voidShell.agentScm.grouped.v1';
+
+function readScmGrouped(): boolean {
+	if (typeof window === 'undefined') {
+		return true;
+	}
+	try {
+		const raw = window.localStorage.getItem(SCM_GROUPED_KEY);
+		return raw == null ? true : raw === '1';
+	} catch {
+		return true;
+	}
+}
+
+function writeScmGrouped(value: boolean): void {
+	if (typeof window === 'undefined') {
+		return;
+	}
+	try {
+		window.localStorage.setItem(SCM_GROUPED_KEY, value ? '1' : '0');
+	} catch {
+		// ignore
+	}
+}
 
 function isMeaningfulGitBranch(branch: string | undefined): branch is string {
 	const b = String(branch ?? '').trim();
@@ -2725,6 +2750,14 @@ const AgentRightSidebarGitPanel = memo(function AgentRightSidebarGitPanel({
 	}, [gitViewActive, refreshGit]);
 
 	const [showCommitModal, setShowCommitModal] = useState(false);
+	const [scmGrouped, setScmGrouped] = useState<boolean>(() => readScmGrouped());
+	const toggleScmGrouped = useCallback(() => {
+		setScmGrouped((cur) => {
+			const next = !cur;
+			writeScmGrouped(next);
+			return next;
+		});
+	}, []);
 	const previousBranch = useMemo(
 		() => (showCommitModal ? readPreviousCommitBranch(currentThreadId) : undefined),
 		[showCommitModal, currentThreadId]
@@ -2797,6 +2830,16 @@ const AgentRightSidebarGitPanel = memo(function AgentRightSidebarGitPanel({
 							>
 								<IconRefresh />
 							</button>
+							<button
+								type="button"
+								className={`ref-icon-tile ${scmGrouped ? 'is-active' : ''}`}
+								aria-label={t('app.gitGroupToggleAria')}
+								aria-pressed={scmGrouped}
+								title={scmGrouped ? t('app.gitGroupOnTitle') : t('app.gitGroupOffTitle')}
+								onClick={toggleScmGrouped}
+							>
+								<IconFolderOpen />
+							</button>
 							<span className="ref-local-label">{t('app.gitLocal')}</span>
 							<span className="ref-branch-chip">{gitBranch || '—'}</span>
 						</div>
@@ -2831,6 +2874,7 @@ const AgentRightSidebarGitPanel = memo(function AgentRightSidebarGitPanel({
 									onEnsurePreviews={(paths) => {
 										void loadGitDiffPreviews(paths);
 									}}
+									grouped={scmGrouped}
 								/>
 							) : null}
 							{gitUnavailableReason === 'none' && gitActionError ? (

--- a/src/AppErrorBoundary.tsx
+++ b/src/AppErrorBoundary.tsx
@@ -1,0 +1,116 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+type Props = {
+	children: ReactNode;
+};
+
+type State = {
+	error: Error | null;
+	componentStack: string | null;
+	resetState: 'idle' | 'pending' | 'done' | 'failed';
+	resetMessage: string | null;
+};
+
+type AsyncShellLike = {
+	invoke: (channel: string, ...args: unknown[]) => Promise<unknown>;
+};
+
+function getAsyncShell(): AsyncShellLike | null {
+	const w = window as unknown as { asyncShell?: AsyncShellLike };
+	return w.asyncShell ?? null;
+}
+
+/**
+ * 渲染进程根错误兜底：避免初始化时单点异常把整个窗口顶成黑屏。
+ * 命中时显示故障页：重载、备份并重置当前工作区 .async/ 目录。
+ */
+export class AppErrorBoundary extends Component<Props, State> {
+	state: State = { error: null, componentStack: null, resetState: 'idle', resetMessage: null };
+
+	static getDerivedStateFromError(error: Error): Partial<State> {
+		return { error };
+	}
+
+	componentDidCatch(error: Error, info: ErrorInfo): void {
+		this.setState({ componentStack: info.componentStack ?? null });
+		console.error('[AppErrorBoundary] caught render error', error, info);
+	}
+
+	private handleReload = (): void => {
+		window.location.reload();
+	};
+
+	private handleResetAsync = async (): Promise<void> => {
+		const shell = getAsyncShell();
+		if (!shell) {
+			this.setState({ resetState: 'failed', resetMessage: 'IPC bridge unavailable.' });
+			return;
+		}
+		this.setState({ resetState: 'pending', resetMessage: null });
+		try {
+			const result = (await shell.invoke('workspaceAgent:resetAsyncDir')) as
+				| { ok: true; backupPath: string | null }
+				| { ok: false; error: string };
+			if (result.ok) {
+				this.setState({
+					resetState: 'done',
+					resetMessage: result.backupPath
+						? `Backed up to ${result.backupPath}. Reload to continue.`
+						: 'No .async folder was found. Reload to continue.',
+				});
+			} else {
+				this.setState({ resetState: 'failed', resetMessage: result.error });
+			}
+		} catch (e) {
+			this.setState({ resetState: 'failed', resetMessage: (e as Error)?.message ?? String(e) });
+		}
+	};
+
+	render(): ReactNode {
+		const { error, componentStack, resetState, resetMessage } = this.state;
+		if (!error) {
+			return this.props.children;
+		}
+		const resetting = resetState === 'pending';
+		return (
+			<div className="ref-app-error-boundary" role="alert">
+				<div className="ref-app-error-boundary-card">
+					<h1 className="ref-app-error-boundary-title">Async ran into a problem</h1>
+					<p className="ref-app-error-boundary-msg">
+						The window failed to initialize. This is often caused by a corrupted file under your workspace's
+						<code>.async/</code> folder (for example <code>.async/agent.json</code>). Try reloading first; if it still
+						crashes, back up and reset that folder — your global settings are not affected.
+					</p>
+					<div className="ref-app-error-boundary-actions">
+						<button type="button" className="ref-app-error-boundary-btn" onClick={this.handleReload}>
+							Reload window
+						</button>
+						<button
+							type="button"
+							className="ref-app-error-boundary-btn"
+							onClick={() => void this.handleResetAsync()}
+							disabled={resetting || resetState === 'done'}
+						>
+							{resetting ? 'Resetting…' : 'Back up & reset .async/'}
+						</button>
+					</div>
+					{resetMessage ? (
+						<p
+							className={`ref-app-error-boundary-status ${resetState === 'failed' ? 'is-error' : 'is-ok'}`}
+						>
+							{resetMessage}
+						</p>
+					) : null}
+					<details className="ref-app-error-boundary-details">
+						<summary>Technical details</summary>
+						<pre className="ref-app-error-boundary-pre">
+							{error.name}: {error.message}
+							{error.stack ? `\n\n${error.stack}` : ''}
+							{componentStack ? `\n\nComponent stack:${componentStack}` : ''}
+						</pre>
+					</details>
+				</div>
+			</div>
+		);
+	}
+}

--- a/src/GitScmVirtualLists.test.ts
+++ b/src/GitScmVirtualLists.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { groupPathsByDir } from './GitScmVirtualLists';
+
+describe('groupPathsByDir', () => {
+	it('returns empty array for empty input', () => {
+		expect(groupPathsByDir([])).toEqual([]);
+	});
+
+	it('groups single root file under empty directory key', () => {
+		expect(groupPathsByDir(['README.md'])).toEqual([{ dir: '', paths: ['README.md'] }]);
+	});
+
+	it('groups files by their immediate parent directory', () => {
+		const out = groupPathsByDir(['src/a.ts', 'src/b.ts', 'docs/readme.md', 'package.json']);
+		expect(out).toEqual([
+			{ dir: '', paths: ['package.json'] },
+			{ dir: 'docs', paths: ['docs/readme.md'] },
+			{ dir: 'src', paths: ['src/a.ts', 'src/b.ts'] },
+		]);
+	});
+
+	it('keeps the original path string (with backslashes) but groups using normalized dir', () => {
+		const out = groupPathsByDir(['src\\a.ts', 'src/b.ts']);
+		expect(out).toHaveLength(1);
+		expect(out[0].dir).toBe('src');
+		expect(out[0].paths).toEqual(['src\\a.ts', 'src/b.ts']);
+	});
+
+	it('places the root group ("") first regardless of other dir names', () => {
+		const out = groupPathsByDir(['z/last.ts', 'README.md', 'a/first.ts']);
+		expect(out.map((g) => g.dir)).toEqual(['', 'a', 'z']);
+	});
+
+	it('sorts non-root groups lexicographically', () => {
+		const out = groupPathsByDir(['z/x.ts', 'b/x.ts', 'a/x.ts', 'c/x.ts']);
+		expect(out.map((g) => g.dir)).toEqual(['a', 'b', 'c', 'z']);
+	});
+
+	it('uses the full parent path as the group key (not just basename)', () => {
+		const out = groupPathsByDir(['src/foo/x.ts', 'src/bar/y.ts']);
+		expect(out.map((g) => g.dir)).toEqual(['src/bar', 'src/foo']);
+	});
+
+	it('preserves insertion order within each group', () => {
+		const out = groupPathsByDir(['src/c.ts', 'src/a.ts', 'src/b.ts']);
+		expect(out[0].paths).toEqual(['src/c.ts', 'src/a.ts', 'src/b.ts']);
+	});
+});

--- a/src/GitScmVirtualLists.tsx
+++ b/src/GitScmVirtualLists.tsx
@@ -325,7 +325,7 @@ const AgentGitScmStaticCards = memo(function AgentGitScmStaticCards({
 });
 
 /** 把改动路径按一级父目录分组，根目录归到 '' 组；返回顺序按目录字典序，根目录置顶 */
-function groupPathsByDir(paths: readonly string[]): Array<{ dir: string; paths: string[] }> {
+export function groupPathsByDir(paths: readonly string[]): Array<{ dir: string; paths: string[] }> {
 	const map = new Map<string, string[]>();
 	for (const rel of paths) {
 		const norm = rel.replace(/\\/g, '/');

--- a/src/GitScmVirtualLists.tsx
+++ b/src/GitScmVirtualLists.tsx
@@ -3,7 +3,7 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import { changeBadgeLabel, changeBadgeVariant } from './gitBadge';
 import { FileTypeIcon } from './fileTypeIcons';
 import type { TFunction } from './i18n';
-import { IconEye } from './icons';
+import { IconChevron, IconEye } from './icons';
 import type { GitPathStatusMap } from './WorkspaceExplorer';
 import {
 	agentFilePreviewPathToLang,
@@ -324,7 +324,33 @@ const AgentGitScmStaticCards = memo(function AgentGitScmStaticCards({
 	);
 });
 
-export const AgentGitScmChangedCards = memo(function AgentGitScmChangedCards({
+/** 把改动路径按一级父目录分组，根目录归到 '' 组；返回顺序按目录字典序，根目录置顶 */
+function groupPathsByDir(paths: readonly string[]): Array<{ dir: string; paths: string[] }> {
+	const map = new Map<string, string[]>();
+	for (const rel of paths) {
+		const norm = rel.replace(/\\/g, '/');
+		const idx = norm.lastIndexOf('/');
+		const dir = idx < 0 ? '' : norm.slice(0, idx);
+		const arr = map.get(dir);
+		if (arr) {
+			arr.push(rel);
+		} else {
+			map.set(dir, [rel]);
+		}
+	}
+	const dirs = Array.from(map.keys()).sort((a, b) => {
+		if (a === '') {
+			return -1;
+		}
+		if (b === '') {
+			return 1;
+		}
+		return a.localeCompare(b);
+	});
+	return dirs.map((dir) => ({ dir, paths: map.get(dir)! }));
+}
+
+const AgentGitScmGroupedCards = memo(function AgentGitScmGroupedCards({
 	paths,
 	diffPreviews,
 	gitPathStatus,
@@ -341,6 +367,116 @@ export const AgentGitScmChangedCards = memo(function AgentGitScmChangedCards({
 	onOpenGitDiff: (rel: string, diff: string | null) => void;
 	onEnsurePreviews?: (paths: readonly string[]) => void;
 }) {
+	const { expandedRel, toggleRel } = useAgentGitAccordion(paths);
+	const groups = useMemo(() => groupPathsByDir(paths), [paths]);
+	const [collapsedDirs, setCollapsedDirs] = useState<Set<string>>(() => new Set());
+	useEffect(() => {
+		setCollapsedDirs((cur) => {
+			const validDirs = new Set(groups.map((g) => g.dir));
+			let changed = false;
+			const next = new Set<string>();
+			for (const d of cur) {
+				if (validDirs.has(d)) {
+					next.add(d);
+				} else {
+					changed = true;
+				}
+			}
+			return changed ? next : cur;
+		});
+	}, [groups]);
+	const toggleDir = useCallback((dir: string) => {
+		setCollapsedDirs((cur) => {
+			const next = new Set(cur);
+			if (next.has(dir)) {
+				next.delete(dir);
+			} else {
+				next.add(dir);
+			}
+			return next;
+		});
+	}, []);
+
+	return (
+		<div className="ref-git-changed-scroll">
+			<div className="ref-git-groups">
+				{groups.map(({ dir, paths: groupPaths }) => {
+					const collapsed = collapsedDirs.has(dir);
+					const label = dir === '' ? t('app.gitGroupRoot') : dir;
+					return (
+						<section key={dir || '__root__'} className="ref-git-group">
+							<button
+								type="button"
+								className={`ref-git-group-head ${collapsed ? 'is-collapsed' : ''}`}
+								onClick={() => toggleDir(dir)}
+								aria-expanded={!collapsed}
+							>
+								<IconChevron className="ref-git-group-chev" />
+								<span className="ref-git-group-name" title={label}>
+									{label}
+								</span>
+								<span className="ref-git-group-count">{groupPaths.length}</span>
+							</button>
+							<div className={`ref-git-group-body ${collapsed ? 'is-collapsed' : ''}`} aria-hidden={collapsed}>
+								<div className="ref-git-group-body-inner">
+									<div className="ref-git-cards ref-git-cards--grouped">
+										{groupPaths.map((rel) => (
+											<AgentGitChangeCard
+												key={rel}
+												rel={rel}
+												pr={diffPreviews[rel]}
+												st={gitPathStatus[rel]}
+												diffLoading={diffLoading}
+												t={t}
+												onOpenGitDiff={onOpenGitDiff}
+												onEnsurePreview={onEnsurePreviews ? (r) => onEnsurePreviews([r]) : undefined}
+												diffOpen={!collapsed && expandedRel === rel}
+												onToggleDiffOpen={() => toggleRel(rel)}
+											/>
+										))}
+									</div>
+								</div>
+							</div>
+						</section>
+					);
+				})}
+			</div>
+		</div>
+	);
+});
+
+export const AgentGitScmChangedCards = memo(function AgentGitScmChangedCards({
+	paths,
+	diffPreviews,
+	gitPathStatus,
+	diffLoading,
+	t,
+	onOpenGitDiff,
+	onEnsurePreviews,
+	grouped,
+}: {
+	paths: string[];
+	diffPreviews: Record<string, DiffPreview>;
+	gitPathStatus: GitPathStatusMap;
+	diffLoading: boolean;
+	t: TFunction;
+	onOpenGitDiff: (rel: string, diff: string | null) => void;
+	onEnsurePreviews?: (paths: readonly string[]) => void;
+	grouped?: boolean;
+}) {
+	if (grouped) {
+		return (
+			<AgentGitScmGroupedCards
+				paths={paths}
+				diffPreviews={diffPreviews}
+				gitPathStatus={gitPathStatus}
+				diffLoading={diffLoading}
+				t={t}
+				onOpenGitDiff={onOpenGitDiff}
+				onEnsurePreviews={onEnsurePreviews}
+			/>
+		);
+	}
 	if (paths.length >= AGENT_GIT_SCM_VIRTUAL_THRESHOLD) {
 		return (
 			<AgentGitScmVirtualCards

--- a/src/app/agentSidebarWorkspaceList.test.ts
+++ b/src/app/agentSidebarWorkspaceList.test.ts
@@ -41,7 +41,7 @@ describe('selectAgentSidebarThreadPaths', () => {
 		).toHaveLength(12);
 	});
 
-	it('ignores stale hidden state so conversation workspaces remain visible', () => {
+	it('filters out hidden workspaces so removed entries do not reappear', () => {
 		expect(
 			selectAgentSidebarThreadPaths({
 				orderedPaths: ['D:/work/A', 'D:/work/B'],
@@ -49,6 +49,6 @@ describe('selectAgentSidebarThreadPaths', () => {
 				currentWorkspace: null,
 				limit: 8,
 			})
-		).toEqual(['D:/work/A', 'D:/work/B']);
+		).toEqual(['D:/work/A']);
 	});
 });

--- a/src/app/agentSidebarWorkspaceList.ts
+++ b/src/app/agentSidebarWorkspaceList.ts
@@ -21,7 +21,14 @@ export function selectAgentSidebarThreadPaths(params: {
 	limit?: number;
 }): string[] {
 	const currentKey = params.currentWorkspace ? normWorkspaceRootKey(params.currentWorkspace) : null;
-	const visible = uniqueByWorkspaceKey(params.orderedPaths);
+	const hiddenKeys = new Set<string>();
+	for (const path of params.hiddenPaths) {
+		const key = normWorkspaceRootKey(path);
+		if (key) hiddenKeys.add(key);
+	}
+	const visible = uniqueByWorkspaceKey(params.orderedPaths).filter(
+		(path) => !hiddenKeys.has(normWorkspaceRootKey(path))
+	);
 	if (params.limit == null) {
 		return visible;
 	}

--- a/src/hooks/useWorkspaceManager.ts
+++ b/src/hooks/useWorkspaceManager.ts
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useRef, useState, type MutableRefObject } from 'react';
-import { normWorkspaceRootKey } from '../workspaceRootKey';
 
 type Shell = NonNullable<Window['asyncShell']>;
 
@@ -155,15 +154,6 @@ export function useWorkspaceManager(shell: Shell | undefined) {
 			cancelled = true;
 		};
 	}, [shell, workspace]);
-
-	// 兼容旧数据：当前工作区不能因为历史 hidden 标记从 Agent 全局侧栏消失。
-	useEffect(() => {
-		if (!workspace) return;
-		const workspaceKey = normWorkspaceRootKey(workspace);
-		setHiddenAgentWorkspacePaths((prev) =>
-			prev.filter((item) => normWorkspaceRootKey(item) !== workspaceKey)
-		);
-	}, [workspace]);
 
 	// ── TS LSP ────────────────────────────────────────────────────────────────
 	// 不在渲染进程自动启动 LSP。关闭工作区时通知主进程释放 WorkspaceLspManager。

--- a/src/i18n/messages.en.ts
+++ b/src/i18n/messages.en.ts
@@ -894,6 +894,10 @@ export const messagesEn: Record<string, string> = {
 	'git.badge.renamed': 'Renamed',
 	'git.badge.ignored': 'Ignored',
 	'git.diffPreview': 'Diff preview',
+	'app.gitGroupToggleAria': 'Toggle folder grouping',
+	'app.gitGroupOnTitle': 'Group by folder (on)',
+	'app.gitGroupOffTitle': 'Group by folder (off)',
+	'app.gitGroupRoot': '(root)',
 
 	'settings.dialogAria': 'Settings',
 	'settings.searchAria': 'Search',

--- a/src/i18n/messages.zh-CN.ts
+++ b/src/i18n/messages.zh-CN.ts
@@ -877,6 +877,10 @@ export const messagesZhCN: Record<string, string> = {
 	'git.badge.renamed': '已重命名',
 	'git.badge.ignored': '已忽略',
 	'git.diffPreview': '差异预览',
+	'app.gitGroupToggleAria': '切换文件夹分组',
+	'app.gitGroupOnTitle': '按文件夹分组（开）',
+	'app.gitGroupOffTitle': '按文件夹分组（关）',
+	'app.gitGroupRoot': '(根目录)',
 
 	// settings
 	'settings.dialogAria': '设置',

--- a/src/index.css
+++ b/src/index.css
@@ -12025,6 +12025,118 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 	overflow: hidden;
 }
 
+.ref-app-error-boundary {
+	position: fixed;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 24px;
+	background: var(--void-bg-1, #1a1a1a);
+	color: var(--void-fg-0, #e8e8e8);
+	font-family: 'Inter', system-ui, sans-serif;
+	z-index: 9999;
+	overflow: auto;
+}
+
+.ref-app-error-boundary-card {
+	max-width: 560px;
+	width: 100%;
+	background: var(--void-bg-0, #222);
+	border: 1px solid var(--void-border, rgba(255, 255, 255, 0.08));
+	border-radius: 12px;
+	padding: 28px;
+	box-shadow: 0 8px 32px rgba(0, 0, 0, 0.32);
+}
+
+.ref-app-error-boundary-title {
+	font-size: 18px;
+	font-weight: 600;
+	margin: 0 0 12px;
+}
+
+.ref-app-error-boundary-msg {
+	font-size: 13px;
+	line-height: 1.55;
+	color: var(--void-fg-2, #b8b8b8);
+	margin: 0 0 18px;
+}
+
+.ref-app-error-boundary-msg code {
+	font-family: ui-monospace, monospace;
+	font-size: 12px;
+	background: var(--void-bg-2, rgba(255, 255, 255, 0.06));
+	padding: 1px 5px;
+	border-radius: 4px;
+}
+
+.ref-app-error-boundary-actions {
+	display: flex;
+	gap: 8px;
+	margin-bottom: 18px;
+}
+
+.ref-app-error-boundary-btn {
+	font-size: 13px;
+	font-weight: 500;
+	padding: 8px 16px;
+	border-radius: 8px;
+	border: 1px solid var(--void-border, rgba(255, 255, 255, 0.12));
+	background: var(--void-bg-2, rgba(255, 255, 255, 0.06));
+	color: var(--void-fg-0, #e8e8e8);
+	cursor: pointer;
+}
+
+.ref-app-error-boundary-btn:hover {
+	background: var(--void-bg-3, rgba(255, 255, 255, 0.1));
+}
+
+.ref-app-error-boundary-btn:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+
+.ref-app-error-boundary-status {
+	font-size: 12px;
+	margin: 0 0 14px;
+	padding: 8px 12px;
+	border-radius: 6px;
+	background: var(--void-bg-2, rgba(255, 255, 255, 0.04));
+}
+
+.ref-app-error-boundary-status.is-error {
+	color: #f0ab8c;
+}
+
+.ref-app-error-boundary-status.is-ok {
+	color: var(--void-fg-1, #d0d0d0);
+}
+
+.ref-app-error-boundary-details {
+	font-size: 12px;
+	color: var(--void-fg-3, #888);
+}
+
+.ref-app-error-boundary-details summary {
+	cursor: pointer;
+	user-select: none;
+	padding: 4px 0;
+}
+
+.ref-app-error-boundary-pre {
+	margin: 8px 0 0;
+	padding: 12px;
+	border-radius: 8px;
+	background: var(--void-bg-2, rgba(255, 255, 255, 0.04));
+	max-height: 280px;
+	overflow: auto;
+	font-family: ui-monospace, monospace;
+	font-size: 11px;
+	line-height: 1.5;
+	white-space: pre-wrap;
+	word-break: break-word;
+}
+
 @media (prefers-reduced-motion: reduce) {
 	.ref-git-group-body {
 		transition: none;

--- a/src/index.css
+++ b/src/index.css
@@ -11961,6 +11961,96 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 	gap: 10px;
 }
 
+.ref-git-cards--grouped {
+	gap: 8px;
+	padding-left: 12px;
+}
+
+.ref-git-groups {
+	display: flex;
+	flex-direction: column;
+	gap: 14px;
+}
+
+.ref-git-group {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.ref-git-group-head {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 4px 6px;
+	border: none;
+	background: transparent;
+	color: var(--void-fg-2);
+	font-size: 13px;
+	font-weight: 500;
+	cursor: pointer;
+	text-align: left;
+	border-radius: 6px;
+}
+
+.ref-git-group-head:hover {
+	background: var(--void-bg-2);
+	color: var(--void-fg-0);
+}
+
+.ref-git-group-chev {
+	flex-shrink: 0;
+	transition: transform 120ms ease;
+}
+
+.ref-git-group-head.is-collapsed .ref-git-group-chev {
+	transform: rotate(-90deg);
+}
+
+.ref-git-group-body {
+	display: grid;
+	grid-template-rows: 1fr;
+	transition: grid-template-rows 200ms ease, opacity 180ms ease;
+	opacity: 1;
+}
+
+.ref-git-group-body.is-collapsed {
+	grid-template-rows: 0fr;
+	opacity: 0;
+	pointer-events: none;
+}
+
+.ref-git-group-body-inner {
+	min-height: 0;
+	overflow: hidden;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.ref-git-group-body {
+		transition: none;
+	}
+	.ref-git-group-chev {
+		transition: none;
+	}
+}
+
+.ref-git-group-name {
+	flex: 1 1 auto;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.ref-git-group-count {
+	flex-shrink: 0;
+	font-size: 11px;
+	color: var(--void-fg-3);
+	background: var(--void-bg-2);
+	padding: 1px 7px;
+	border-radius: var(--void-pill);
+}
+
 .ref-git-card {
 	border-radius: 12px;
 	border: 1px solid var(--void-border-soft);

--- a/src/index.css
+++ b/src/index.css
@@ -1717,10 +1717,19 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 }
 
 .ref-agent-workspace-row-shell:hover::before,
-.ref-agent-workspace-group.is-menu-open .ref-agent-workspace-row-shell::before,
+.ref-agent-workspace-group.is-menu-open .ref-agent-workspace-row-shell::before {
+	opacity: 1;
+	background: color-mix(in srgb, var(--void-fg-2) 8%, transparent);
+}
+
 .ref-agent-workspace-row-shell.is-active::before {
 	opacity: 1;
-	background: var(--void-bg-2);
+	background: color-mix(in srgb, var(--void-ring) 10%, transparent);
+	box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--void-ring) 22%, transparent);
+}
+
+.ref-agent-workspace-row-shell.is-active:hover::before {
+	background: color-mix(in srgb, var(--void-ring) 13%, transparent);
 }
 
 .ref-agent-workspace-row {
@@ -2651,11 +2660,16 @@ html[data-theme-switching='true'] .ref-editor-welcome-panel {
 }
 
 .ref-agent-thread-item:hover {
-	background: var(--void-bg-2);
+	background: color-mix(in srgb, var(--void-fg-2) 8%, transparent);
 }
 
 .ref-agent-thread-item.is-active {
-	background: color-mix(in srgb, var(--void-bg-3) 86%, transparent);
+	background: color-mix(in srgb, var(--void-ring) 12%, transparent);
+	box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--void-ring) 22%, transparent);
+}
+
+.ref-agent-thread-item.is-active:hover {
+	background: color-mix(in srgb, var(--void-ring) 16%, transparent);
 }
 
 .ref-agent-thread-item.is-awaiting-reply {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
+import { AppErrorBoundary } from './AppErrorBoundary';
 import { applyAppearanceSettingsToDom } from './appearanceSettings';
 import { APP_UI_STYLE, readPrefersDark, readStoredColorMode, resolveEffectiveScheme } from './colorMode';
 import { readInitialWindowThemeSnapshot } from './initialWindowTheme';
@@ -75,14 +76,16 @@ const terminalStartPage = readTerminalStartPageFlagFromUrl();
 
 createRoot(document.getElementById('root')!).render(
 	<StrictMode>
-		<I18nProvider>
-			<App
-				appSurface={appSurface}
-				browserWindow={browserWindow}
-				initialThemeSnapshot={initialThemeSnapshot}
-				terminalWindow={terminalWindow}
-				terminalStartPage={terminalStartPage}
-			/>
-		</I18nProvider>
+		<AppErrorBoundary>
+			<I18nProvider>
+				<App
+					appSurface={appSurface}
+					browserWindow={browserWindow}
+					initialThemeSnapshot={initialThemeSnapshot}
+					terminalWindow={terminalWindow}
+					terminalStartPage={terminalStartPage}
+				/>
+			</I18nProvider>
+		</AppErrorBoundary>
 	</StrictMode>
 );

--- a/src/styles/mac-codex.css
+++ b/src/styles/mac-codex.css
@@ -3324,6 +3324,21 @@
 	box-shadow: inset 0 1px 0 color-mix(in srgb, var(--color-text-primary) 4%, transparent);
 }
 
+:root[data-ui-style='mac-codex'] .ref-left--agent-layout .ref-agent-workspace-row-shell:hover::before,
+:root[data-ui-style='mac-codex'] .ref-left--agent-layout .ref-agent-workspace-group.is-menu-open .ref-agent-workspace-row-shell::before {
+	background: color-mix(in srgb, var(--color-text-tertiary) 10%, transparent);
+	box-shadow: none;
+}
+
+:root[data-ui-style='mac-codex'] .ref-left--agent-layout .ref-agent-workspace-row-shell.is-active::before {
+	background: color-mix(in srgb, var(--color-accent) 11%, transparent);
+	box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-accent) 22%, transparent);
+}
+
+:root[data-ui-style='mac-codex'] .ref-left--agent-layout .ref-agent-workspace-row-shell.is-active:hover::before {
+	background: color-mix(in srgb, var(--color-accent) 14%, transparent);
+}
+
 :root[data-ui-style='mac-codex'] .ref-left--agent-layout .ref-agent-workspace-row {
 	padding: 6px 8px 6px 6px;
 	border-radius: 9px;
@@ -3447,12 +3462,17 @@
 }
 
 :root[data-ui-style='mac-codex'] .ref-left--agent-layout .ref-agent-thread-item:hover {
-	background: color-mix(in srgb, var(--surface-panel-bg-soft) 78%, transparent);
+	background: color-mix(in srgb, var(--color-text-tertiary) 10%, transparent);
+	box-shadow: none;
 }
 
 :root[data-ui-style='mac-codex'] .ref-left--agent-layout .ref-agent-thread-item.is-active {
-	background: color-mix(in srgb, var(--surface-panel-bg-soft) 92%, var(--surface-tint-soft));
-	box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-accent) 16%, transparent);
+	background: color-mix(in srgb, var(--color-accent) 12%, transparent);
+	box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-accent) 24%, transparent);
+}
+
+:root[data-ui-style='mac-codex'] .ref-left--agent-layout .ref-agent-thread-item.is-active:hover {
+	background: color-mix(in srgb, var(--color-accent) 16%, transparent);
 }
 
 :root[data-ui-style='mac-codex'] .ref-left--agent-layout .ref-agent-thread-item.is-awaiting-reply {

--- a/src/styles/terminal-window.css
+++ b/src/styles/terminal-window.css
@@ -34,8 +34,8 @@
 	flex: 0 0 var(--ref-uterm-titlebar-height);
 	min-height: var(--ref-uterm-titlebar-height);
 	padding: 0 10px 0 8px;
-	border-bottom: 1px solid color-mix(in srgb, var(--void-border) 72%, transparent);
-	background: color-mix(in srgb, var(--void-bg-0) 92%, transparent);
+	border-bottom: 1px solid transparent;
+	background: var(--ref-menubar-chrome-bg, var(--void-bg-0));
 	user-select: none;
 }
 


### PR DESCRIPTION
## Overview
This PR hardens workspace startup recovery and improves the Agent-side Git/SCM experience. It makes corrupted workspace agent storage safer to read, adds an application-level fallback for startup failures, and keeps hidden or grouped workspace/file-list behavior consistent across sessions.

## Changes
- Validate and normalize workspace agent project data before merging it into runtime state.
- Quarantine invalid `.async/agent.json` files instead of repeatedly failing on startup.
- Add an IPC recovery path that backs up and resets the current workspace `.async/` directory.
- Add an application error boundary with reload and `.async/` backup/reset recovery actions.
- Add persisted folder grouping for Agent Git changed files, including collapsible directory groups and root-level handling.
- Respect hidden workspace entries in the Agent sidebar workspace selector.
- Refresh related styling and localization for the SCM grouping and recovery UI.
- Add tests for workspace agent storage normalization/quarantine behavior and SCM path grouping.

## Verification
- `npm test -- main-src/workspaceAgentStore.test.ts src/GitScmVirtualLists.test.ts src/app/agentSidebarWorkspaceList.test.ts`
- `npm run typecheck`