### PR TITLE
Fix chat scroll and WebSearch proxy support

### DIFF
--- a/main-src/agent/toolExecutor.ts
+++ b/main-src/agent/toolExecutor.ts
@@ -10,8 +10,9 @@ import * as http from 'node:http';
 import * as https from 'node:https';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 import { getThread } from '../threadStore.js';
-import { pathToFileURL, fileURLToPath } from 'node:url';
+import { pathToFileURL, fileURLToPath, URL } from 'node:url';
 import { resolveWorkspacePath, isPathInsideRoot } from '../workspace.js';
 import { formatSymbolSearchResults, searchWorkspaceSymbols, ensureSymbolIndexLoaded } from '../workspaceSymbolIndex.js';
 import type { ToolCall, ToolResult } from './agentTools.js';
@@ -816,12 +817,179 @@ function parseDuckDuckGoHtml(html: string): Array<{ title: string; url: string; 
 	return results.slice(0, 8);
 }
 
-function performWebSearch(
+const WEB_SEARCH_TIMEOUT_MS = 15_000;
+
+type WindowsProxySettings = {
+	enabled: boolean;
+	server: string;
+	override: string;
+};
+
+function getEnvValue(names: string[]): string | undefined {
+	for (const name of names) {
+		const value = process.env[name];
+		if (value?.trim()) {
+			return value.trim();
+		}
+	}
+	return undefined;
+}
+
+function normalizeProxyUrl(rawProxy: string): string | null {
+	const value = rawProxy.trim().replace(/^"|"$/g, '');
+	if (!value || /^direct$/i.test(value)) {
+		return null;
+	}
+	const withScheme = /^[a-z][a-z\d+.-]*:\/\//i.test(value) ? value : `http://${value}`;
+	try {
+		const parsed = new URL(withScheme);
+		if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:' || !parsed.hostname) {
+			return null;
+		}
+		return parsed.toString();
+	} catch {
+		return null;
+	}
+}
+
+function wildcardToRegex(pattern: string): RegExp {
+	const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+	return new RegExp(`^${escaped}$`, 'i');
+}
+
+function shouldBypassProxy(hostname: string, rules: string | undefined): boolean {
+	if (!rules?.trim()) {
+		return false;
+	}
+	const host = hostname.toLowerCase();
+	for (const rawRule of rules.split(/[;,]/)) {
+		const rule = rawRule.trim().toLowerCase();
+		if (!rule) {
+			continue;
+		}
+		if (rule === '*') {
+			return true;
+		}
+		if (rule === '<local>' && !host.includes('.')) {
+			return true;
+		}
+		const hostRule = rule.replace(/:\d+$/, '');
+		if (hostRule.startsWith('*.')) {
+			const suffix = hostRule.slice(1);
+			if (host.endsWith(suffix) || host === suffix.slice(1)) {
+				return true;
+			}
+			continue;
+		}
+		if (hostRule.startsWith('.')) {
+			if (host.endsWith(hostRule) || host === hostRule.slice(1)) {
+				return true;
+			}
+			continue;
+		}
+		if (hostRule.includes('*')) {
+			if (wildcardToRegex(hostRule).test(host)) {
+				return true;
+			}
+			continue;
+		}
+		if (host === hostRule) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function parseWindowsProxyServer(proxyServer: string, targetProtocol: string): string | null {
+	const entries = proxyServer.split(';').map((entry) => entry.trim()).filter(Boolean);
+	const perProtocol = new Map<string, string>();
+	for (const entry of entries) {
+		const separatorIndex = entry.indexOf('=');
+		if (separatorIndex > 0) {
+			perProtocol.set(entry.slice(0, separatorIndex).trim().toLowerCase(), entry.slice(separatorIndex + 1).trim());
+		}
+	}
+	if (perProtocol.size > 0) {
+		const preferred = perProtocol.get(targetProtocol) ?? perProtocol.get('http') ?? perProtocol.get('https');
+		return preferred ? normalizeProxyUrl(preferred) : null;
+	}
+	return normalizeProxyUrl(proxyServer);
+}
+
+async function readWindowsProxySettings(): Promise<WindowsProxySettings | null> {
+	if (process.platform !== 'win32') {
+		return null;
+	}
+	try {
+		const { stdout } = await execFileAsync('reg', [
+			'query',
+			'HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+			'/v',
+			'ProxyEnable',
+		]);
+		const { stdout: serverStdout } = await execFileAsync('reg', [
+			'query',
+			'HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+			'/v',
+			'ProxyServer',
+		]);
+		const { stdout: overrideStdout } = await execFileAsync('reg', [
+			'query',
+			'HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+			'/v',
+			'ProxyOverride',
+		]).catch(() => ({ stdout: '' }));
+		const parseRegistryValue = (output: string | Buffer): string => {
+			const line = String(output).split(/\r?\n/).find((candidate) => /\s+REG_\w+\s+/i.test(candidate));
+			return line?.replace(/^.*?\s+REG_\w+\s+/i, '').trim() ?? '';
+		};
+		const enabledRaw = parseRegistryValue(stdout);
+		const enabled = Number.parseInt(enabledRaw, enabledRaw.toLowerCase().startsWith('0x') ? 16 : 10) !== 0;
+		return {
+			enabled,
+			server: parseRegistryValue(serverStdout),
+			override: parseRegistryValue(overrideStdout),
+		};
+	} catch {
+		return null;
+	}
+}
+
+async function getProxyUrlForRequest(targetUrl: URL): Promise<string | null> {
+	const envBypass = getEnvValue(['NO_PROXY', 'no_proxy']);
+	if (shouldBypassProxy(targetUrl.hostname, envBypass)) {
+		return null;
+	}
+	const envProxyNames =
+		targetUrl.protocol === 'https:'
+			? ['HTTPS_PROXY', 'https_proxy', 'ALL_PROXY', 'all_proxy', 'HTTP_PROXY', 'http_proxy']
+			: ['HTTP_PROXY', 'http_proxy', 'ALL_PROXY', 'all_proxy'];
+	const envProxy = getEnvValue(envProxyNames);
+	const normalizedEnvProxy = envProxy ? normalizeProxyUrl(envProxy) : null;
+	if (normalizedEnvProxy) {
+		return normalizedEnvProxy;
+	}
+
+	const windowsProxy = await readWindowsProxySettings();
+	if (!windowsProxy?.enabled || !windowsProxy.server) {
+		return null;
+	}
+	if (shouldBypassProxy(targetUrl.hostname, windowsProxy.override)) {
+		return null;
+	}
+	return parseWindowsProxyServer(windowsProxy.server, targetUrl.protocol.replace(':', ''));
+}
+
+async function performWebSearch(
 	query: string,
 	signal?: AbortSignal
 ): Promise<Array<{ title: string; url: string; snippet: string }>> {
+	const url = new URL(`https://html.duckduckgo.com/html/?q=${encodeURIComponent(query)}`);
+	const proxyUrl = await getProxyUrlForRequest(url);
+	if (signal?.aborted) {
+		throw new DOMException('Aborted', 'AbortError');
+	}
 	return new Promise((resolve, reject) => {
-		const url = `https://html.duckduckgo.com/html/?q=${encodeURIComponent(query)}`;
 		const req = https.get(
 			url,
 			{
@@ -831,7 +999,8 @@ function performWebSearch(
 					Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
 					'Accept-Language': 'en-US,en;q=0.9',
 				},
-				timeout: 15_000,
+				agent: proxyUrl ? new HttpsProxyAgent(proxyUrl) : undefined,
+				timeout: WEB_SEARCH_TIMEOUT_MS,
 			},
 			(res) => {
 				if (signal?.aborted) {
@@ -861,7 +1030,7 @@ function performWebSearch(
 		req.on('error', (err) => reject(err));
 		req.on('timeout', () => {
 			req.destroy();
-			reject(new Error('Search request timed out after 15s'));
+			reject(new Error(`Search request timed out after ${WEB_SEARCH_TIMEOUT_MS / 1000}s`));
 		});
 		signal?.addEventListener('abort', () => {
 			req.destroy();

--- a/src/AgentChatPanel.tsx
+++ b/src/AgentChatPanel.tsx
@@ -238,6 +238,7 @@ type ChatRenderRow = TurnFocusRow & {
 	content: ReactNode;
 	dataMsgIndex?: number;
 	dataPreflightFor?: number;
+	dataContentBottom?: boolean;
 };
 
 export const AgentChatPanel = memo(function AgentChatPanel({
@@ -1544,6 +1545,7 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 			isTurnStart: false,
 			stickyUserIndex: null,
 			className: 'ref-msg-row-measure ref-msg-row-measure--team-leader',
+			dataContentBottom: true,
 			content: (
 				<div className="ref-msg-slot ref-msg-slot--assistant">
 					<div className="ref-msg-assistant-body">
@@ -1582,6 +1584,7 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 			isTurnStart: false,
 			stickyUserIndex: null,
 			className: 'ref-msg-row-measure ref-msg-row-measure--team-leader',
+			dataContentBottom: true,
 			content: (
 				<div className="ref-msg-slot ref-msg-slot--assistant">
 					<div className="ref-msg-assistant-body">
@@ -1626,6 +1629,7 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 			isTurnStart: false,
 			stickyUserIndex: null,
 			className: 'ref-msg-row-measure ref-msg-row-measure--team-item',
+			dataContentBottom: true,
 			content: (
 				<div className="ref-msg-slot ref-msg-slot--assistant ref-msg-slot--team-item">
 					<button
@@ -1681,6 +1685,7 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 						isTurnStart: false,
 						stickyUserIndex: null,
 						className: 'ref-msg-row-measure ref-msg-row-measure--team-plan',
+						dataContentBottom: true,
 						content: (
 							<div className="ref-msg-slot ref-msg-slot--assistant ref-msg-slot--team-plan">
 								<TeamPlanReviewPanel
@@ -1706,6 +1711,7 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 						isTurnStart: false,
 						stickyUserIndex: null,
 						className: 'ref-msg-row-measure ref-msg-row-measure--team-plan',
+						dataContentBottom: true,
 						content: (
 							<div className="ref-msg-slot ref-msg-slot--assistant ref-msg-slot--team-plan">
 								<TeamPlanRevisionCard
@@ -1807,6 +1813,7 @@ export const AgentChatPanel = memo(function AgentChatPanel({
 				data-preflight-for={
 					row.dataPreflightFor != null ? String(row.dataPreflightFor) : undefined
 				}
+				data-content-bottom={row.dataContentBottom ? 'true' : undefined}
 				data-turn-owner={
 					row.turnOwnerUserIndex != null ? String(row.turnOwnerUserIndex) : undefined
 				}

--- a/src/hooks/useMessagesScroll.test.ts
+++ b/src/hooks/useMessagesScroll.test.ts
@@ -7,6 +7,28 @@ import {
 	resolveContentBottomScroll,
 } from './useMessagesScroll';
 
+function fakeTrackWithDataRows(
+	rows: Array<{
+		dataset: Record<string, string | undefined>;
+		rect: Partial<DOMRect>;
+	}>
+): HTMLElement {
+	return {
+		querySelectorAll: (selector: string) =>
+			rows
+				.filter(
+					(row) =>
+						(selector.includes('[data-msg-index]') && row.dataset.msgIndex != null) ||
+						(selector.includes('[data-preflight-for]') && row.dataset.preflightFor != null) ||
+						(selector.includes('[data-content-bottom]') && row.dataset.contentBottom != null)
+				)
+				.map((row) => ({
+					dataset: row.dataset,
+					getBoundingClientRect: () => row.rect as DOMRect,
+				})) as unknown as NodeListOf<HTMLElement>,
+	} as unknown as HTMLElement;
+}
+
 describe('useMessagesScroll helpers', () => {
 	it('keeps follow-bottom intent during layout growth when the user was already pinned', () => {
 		expect(
@@ -82,6 +104,34 @@ describe('useMessagesScroll helpers', () => {
 					{ getBoundingClientRect: () => ({ bottom: 940 } as DOMRect) },
 				] as unknown as NodeListOf<HTMLElement>,
 		} as unknown as HTMLElement;
+
+		expect(resolveContentBottomScroll(viewport, track)).toBe(656);
+	});
+
+	it('includes team supplemental rows when resolving the bottom scroll target', () => {
+		const viewport = {
+			scrollHeight: 2000,
+			clientHeight: 400,
+			scrollTop: 120,
+			ownerDocument: {
+				defaultView: {
+					getComputedStyle: () => ({
+						paddingBottom: '96px',
+					}),
+				},
+			},
+			getBoundingClientRect: () => ({ top: 100 } as DOMRect),
+		} as unknown as HTMLElement;
+		const track = fakeTrackWithDataRows([
+			{
+				dataset: { msgIndex: '1' },
+				rect: { bottom: 360, height: 80 },
+			},
+			{
+				dataset: { contentBottom: 'true' },
+				rect: { bottom: 940, height: 160 },
+			},
+		]);
 
 		expect(resolveContentBottomScroll(viewport, track)).toBe(656);
 	});

--- a/src/hooks/useMessagesScroll.ts
+++ b/src/hooks/useMessagesScroll.ts
@@ -53,7 +53,7 @@ export type UseMessagesScrollResult = {
 	syncMessagesScrollIndicators: () => void;
 };
 
-/** 计算滚动位置时，以「最后一条内容行（带 data-msg-index）的底部」为准，
+/** 计算滚动位置时，以「最后一条内容行（普通消息 / preflight / team 补充行）的底部」为准，
  *  而不是 track 的 scrollHeight 底部。这样 turn 容器 padding、tail spacer 等
  *  纯装饰性高度不会把视口顶下去；同时保留 messages viewport 自己的
  *  padding-bottom，让最后一条消息与底部输入区之间仍有安全呼吸感。 */
@@ -77,16 +77,20 @@ export function resolveContentBottomScroll(
 	if (!track) {
 		return Math.max(0, viewport.scrollHeight - viewport.clientHeight - bottomInset);
 	}
-	const messageRows = track.querySelectorAll<HTMLElement>(
-		'.ref-msg-row-measure[data-msg-index], .ref-msg-row-measure[data-preflight-for]'
+	const contentBottomRows = track.querySelectorAll<HTMLElement>(
+		[
+			'.ref-msg-row-measure[data-msg-index]',
+			'.ref-msg-row-measure[data-preflight-for]',
+			'.ref-msg-row-measure[data-content-bottom]',
+		].join(', ')
 	);
-	if (messageRows.length === 0) {
+	if (contentBottomRows.length === 0) {
 		return Math.max(0, viewport.scrollHeight - viewport.clientHeight - bottomInset);
 	}
 	const viewportRect = viewport.getBoundingClientRect();
 	let maxBottomInViewport = -Infinity;
 	let activePreflightTopInTrack: number | null = null;
-	for (const row of Array.from(messageRows)) {
+	for (const row of Array.from(contentBottomRows)) {
 		const rect = row.getBoundingClientRect();
 		const bottomInViewport = rect.bottom - viewportRect.top;
 		if (bottomInViewport > maxBottomInViewport) {


### PR DESCRIPTION
## Summary
- Include team supplemental rows when resolving chat content-bottom scroll targets, so generated team-plan/status rows don't leave the viewport anchored too high.
- Mark team leader, team item, and team plan rows with `data-content-bottom` and add coverage for the new scroll target behavior.
- Add proxy support to `WebSearch`: environment proxy variables, `NO_PROXY`, and Windows system proxy settings are now honored before DuckDuckGo HTML requests.

## Verification
- `npm test -- src/hooks/useMessagesScroll.test.ts`
- `npm run typecheck`
- `npm run build:main`
- Manually verified DuckDuckGo HTML search through `127.0.0.1:7890` with `https-proxy-agent` returns HTTP 200.