### PR TITLE
feat(browser): Playwright bridge, humanized cursor/HUD, context-meter fix, sidebar reply state

### DIFF
--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -23,6 +23,7 @@ const INVOKE_CHANNELS = new Set([
 	'browser:windowReady',
 	'browser:openWindow',
 	'browser:clearData',
+	'browser:pwStatus',
 	'browserCapture:getState',
 	'browserCapture:start',
 	'browserCapture:stop',

--- a/esbuild.main.mjs
+++ b/esbuild.main.mjs
@@ -25,6 +25,9 @@ const ctx = await esbuild.context({
 		'chokidar',
 		'fsevents',
 		'better-sqlite3',
+		// Playwright 携带可选依赖（chromium-bidi 等）和动态 require，
+		// 不能 bundle，必须从 node_modules 在运行时加载。
+		'playwright-core',
 	],
 	sourcemap: true,
 	minify: !isWatch,

--- a/main-src/agent/agentTools.ts
+++ b/main-src/agent/agentTools.ts
@@ -567,6 +567,166 @@ export const AGENT_TOOLS: AgentToolDef[] = [
 		},
 	},
 	{
+		name: 'Playwright',
+		description:
+			'AI-driven browser automation against the app\'s built-in browser via Playwright over CDP. Use this for **frontend automation testing**: navigating, interacting with elements, asserting outcomes, and capturing evidence. Each interaction is animated with a humanized cursor overlay (eased motion, hover delays, click ripples) so the user can see what the AI is doing.\n\n**When to use:** the user explicitly asks to test/verify a frontend feature in the browser, validate a UI flow, or reproduce a bug visually. Do NOT use for plain code reading, refactoring, or unit-testing tasks.\n\n**Locating elements (preferred order):** `role`+`role_name` (most robust) → `test_id` → `label` → `placeholder` → `text` → `selector` (CSS, last resort). Pass exactly one. Use `nth` to pick among matches.\n\n**Typical test flow:** `navigate` → `wait_for` (page ready) → `snapshot` (read accessibility tree) → `click`/`fill`/`press_key` → `assert` (verify outcome) → `screenshot` (evidence).',
+		parameters: {
+			type: 'object',
+			properties: {
+				action: {
+					type: 'string',
+					enum: [
+						'status',
+						'navigate',
+						'click',
+						'hover',
+						'fill',
+						'press_key',
+						'scroll',
+						'wait_for',
+						'evaluate',
+						'snapshot',
+						'screenshot',
+						'assert',
+					],
+					description: 'Playwright action to perform.',
+				},
+				url: {
+					type: 'string',
+					description: 'For navigate: target URL (absolute, including protocol).',
+				},
+				wait_until: {
+					type: 'string',
+					enum: ['load', 'domcontentloaded', 'networkidle', 'commit'],
+					description: 'For navigate: when to consider navigation complete. Default load.',
+				},
+				role: {
+					type: 'string',
+					description:
+						'For element actions: ARIA role (button, link, textbox, checkbox, heading, etc). Most robust locator.',
+				},
+				role_name: {
+					type: 'string',
+					description: 'For element actions with role: accessible name to disambiguate. Often the visible label.',
+				},
+				role_exact: {
+					type: 'boolean',
+					description: 'For role+name: require exact name match instead of substring.',
+				},
+				text: {
+					type: 'string',
+					description: 'For element actions: locate by visible text content.',
+				},
+				text_exact: {
+					type: 'boolean',
+					description: 'For text locator: require exact match. Default false.',
+				},
+				label: {
+					type: 'string',
+					description: 'For element actions: locate form control by associated <label>.',
+				},
+				placeholder: {
+					type: 'string',
+					description: 'For element actions: locate input by placeholder text.',
+				},
+				test_id: {
+					type: 'string',
+					description: 'For element actions: locate by data-testid attribute.',
+				},
+				selector: {
+					type: 'string',
+					description: 'For element actions: CSS selector. Use only when accessible locators are insufficient.',
+				},
+				nth: {
+					type: 'number',
+					description: 'For element actions: 0-based index when the locator matches multiple elements.',
+				},
+				value: {
+					type: 'string',
+					description: 'For fill: text value to type into the located element.',
+				},
+				clear_first: {
+					type: 'boolean',
+					description: 'For fill: select-all + delete before typing. Default true.',
+				},
+				min_per_char_ms: {
+					type: 'number',
+					description: 'For fill: minimum delay between characters in ms. Default 60.',
+				},
+				max_per_char_ms: {
+					type: 'number',
+					description: 'For fill: maximum delay between characters in ms. Default 160.',
+				},
+				key: {
+					type: 'string',
+					description: 'For press_key: e.g. "Enter", "Escape", "Tab", "Control+A".',
+				},
+				delta_y: {
+					type: 'number',
+					description: 'For scroll: vertical pixels to scroll. Positive = down.',
+				},
+				step_px: {
+					type: 'number',
+					description: 'For scroll: pixels per wheel step. Default 120 (smoother = lower).',
+				},
+				step_delay_ms: {
+					type: 'number',
+					description: 'For scroll: delay between wheel steps. Default 30.',
+				},
+				state: {
+					type: 'string',
+					enum: ['attached', 'detached', 'visible', 'hidden'],
+					description: 'For wait_for: target visibility state. Default visible. Omit locator args to wait for page load instead.',
+				},
+				expression: {
+					type: 'string',
+					description:
+						'For evaluate: JavaScript body executed in the page (async). Return a JSON-serializable value. Wrapped in `(async () => { ... })()`.',
+				},
+				expect: {
+					type: 'string',
+					enum: ['visible', 'hidden', 'has_text', 'has_value', 'has_count', 'url_matches'],
+					description: 'For assert: which assertion to perform. Default visible.',
+				},
+				expected_text: {
+					type: 'string',
+					description: 'For assert with has_text/has_value/url_matches: expected substring or regex.',
+				},
+				expected_count: {
+					type: 'number',
+					description: 'For assert with has_count: required match count.',
+				},
+				full_page: {
+					type: 'boolean',
+					description: 'For screenshot: capture full scrollable page instead of viewport. Default false.',
+				},
+				file_path: {
+					type: 'string',
+					description:
+						'For screenshot: optional output path. If omitted, saves to `.async/pw-captures/` under the workspace.',
+				},
+				timeout_ms: {
+					type: 'number',
+					description: 'For wait_for/navigate/assert: per-operation timeout in ms.',
+				},
+				tab_id: {
+					type: 'string',
+					description: 'Optional: target a specific browser tab. Omit for the active tab.',
+				},
+				label_text: {
+					type: 'string',
+					description:
+						'Optional: short text shown next to the animated cursor while the action runs (e.g. "点击登录"). Helps the user follow what the AI is doing.',
+				},
+				max_chars: {
+					type: 'number',
+					description: 'For snapshot: maximum characters of accessibility tree to return. Default 8000.',
+				},
+			},
+			required: ['action'],
+		},
+	},
+	{
 		name: 'LSP',
 		description:
 			'Language-server intelligence for the workspace, routed by **file extension** to LSP servers declared in plugin dirs under `<asyncData>/plugins/<name>/` or `<workspace>/.async/plugins/<name>/` with **`.lsp.json`** or **`plugin.json` → `lspServers`** (each server: **command**, optional **args**, required **extensionToLanguage** map). Legacy **`lsp.servers`** in settings.json is still merged. TS/JS additionally works if **typescript-language-server** is discoverable under the app or workspace `node_modules` (optional).\n\nOperations: goToDefinition, findReferences, hover, documentSymbol, workspaceSymbol, goToImplementation, prepareCallHierarchy, incomingCalls, outgoingCalls, getDiagnostics. Use **filePath** plus 1-based **line**/**character** except **getDiagnostics**/**workspaceSymbol** (optional line/char).\n\nIf nothing matches the file extension, add a plugin or legacy server entry. If an LSP method fails, fall back to **Read** / **Grep** / **Bash**.',

--- a/main-src/agent/toolExecutor.ts
+++ b/main-src/agent/toolExecutor.ts
@@ -62,6 +62,7 @@ import {
 	startBrowserCaptureForHostId,
 	stopBrowserCaptureForHostId,
 } from '../browser/browserCapture.js';
+import { executePlaywrightTool } from '../browser/playwrightTool.js';
 import {
 	closeManagedAgent,
 	getManagedAgentSession,
@@ -1552,6 +1553,21 @@ export async function executeTool(
 			return await executeBrowserTool(call, execCtx);
 		case 'BrowserCapture':
 			return await executeBrowserCaptureTool(call, execCtx);
+		case 'Playwright': {
+			const hostId = execCtx.hostWebContentsId ?? null;
+			if (!hostId) {
+				return {
+					toolCallId: call.id,
+					name: call.name,
+					content: 'Playwright tool is unavailable because this run is not attached to an app window.',
+					isError: true,
+				};
+			}
+			return await executePlaywrightTool(call, {
+				hostId,
+				workspaceRoot: execCtx.workspaceRoot ?? null,
+			});
+		}
 		case 'WebSearch':
 			return await executeWebSearchTool(call, execCtx);
 		case 'Fetch':

--- a/main-src/browser/aiBrowserFlag.ts
+++ b/main-src/browser/aiBrowserFlag.ts
@@ -1,0 +1,53 @@
+/**
+ * AI 浏览器（Playwright over CDP）启动开关。
+ *
+ * Chromium 的 `--remote-debugging-port` 必须在 `app.whenReady` 前设置，所以
+ * 我们在每次启动时都默认开启 —— 端口选 `0` 让 OS 随机分配；启动后从
+ * `<userData>/DevToolsActivePort` 读取实际端口。该文件由 Chromium 在启用
+ * remote-debugging-port 时自动写入，第一行为端口号。
+ *
+ * 仅监听 127.0.0.1，避免外部网络访问。本机风险面与 IDE 已持有的源码访问权
+ * 同级，AI 工具调用时无需重启即可使用。
+ *
+ * 如需禁用（罕见场景，比如企业合规），设置环境变量 `ASYNC_AI_BROWSER=0`。
+ */
+
+import { app } from 'electron';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+export function isAiBrowserEnabledForThisLaunch(): boolean {
+	if (process.env.ASYNC_AI_BROWSER === '0' || process.env.VOID_AI_BROWSER === '0') {
+		return false;
+	}
+	return true;
+}
+
+/**
+ * 必须在 `app.whenReady` 之前调用。
+ */
+export function applyAiBrowserStartupSwitches(): boolean {
+	if (!isAiBrowserEnabledForThisLaunch()) {
+		return false;
+	}
+	app.commandLine.appendSwitch('remote-debugging-port', '0');
+	app.commandLine.appendSwitch('remote-allow-origins', 'http://127.0.0.1,http://localhost');
+	return true;
+}
+
+/**
+ * 读 `<userData>/DevToolsActivePort`，返回 Chromium 实际监听的端口。
+ * 文件首行是端口号，第二行是 browser target 的 ws path（不需要）。
+ */
+export function readDevToolsActivePort(): number | null {
+	try {
+		const p = path.join(app.getPath('userData'), 'DevToolsActivePort');
+		if (!existsSync(p)) return null;
+		const raw = readFileSync(p, 'utf8');
+		const firstLine = raw.split(/\r?\n/, 1)[0]?.trim();
+		const port = firstLine ? Number.parseInt(firstLine, 10) : NaN;
+		return Number.isFinite(port) && port > 0 ? port : null;
+	} catch {
+		return null;
+	}
+}

--- a/main-src/browser/humanCursor.ts
+++ b/main-src/browser/humanCursor.ts
@@ -1,0 +1,263 @@
+/**
+ * 注入到目标页面的"人形光标"overlay。
+ *
+ * 设计：
+ * - 一个固定定位的 SVG 鼠标指针（独立于真实系统光标），位于最高 z-index。
+ * - 暴露 `window.__asyncAiCursor` API：
+ *     `.show()` / `.hide()` —— 显隐光标
+ *     `.moveTo(x, y, durationMs?)` —— 缓动移动到目标点（视口坐标）
+ *     `.click(x, y)` —— 在目标点产生按压 + 涟漪效果
+ *     `.type()` —— 触发短暂的输入指示动画
+ *     `.label(text, ms)` —— 在光标旁短暂显示一行说明（如"点击登录按钮"）
+ * - 完全在页面侧绘制，不与真实输入设备冲突；Playwright 的真实点击/输入由 CDP 派发，
+ *   光标动画与之并行展示给用户看。
+ *
+ * 该函数返回一个 IIFE 字符串，既能作为 `addInitScript` 内容（每次导航重建 DOM 时重新注入），
+ * 也能用 `page.evaluate` 立即执行（首次激活时让光标立刻出现）。
+ */
+export function humanCursorInitScript(): string {
+	// 注：此字符串被原样注入到目标页面，不能引用主进程符号；
+	// 内部以 self-installing IIFE 形式编写，并具备幂等性。
+	return `
+(() => {
+	if (typeof window === 'undefined') return;
+	if (window.__asyncAiCursor && window.__asyncAiCursor.__installed) return;
+
+	const STATE = {
+		x: window.innerWidth / 2,
+		y: window.innerHeight / 2,
+		visible: false,
+		container: null,
+		cursor: null,
+		halo: null,
+		labelEl: null,
+		styleEl: null,
+		moveAnim: null,
+		labelTimer: null,
+	};
+
+	function ensureRoot() {
+		if (STATE.container && document.documentElement.contains(STATE.container)) {
+			return;
+		}
+		if (!document.documentElement) {
+			// DOMContentLoaded 之前先把节点缓存，等就绪再 append。
+			document.addEventListener('DOMContentLoaded', ensureRoot, { once: true });
+			return;
+		}
+
+		const style = document.createElement('style');
+		style.setAttribute('data-async-ai-cursor', '1');
+		style.textContent = [
+			'.async-ai-cursor-root{position:fixed;inset:0;pointer-events:none;z-index:2147483646;contain:layout style;}',
+			'.async-ai-cursor{position:absolute;width:28px;height:28px;transform:translate(-4px,-2px);transition:opacity .18s ease;will-change:transform;filter:drop-shadow(0 4px 8px rgba(0,0,0,.35));}',
+			'.async-ai-cursor[data-visible="0"]{opacity:0;}',
+			'.async-ai-cursor[data-visible="1"]{opacity:1;}',
+			'.async-ai-cursor[data-pressed="1"] svg{transform:scale(.86);}',
+			'.async-ai-cursor svg{transition:transform .12s cubic-bezier(.4,0,.2,1);width:100%;height:100%;display:block;}',
+			'.async-ai-cursor-halo{position:absolute;width:36px;height:36px;border-radius:50%;border:2px solid rgba(99,179,237,.85);transform:translate(-18px,-18px) scale(.6);opacity:0;pointer-events:none;}',
+			'@keyframes async-ai-ripple{0%{opacity:.85;transform:translate(-18px,-18px) scale(.4);}80%{opacity:.0;transform:translate(-18px,-18px) scale(2.2);}100%{opacity:0;}}',
+			'.async-ai-cursor-halo[data-active="1"]{animation:async-ai-ripple .55s cubic-bezier(.2,.7,.3,1) forwards;}',
+			'.async-ai-cursor-label{position:absolute;padding:4px 10px;border-radius:8px;font:600 12px/1.4 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,sans-serif;color:#fff;background:rgba(15,23,42,.92);white-space:nowrap;transform:translate(14px,4px);box-shadow:0 6px 18px rgba(0,0,0,.32);pointer-events:none;opacity:0;transition:opacity .18s ease;}',
+			'.async-ai-cursor-label[data-visible="1"]{opacity:1;}',
+		].join('\\n');
+		document.documentElement.appendChild(style);
+		STATE.styleEl = style;
+
+		const root = document.createElement('div');
+		root.className = 'async-ai-cursor-root';
+		root.setAttribute('aria-hidden', 'true');
+
+		const halo = document.createElement('div');
+		halo.className = 'async-ai-cursor-halo';
+
+		const cursor = document.createElement('div');
+		cursor.className = 'async-ai-cursor';
+		cursor.setAttribute('data-visible', '0');
+		cursor.innerHTML = [
+			'<svg viewBox="0 0 28 28" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">',
+			'<defs><linearGradient id="async-ai-cursor-grad" x1="0" y1="0" x2="0" y2="1">',
+			'<stop offset="0%" stop-color="#60a5fa"/>',
+			'<stop offset="100%" stop-color="#2563eb"/>',
+			'</linearGradient></defs>',
+			'<path d="M5 3 L5 22 L10 17 L13 24 L16 23 L13 16 L20 16 Z" fill="url(#async-ai-cursor-grad)" stroke="#0f172a" stroke-width="1.2" stroke-linejoin="round"/>',
+			'</svg>',
+		].join('');
+
+		const label = document.createElement('div');
+		label.className = 'async-ai-cursor-label';
+		label.setAttribute('data-visible', '0');
+
+		root.appendChild(halo);
+		root.appendChild(cursor);
+		root.appendChild(label);
+		document.documentElement.appendChild(root);
+
+		STATE.container = root;
+		STATE.cursor = cursor;
+		STATE.halo = halo;
+		STATE.labelEl = label;
+		applyPosition(STATE.x, STATE.y);
+	}
+
+	function applyPosition(x, y) {
+		STATE.x = x;
+		STATE.y = y;
+		if (STATE.cursor) {
+			STATE.cursor.style.left = x + 'px';
+			STATE.cursor.style.top = y + 'px';
+		}
+		if (STATE.halo) {
+			STATE.halo.style.left = x + 'px';
+			STATE.halo.style.top = y + 'px';
+		}
+		if (STATE.labelEl) {
+			STATE.labelEl.style.left = x + 'px';
+			STATE.labelEl.style.top = y + 'px';
+		}
+	}
+
+	function easeInOutCubic(t) {
+		return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+	}
+
+	function bezier(p0, p1, p2, p3, t) {
+		const u = 1 - t;
+		return u * u * u * p0 + 3 * u * u * t * p1 + 3 * u * t * t * p2 + t * t * t * p3;
+	}
+
+	function moveTo(targetX, targetY, durationMs) {
+		ensureRoot();
+		if (!STATE.cursor) return Promise.resolve();
+		if (STATE.moveAnim && STATE.moveAnim.cancel) STATE.moveAnim.cancel();
+		const startX = STATE.x;
+		const startY = STATE.y;
+		const dx = targetX - startX;
+		const dy = targetY - startY;
+		const distance = Math.hypot(dx, dy);
+		// 自适应速度：短距离更快，长距离仍然有上限。
+		const dur = typeof durationMs === 'number'
+			? Math.max(80, durationMs)
+			: Math.min(900, Math.max(180, distance * 1.4));
+
+		// 用三阶贝塞尔曲线产生轻微弯曲的轨迹（不是直线），更像人手。
+		const perpX = -dy / (distance || 1);
+		const perpY = dx / (distance || 1);
+		const sag = Math.min(80, distance * 0.18) * (Math.random() > 0.5 ? 1 : -1);
+		const c1x = startX + dx * 0.3 + perpX * sag * 0.6;
+		const c1y = startY + dy * 0.3 + perpY * sag * 0.6;
+		const c2x = startX + dx * 0.7 + perpX * sag * 0.9;
+		const c2y = startY + dy * 0.7 + perpY * sag * 0.9;
+
+		showInternal();
+		return new Promise((resolve) => {
+			const t0 = performance.now();
+			let cancelled = false;
+			function frame(now) {
+				if (cancelled) return;
+				const raw = Math.min(1, (now - t0) / dur);
+				const t = easeInOutCubic(raw);
+				const x = bezier(startX, c1x, c2x, targetX, t);
+				const y = bezier(startY, c1y, c2y, targetY, t);
+				// 轻微抖动，仅前 70%
+				const jitter = raw < 0.7 ? (Math.random() - 0.5) * 0.6 : 0;
+				applyPosition(x + jitter, y + jitter);
+				if (raw < 1) {
+					requestAnimationFrame(frame);
+				} else {
+					applyPosition(targetX, targetY);
+					STATE.moveAnim = null;
+					resolve();
+				}
+			}
+			STATE.moveAnim = { cancel: () => { cancelled = true; STATE.moveAnim = null; resolve(); } };
+			requestAnimationFrame(frame);
+		});
+	}
+
+	function showInternal() {
+		ensureRoot();
+		STATE.visible = true;
+		if (STATE.cursor) STATE.cursor.setAttribute('data-visible', '1');
+	}
+
+	function hideInternal() {
+		STATE.visible = false;
+		if (STATE.cursor) STATE.cursor.setAttribute('data-visible', '0');
+		if (STATE.labelEl) STATE.labelEl.setAttribute('data-visible', '0');
+	}
+
+	function ripple(x, y) {
+		ensureRoot();
+		if (!STATE.halo) return;
+		applyPosition(x, y);
+		// 重置动画
+		STATE.halo.removeAttribute('data-active');
+		// 触发 reflow 让 keyframe 重启
+		void STATE.halo.offsetWidth;
+		STATE.halo.setAttribute('data-active', '1');
+	}
+
+	function click(x, y) {
+		ensureRoot();
+		if (!STATE.cursor) return Promise.resolve();
+		applyPosition(x, y);
+		showInternal();
+		STATE.cursor.setAttribute('data-pressed', '1');
+		ripple(x, y);
+		return new Promise((resolve) => {
+			setTimeout(() => {
+				if (STATE.cursor) STATE.cursor.removeAttribute('data-pressed');
+				resolve();
+			}, 130);
+		});
+	}
+
+	function typeIndicator() {
+		ripple(STATE.x, STATE.y + 14);
+	}
+
+	function setLabel(text, ms) {
+		ensureRoot();
+		if (!STATE.labelEl) return;
+		if (STATE.labelTimer) {
+			clearTimeout(STATE.labelTimer);
+			STATE.labelTimer = null;
+		}
+		if (!text) {
+			STATE.labelEl.setAttribute('data-visible', '0');
+			return;
+		}
+		STATE.labelEl.textContent = String(text).slice(0, 80);
+		STATE.labelEl.setAttribute('data-visible', '1');
+		const dur = typeof ms === 'number' && ms > 0 ? ms : 1600;
+		STATE.labelTimer = setTimeout(() => {
+			if (STATE.labelEl) STATE.labelEl.setAttribute('data-visible', '0');
+		}, dur);
+	}
+
+	const api = {
+		__installed: true,
+		show: showInternal,
+		hide: hideInternal,
+		moveTo,
+		click,
+		ripple,
+		typeIndicator,
+		label: setLabel,
+		getState: () => ({ x: STATE.x, y: STATE.y, visible: STATE.visible }),
+	};
+
+	Object.defineProperty(window, '__asyncAiCursor', {
+		value: api,
+		configurable: true,
+	});
+
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', ensureRoot, { once: true });
+	} else {
+		ensureRoot();
+	}
+})();
+`.trim();
+}

--- a/main-src/browser/humanCursor.ts
+++ b/main-src/browser/humanCursor.ts
@@ -34,6 +34,9 @@ export function humanCursorInitScript(): string {
 		styleEl: null,
 		moveAnim: null,
 		labelTimer: null,
+		keyHud: null,
+		keyPills: [],
+		keyHudTimer: null,
 	};
 
 	function ensureRoot() {
@@ -50,16 +53,23 @@ export function humanCursorInitScript(): string {
 		style.setAttribute('data-async-ai-cursor', '1');
 		style.textContent = [
 			'.async-ai-cursor-root{position:fixed;inset:0;pointer-events:none;z-index:2147483646;contain:layout style;}',
-			'.async-ai-cursor{position:absolute;width:28px;height:28px;transform:translate(-4px,-2px);transition:opacity .18s ease;will-change:transform;filter:drop-shadow(0 4px 8px rgba(0,0,0,.35));}',
+			'.async-ai-cursor{position:absolute;width:24px;height:24px;transform:translate(-3px,-2px);transition:opacity .2s ease;will-change:transform;}',
 			'.async-ai-cursor[data-visible="0"]{opacity:0;}',
 			'.async-ai-cursor[data-visible="1"]{opacity:1;}',
-			'.async-ai-cursor[data-pressed="1"] svg{transform:scale(.86);}',
-			'.async-ai-cursor svg{transition:transform .12s cubic-bezier(.4,0,.2,1);width:100%;height:100%;display:block;}',
-			'.async-ai-cursor-halo{position:absolute;width:36px;height:36px;border-radius:50%;border:2px solid rgba(99,179,237,.85);transform:translate(-18px,-18px) scale(.6);opacity:0;pointer-events:none;}',
-			'@keyframes async-ai-ripple{0%{opacity:.85;transform:translate(-18px,-18px) scale(.4);}80%{opacity:.0;transform:translate(-18px,-18px) scale(2.2);}100%{opacity:0;}}',
-			'.async-ai-cursor-halo[data-active="1"]{animation:async-ai-ripple .55s cubic-bezier(.2,.7,.3,1) forwards;}',
-			'.async-ai-cursor-label{position:absolute;padding:4px 10px;border-radius:8px;font:600 12px/1.4 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,sans-serif;color:#fff;background:rgba(15,23,42,.92);white-space:nowrap;transform:translate(14px,4px);box-shadow:0 6px 18px rgba(0,0,0,.32);pointer-events:none;opacity:0;transition:opacity .18s ease;}',
+			'.async-ai-cursor[data-pressed="1"] .async-ai-cursor-svg{transform:scale(.82);}',
+			'.async-ai-cursor-svg{transition:transform .14s cubic-bezier(.4,0,.2,1);width:100%;height:100%;display:block;filter:drop-shadow(0 1px 1px rgba(0,0,0,.35)) drop-shadow(0 6px 16px rgba(99,102,241,.45));}',
+			'.async-ai-cursor-glow{position:absolute;left:0;top:0;width:24px;height:24px;border-radius:50%;background:radial-gradient(circle at 30% 30%,rgba(129,140,248,.55),rgba(129,140,248,0) 65%);transform:translate(-12px,-12px) scale(1);opacity:.55;animation:async-ai-glow 2.4s ease-in-out infinite;pointer-events:none;}',
+			'@keyframes async-ai-glow{0%,100%{opacity:.4;transform:translate(-12px,-12px) scale(.9);}50%{opacity:.65;transform:translate(-12px,-12px) scale(1.15);}}',
+			'.async-ai-cursor-halo{position:absolute;width:18px;height:18px;border-radius:50%;border:1.5px solid rgba(129,140,248,.9);background:radial-gradient(circle,rgba(129,140,248,.18),rgba(129,140,248,0) 70%);transform:translate(-9px,-9px) scale(.5);opacity:0;pointer-events:none;}',
+			'@keyframes async-ai-ripple{0%{opacity:.95;transform:translate(-9px,-9px) scale(.4);border-width:2px;}70%{opacity:.0;transform:translate(-9px,-9px) scale(3);border-width:.6px;}100%{opacity:0;border-width:.5px;}}',
+			'.async-ai-cursor-halo[data-active="1"]{animation:async-ai-ripple .6s cubic-bezier(.16,.78,.3,1) forwards;}',
+			'.async-ai-cursor-label{position:absolute;padding:5px 11px;border-radius:999px;font:600 11.5px/1.3 ui-sans-serif,system-ui,-apple-system,"SF Pro Text","Segoe UI",Roboto,sans-serif;color:#fff;background:linear-gradient(135deg,rgba(15,23,42,.94),rgba(30,41,59,.94));white-space:nowrap;transform:translate(14px,8px);box-shadow:0 8px 24px rgba(15,23,42,.45),0 0 0 1px rgba(255,255,255,.08) inset;pointer-events:none;opacity:0;transition:opacity .2s ease,transform .2s ease;letter-spacing:.01em;backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px);}',
 			'.async-ai-cursor-label[data-visible="1"]{opacity:1;}',
+			'.async-ai-keyhud{position:fixed;left:50%;bottom:36px;transform:translateX(-50%);display:flex;gap:8px;align-items:center;justify-content:center;pointer-events:none;font:600 17px/1 ui-sans-serif,system-ui,-apple-system,"SF Pro Text","Segoe UI",Roboto,sans-serif;max-width:90vw;flex-wrap:nowrap;overflow:hidden;z-index:2147483646;}',
+			'.async-ai-keyhud-pill{display:inline-flex;align-items:center;justify-content:center;min-width:38px;height:44px;padding:0 14px;border-radius:12px;color:#f8fafc;background:linear-gradient(180deg,rgba(30,41,59,.95),rgba(15,23,42,.95));box-shadow:0 10px 30px rgba(15,23,42,.55),0 0 0 1px rgba(255,255,255,.09) inset,0 -1px 0 rgba(0,0,0,.4) inset;letter-spacing:.02em;animation:async-ai-keypop .2s cubic-bezier(.16,.78,.3,1);will-change:transform,opacity;backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);text-shadow:0 1px 2px rgba(0,0,0,.4);}',
+			'.async-ai-keyhud-pill[data-fading="1"]{transition:opacity .4s ease,transform .4s ease;opacity:0;transform:translateY(10px) scale(.9);}',
+			'.async-ai-keyhud-pill[data-mod="1"]{background:linear-gradient(180deg,rgba(99,102,241,.95),rgba(79,70,229,.95));box-shadow:0 10px 30px rgba(79,70,229,.55),0 0 0 1px rgba(165,180,252,.4) inset,0 -1px 0 rgba(30,27,75,.5) inset;}',
+			'@keyframes async-ai-keypop{0%{opacity:0;transform:translateY(14px) scale(.82);}60%{opacity:1;transform:translateY(-2px) scale(1.04);}100%{opacity:1;transform:translateY(0) scale(1);}}',
 		].join('\\n');
 		document.documentElement.appendChild(style);
 		STATE.styleEl = style;
@@ -75,12 +85,23 @@ export function humanCursorInitScript(): string {
 		cursor.className = 'async-ai-cursor';
 		cursor.setAttribute('data-visible', '0');
 		cursor.innerHTML = [
-			'<svg viewBox="0 0 28 28" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">',
-			'<defs><linearGradient id="async-ai-cursor-grad" x1="0" y1="0" x2="0" y2="1">',
-			'<stop offset="0%" stop-color="#60a5fa"/>',
-			'<stop offset="100%" stop-color="#2563eb"/>',
-			'</linearGradient></defs>',
-			'<path d="M5 3 L5 22 L10 17 L13 24 L16 23 L13 16 L20 16 Z" fill="url(#async-ai-cursor-grad)" stroke="#0f172a" stroke-width="1.2" stroke-linejoin="round"/>',
+			'<div class="async-ai-cursor-glow"></div>',
+			'<svg class="async-ai-cursor-svg" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">',
+			'<defs>',
+			'<linearGradient id="async-ai-cursor-grad" x1="0%" y1="0%" x2="80%" y2="100%">',
+			'<stop offset="0%" stop-color="#a5b4fc"/>',
+			'<stop offset="55%" stop-color="#818cf8"/>',
+			'<stop offset="100%" stop-color="#6366f1"/>',
+			'</linearGradient>',
+			'<linearGradient id="async-ai-cursor-shine" x1="0%" y1="0%" x2="0%" y2="60%">',
+			'<stop offset="0%" stop-color="rgba(255,255,255,.7)"/>',
+			'<stop offset="100%" stop-color="rgba(255,255,255,0)"/>',
+			'</linearGradient>',
+			'</defs>',
+			// 现代瘦削箭头：平滑收尾、圆角连接，带白色描边在亮暗背景都清晰
+			'<path d="M3.4 2.6 L3.4 18.6 Q3.4 19.7 4.5 19.1 L8.4 17 L11.1 21.7 Q11.5 22.4 12.3 22 L13.9 21.1 Q14.6 20.7 14.2 19.9 L11.6 15.4 L16.4 14.2 Q17.5 13.9 16.7 13 L4.7 2.1 Q3.4 1.0 3.4 2.6 Z" fill="url(#async-ai-cursor-grad)" stroke="#fff" stroke-width="1.4" stroke-linejoin="round" stroke-linecap="round"/>',
+			// 顶部高光：让箭头有立体感
+			'<path d="M4.4 3.5 L4.4 9 Q4.4 9.5 4.9 9.3 L7.5 8 Q8 7.8 7.5 7.3 L5 4.0 Q4.4 3.3 4.4 3.5 Z" fill="url(#async-ai-cursor-shine)" opacity=".55"/>',
 			'</svg>',
 		].join('');
 
@@ -93,11 +114,79 @@ export function humanCursorInitScript(): string {
 		root.appendChild(label);
 		document.documentElement.appendChild(root);
 
+		const keyHud = document.createElement('div');
+		keyHud.className = 'async-ai-keyhud';
+		document.documentElement.appendChild(keyHud);
+
 		STATE.container = root;
 		STATE.cursor = cursor;
 		STATE.halo = halo;
 		STATE.labelEl = label;
+		STATE.keyHud = keyHud;
 		applyPosition(STATE.x, STATE.y);
+	}
+
+	const KEY_GLYPHS = {
+		'Enter': '↵ Enter',
+		'Tab': '⇥ Tab',
+		'Backspace': '⌫',
+		'Delete': '⌦',
+		'Escape': 'Esc',
+		'Esc': 'Esc',
+		'ArrowUp': '↑',
+		'ArrowDown': '↓',
+		'ArrowLeft': '←',
+		'ArrowRight': '→',
+		'Shift': '⇧ Shift',
+		'Control': 'Ctrl',
+		'Ctrl': 'Ctrl',
+		'Alt': 'Alt',
+		'Meta': '⌘ Cmd',
+		'Cmd': '⌘ Cmd',
+		'Space': '␣ Space',
+		' ': '␣',
+		'CapsLock': '⇪ Caps',
+		'PageUp': 'PgUp',
+		'PageDown': 'PgDn',
+		'Home': 'Home',
+		'End': 'End',
+	};
+
+	const MAX_KEY_PILLS = 8;
+
+	function pushKey(label) {
+		ensureRoot();
+		if (!STATE.keyHud) return;
+		const raw = String(label == null ? '' : label);
+		if (!raw) return;
+		// Composite shortcut like "Control+Shift+A": split into individual pills.
+		const parts = raw.includes('+') && raw.length > 1
+			? raw.split('+').map((s) => s.trim()).filter(Boolean)
+			: [raw];
+		for (const part of parts) {
+			const isMod = ['Shift', 'Control', 'Ctrl', 'Alt', 'Meta', 'Cmd'].indexOf(part) !== -1;
+			const display = KEY_GLYPHS[part] !== undefined ? KEY_GLYPHS[part] : part;
+			const pill = document.createElement('span');
+			pill.className = 'async-ai-keyhud-pill';
+			if (isMod) pill.setAttribute('data-mod', '1');
+			pill.textContent = display;
+			STATE.keyHud.appendChild(pill);
+			STATE.keyPills.push(pill);
+			while (STATE.keyPills.length > MAX_KEY_PILLS) {
+				const old = STATE.keyPills.shift();
+				if (old && old.parentNode) old.parentNode.removeChild(old);
+			}
+			// Auto-fade after a short window so a steady stream of keys keeps the latest visible.
+			setTimeout(() => {
+				if (!pill.parentNode) return;
+				pill.setAttribute('data-fading', '1');
+				setTimeout(() => {
+					if (pill.parentNode) pill.parentNode.removeChild(pill);
+					const idx = STATE.keyPills.indexOf(pill);
+					if (idx !== -1) STATE.keyPills.splice(idx, 1);
+				}, 380);
+			}, 1100);
+		}
 	}
 
 	function applyPosition(x, y) {
@@ -245,6 +334,7 @@ export function humanCursorInitScript(): string {
 		ripple,
 		typeIndicator,
 		label: setLabel,
+		key: pushKey,
 		getState: () => ({ x: STATE.x, y: STATE.y, visible: STATE.visible }),
 	};
 

--- a/main-src/browser/humanizedActions.ts
+++ b/main-src/browser/humanizedActions.ts
@@ -1,0 +1,191 @@
+/**
+ * 把 Playwright 的原始动作包装成"看起来像人在操作"的版本。
+ *
+ * 流程（以 click 为例）：
+ *   1. 解析 locator → 拿到目标元素的视口坐标。
+ *   2. 在页面侧调用 `__asyncAiCursor.moveTo()` 让虚拟光标缓动到目标点。
+ *   3. 短暂 hover（思考停顿），同时显示一行说明 label。
+ *   4. 在页面侧调用 `__asyncAiCursor.click()` 触发按压 + 涟漪动画。
+ *   5. 用 Playwright `page.mouse.click()` 真实派发点击事件。
+ *
+ * 输入文本时按字符之间随机间隔（80~180ms）来模拟人手速度，
+ * 期间偶尔触发 `typeIndicator()` 让光标周围有节奏的涟漪。
+ */
+
+import type { Locator, Page } from 'playwright-core';
+
+export type HumanActionOptions = {
+	label?: string;
+	hoverDelayMs?: number;
+	moveDurationMs?: number;
+};
+
+export type HumanTypeOptions = HumanActionOptions & {
+	minPerCharMs?: number;
+	maxPerCharMs?: number;
+	clearFirst?: boolean;
+};
+
+function rand(min: number, max: number): number {
+	return min + Math.random() * (max - min);
+}
+
+async function safeShowLabel(page: Page, text: string | undefined, durationMs: number): Promise<void> {
+	if (!text) return;
+	try {
+		await page.evaluate(
+			({ t, d }) => {
+				const api = (window as unknown as { __asyncAiCursor?: { label: (t: string, d?: number) => void } })
+					.__asyncAiCursor;
+				if (api && typeof api.label === 'function') api.label(t, d);
+			},
+			{ t: text, d: durationMs }
+		);
+	} catch {
+		/* page navigated away — ignore */
+	}
+}
+
+async function ensureCursorAt(page: Page, x: number, y: number, durationMs: number): Promise<void> {
+	try {
+		await page.evaluate(
+			({ x, y, d }) => {
+				const api = (window as unknown as {
+					__asyncAiCursor?: {
+						moveTo: (x: number, y: number, d: number) => Promise<void>;
+						show: () => void;
+					};
+				}).__asyncAiCursor;
+				if (!api) return Promise.resolve();
+				api.show();
+				return api.moveTo(x, y, d);
+			},
+			{ x, y, d: durationMs }
+		);
+	} catch {
+		/* ignore — cursor is decorative only */
+	}
+}
+
+async function triggerCursorClick(page: Page, x: number, y: number): Promise<void> {
+	try {
+		await page.evaluate(
+			({ x, y }) => {
+				const api = (window as unknown as {
+					__asyncAiCursor?: { click: (x: number, y: number) => Promise<void> };
+				}).__asyncAiCursor;
+				if (api && typeof api.click === 'function') return api.click(x, y);
+				return Promise.resolve();
+			},
+			{ x, y }
+		);
+	} catch {
+		/* ignore */
+	}
+}
+
+async function locatorViewportCenter(locator: Locator): Promise<{ x: number; y: number }> {
+	// Playwright 的 boundingBox 已是视口坐标（CSS px）。
+	const box = await locator.boundingBox({ timeout: 10_000 });
+	if (!box) {
+		throw new Error('目标元素不可见，无法获取定位框（boundingBox）。');
+	}
+	const cx = box.x + box.width / 2 + rand(-Math.min(box.width / 6, 6), Math.min(box.width / 6, 6));
+	const cy = box.y + box.height / 2 + rand(-Math.min(box.height / 6, 4), Math.min(box.height / 6, 4));
+	return { x: cx, y: cy };
+}
+
+export async function humanClick(
+	page: Page,
+	locator: Locator,
+	options: HumanActionOptions = {}
+): Promise<{ x: number; y: number }> {
+	await locator.waitFor({ state: 'visible', timeout: 15_000 });
+	await locator.scrollIntoViewIfNeeded({ timeout: 10_000 }).catch(() => {});
+	const { x, y } = await locatorViewportCenter(locator);
+	const moveDur = options.moveDurationMs ?? Math.round(rand(280, 520));
+	const hoverDur = options.hoverDelayMs ?? Math.round(rand(120, 260));
+	await safeShowLabel(page, options.label, moveDur + hoverDur + 600);
+	await ensureCursorAt(page, x, y, moveDur);
+	await page.waitForTimeout(hoverDur);
+	await triggerCursorClick(page, x, y);
+	await page.mouse.move(x, y);
+	await page.mouse.down();
+	await page.waitForTimeout(rand(40, 90));
+	await page.mouse.up();
+	return { x, y };
+}
+
+export async function humanHover(
+	page: Page,
+	locator: Locator,
+	options: HumanActionOptions = {}
+): Promise<{ x: number; y: number }> {
+	await locator.waitFor({ state: 'visible', timeout: 15_000 });
+	await locator.scrollIntoViewIfNeeded({ timeout: 10_000 }).catch(() => {});
+	const { x, y } = await locatorViewportCenter(locator);
+	const moveDur = options.moveDurationMs ?? Math.round(rand(260, 500));
+	await safeShowLabel(page, options.label, moveDur + 800);
+	await ensureCursorAt(page, x, y, moveDur);
+	await page.mouse.move(x, y);
+	return { x, y };
+}
+
+export async function humanType(
+	page: Page,
+	locator: Locator,
+	text: string,
+	options: HumanTypeOptions = {}
+): Promise<void> {
+	await humanClick(page, locator, { label: options.label, moveDurationMs: options.moveDurationMs });
+	if (options.clearFirst !== false) {
+		// 全选 + 删除，跨平台兼容
+		const isMac = process.platform === 'darwin';
+		await page.keyboard.press(isMac ? 'Meta+A' : 'Control+A');
+		await page.keyboard.press('Delete');
+	}
+	const minMs = options.minPerCharMs ?? 60;
+	const maxMs = options.maxPerCharMs ?? 160;
+	for (let i = 0; i < text.length; i++) {
+		const ch = text[i];
+		await page.keyboard.type(ch, { delay: 0 });
+		// 每隔几个字符触发一次输入指示器
+		if (i % 3 === 0) {
+			try {
+				await page.evaluate(() => {
+					const api = (window as unknown as { __asyncAiCursor?: { typeIndicator: () => void } })
+						.__asyncAiCursor;
+					api?.typeIndicator();
+				});
+			} catch {
+				/* ignore */
+			}
+		}
+		await page.waitForTimeout(rand(minMs, maxMs));
+	}
+}
+
+export async function humanPressKey(
+	page: Page,
+	key: string,
+	options: { label?: string } = {}
+): Promise<void> {
+	await safeShowLabel(page, options.label, 1200);
+	await page.waitForTimeout(rand(60, 140));
+	await page.keyboard.press(key);
+}
+
+export async function humanScroll(
+	page: Page,
+	deltaY: number,
+	options: { stepPx?: number; stepDelayMs?: number } = {}
+): Promise<void> {
+	const step = options.stepPx ?? 120;
+	const delay = options.stepDelayMs ?? 30;
+	const steps = Math.max(1, Math.round(Math.abs(deltaY) / step));
+	const sign = deltaY < 0 ? -1 : 1;
+	for (let i = 0; i < steps; i++) {
+		await page.mouse.wheel(0, sign * step);
+		await page.waitForTimeout(delay);
+	}
+}

--- a/main-src/browser/humanizedActions.ts
+++ b/main-src/browser/humanizedActions.ts
@@ -84,6 +84,18 @@ async function triggerCursorClick(page: Page, x: number, y: number): Promise<voi
 	}
 }
 
+async function pushKeyToHud(page: Page, label: string): Promise<void> {
+	try {
+		await page.evaluate((l) => {
+			const api = (window as unknown as { __asyncAiCursor?: { key: (l: string) => void } })
+				.__asyncAiCursor;
+			if (api && typeof api.key === 'function') api.key(l);
+		}, label);
+	} catch {
+		/* decorative */
+	}
+}
+
 async function locatorViewportCenter(locator: Locator): Promise<{ x: number; y: number }> {
 	// Playwright 的 boundingBox 已是视口坐标（CSS px）。
 	const box = await locator.boundingBox({ timeout: 10_000 });
@@ -149,18 +161,7 @@ export async function humanType(
 	for (let i = 0; i < text.length; i++) {
 		const ch = text[i];
 		await page.keyboard.type(ch, { delay: 0 });
-		// 每隔几个字符触发一次输入指示器
-		if (i % 3 === 0) {
-			try {
-				await page.evaluate(() => {
-					const api = (window as unknown as { __asyncAiCursor?: { typeIndicator: () => void } })
-						.__asyncAiCursor;
-					api?.typeIndicator();
-				});
-			} catch {
-				/* ignore */
-			}
-		}
+		await pushKeyToHud(page, ch);
 		await page.waitForTimeout(rand(minMs, maxMs));
 	}
 }
@@ -171,6 +172,7 @@ export async function humanPressKey(
 	options: { label?: string } = {}
 ): Promise<void> {
 	await safeShowLabel(page, options.label, 1200);
+	await pushKeyToHud(page, key);
 	await page.waitForTimeout(rand(60, 140));
 	await page.keyboard.press(key);
 }

--- a/main-src/browser/playwrightBridge.ts
+++ b/main-src/browser/playwrightBridge.ts
@@ -1,0 +1,298 @@
+/**
+ * Playwright over CDP 桥接：连接到 Electron 内部 Chromium 暴露的 DevTools 端口，
+ * 把"内置浏览器里的 webview"包装成 Playwright Page，供 AI 工具调用。
+ *
+ * 设计要点：
+ * - 单例 Browser 连接，懒加载；首次 `acquirePageForHost` 触发连接。
+ * - 通过 CDP 的 `Target.targetInfos` 区分 webview / page，按 webContents.id 关联到
+ *   Electron `<webview>` 元素：每个 webview 都是一个独立 OOPIF page target。
+ * - 我们没法直接拿到 Electron webContents.id 与 Playwright Page 的映射关系，但
+ *   可以借助 webview 当前 URL + 浏览器运行时状态做匹配（一对一足够）。
+ * - 当前 active tab 的 webContents 由 `BrowserRuntimeState` 跟踪；其 URL 在主进程
+ *   是已知的（通过 `webContents.getURL()` 直接读）。
+ */
+
+import { app, webContents as electronWebContents, type WebContents } from 'electron';
+import type {
+	Browser as PwBrowser,
+	BrowserContext as PwContext,
+	Page as PwPage,
+} from 'playwright-core';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import {
+	isAiBrowserEnabledForThisLaunch,
+	readDevToolsActivePort,
+} from './aiBrowserFlag.js';
+import { humanCursorInitScript } from './humanCursor.js';
+
+let pwModule: typeof import('playwright-core') | null = null;
+function loadPlaywright(): typeof import('playwright-core') {
+	if (!pwModule) {
+		// 用 require 避免 esbuild bundle 时静态分析；playwright-core 体积较大。
+		pwModule = require('playwright-core');
+	}
+	return pwModule!;
+}
+
+type BridgeState = {
+	browser: PwBrowser;
+	pageByWebContentsId: Map<number, PwPage>;
+	pageInitTokens: WeakSet<PwPage>;
+};
+
+let bridgeState: BridgeState | null = null;
+let connectingPromise: Promise<BridgeState> | null = null;
+
+/**
+ * 等待 `DevToolsActivePort` 文件出现并能解析出端口号。Chromium 在初始化阶段写入。
+ */
+async function waitForDevToolsPort(timeoutMs: number = 8_000): Promise<number> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		const port = readDevToolsActivePort();
+		if (port != null) return port;
+		await new Promise((r) => setTimeout(r, 100));
+	}
+	throw new Error(
+		`[ai-browser] DevToolsActivePort not found at ${path.join(
+			app.getPath('userData'),
+			'DevToolsActivePort'
+		)} within ${timeoutMs}ms`
+	);
+}
+
+async function fetchBrowserVersionEndpoint(port: number): Promise<string> {
+	const http = await import('node:http');
+	return await new Promise<string>((resolve, reject) => {
+		const req = http.request(
+			{
+				host: '127.0.0.1',
+				port,
+				path: '/json/version',
+				method: 'GET',
+				headers: { Host: '127.0.0.1' },
+			},
+			(res) => {
+				const chunks: Buffer[] = [];
+				res.on('data', (c) => chunks.push(c as Buffer));
+				res.on('end', () => {
+					try {
+						const json = JSON.parse(Buffer.concat(chunks).toString('utf8')) as {
+							webSocketDebuggerUrl?: string;
+						};
+						if (!json.webSocketDebuggerUrl) {
+							reject(new Error('webSocketDebuggerUrl missing from /json/version'));
+							return;
+						}
+						resolve(json.webSocketDebuggerUrl);
+					} catch (e) {
+						reject(e instanceof Error ? e : new Error(String(e)));
+					}
+				});
+				res.on('error', reject);
+			}
+		);
+		req.on('error', reject);
+		req.end();
+	});
+}
+
+async function connectBridge(): Promise<BridgeState> {
+	if (!isAiBrowserEnabledForThisLaunch()) {
+		throw new Error(
+			'AI 浏览器自动化已被禁用（环境变量 ASYNC_AI_BROWSER=0）。请取消该设置后重启。'
+		);
+	}
+	const port = await waitForDevToolsPort();
+	const wsUrl = await fetchBrowserVersionEndpoint(port);
+	const { chromium } = loadPlaywright();
+	const browser = await chromium.connectOverCDP(wsUrl, { timeout: 15_000 });
+	const state: BridgeState = {
+		browser,
+		pageByWebContentsId: new Map(),
+		pageInitTokens: new WeakSet(),
+	};
+	browser.on('disconnected', () => {
+		if (bridgeState === state) bridgeState = null;
+	});
+	bridgeState = state;
+	return state;
+}
+
+async function ensureBridge(): Promise<BridgeState> {
+	if (bridgeState) return bridgeState;
+	if (!connectingPromise) {
+		connectingPromise = connectBridge().finally(() => {
+			connectingPromise = null;
+		});
+	}
+	return await connectingPromise;
+}
+
+/**
+ * 在 page 上注入人形光标 + 工具脚本（仅注入一次）。
+ */
+async function ensurePageInstrumentation(state: BridgeState, page: PwPage): Promise<void> {
+	if (state.pageInitTokens.has(page)) return;
+	state.pageInitTokens.add(page);
+	try {
+		// 当前页面立即注入；后续 navigation 用 addInitScript 兜底。
+		await page.addInitScript({ content: humanCursorInitScript() });
+		await page.evaluate(humanCursorInitScript()).catch(() => {
+			/* about:blank or cross-origin scope can fail; init script will catch it. */
+		});
+	} catch (error) {
+		console.warn('[ai-browser] failed to inject human cursor:', error);
+	}
+}
+
+function normalizeUrlKey(raw: string): string {
+	if (!raw) return '';
+	try {
+		const u = new URL(raw);
+		// 忽略 fragment，trailing slash 不归一化（保留以便精确匹配）。
+		u.hash = '';
+		return u.toString();
+	} catch {
+		return raw;
+	}
+}
+
+/**
+ * Playwright 把每个 OOPIF / webview 都暴露为独立 page。我们按 URL 匹配。
+ *
+ * 如果同一 URL 有多个匹配（罕见但可能），优先选未被绑定到其他 webContentsId 的那个。
+ */
+async function findPageForWebContents(
+	state: BridgeState,
+	contents: WebContents
+): Promise<PwPage | null> {
+	const targetUrl = normalizeUrlKey(contents.getURL());
+	if (!targetUrl) return null;
+
+	const claimed = new Set<PwPage>();
+	for (const [, p] of state.pageByWebContentsId) claimed.add(p);
+
+	const candidates: PwPage[] = [];
+	for (const ctx of state.browser.contexts()) {
+		for (const page of ctx.pages()) {
+			if (page.isClosed()) continue;
+			if (normalizeUrlKey(page.url()) === targetUrl) candidates.push(page);
+		}
+	}
+	const free = candidates.find((p) => !claimed.has(p));
+	return free ?? candidates[0] ?? null;
+}
+
+export type BrowserTabRef = {
+	hostId: number;
+	tabId?: string;
+};
+
+/**
+ * 解析一个 host + 可选 tabId 到具体的 webview WebContents。
+ * 当前实现：使用 BrowserRuntimeState 中的 activeTabId 或显式 tabId 找到对应 webview。
+ *
+ * 由于内置浏览器的 webview 实例也是 Electron WebContents，我们枚举所有
+ * `getType() === 'webview'` 的 contents，并通过 `hostWebContents.id === hostId`
+ * 来过滤属于该 host 的那些。
+ */
+function resolveTargetWebContents(ref: BrowserTabRef): WebContents | null {
+	const allContents = electronWebContents.getAllWebContents();
+	const candidates = allContents.filter((c) => {
+		if (c.isDestroyed()) return false;
+		if (c.getType() !== 'webview') return false;
+		try {
+			const host = c.hostWebContents;
+			return !!host && !host.isDestroyed() && host.id === ref.hostId;
+		} catch {
+			return false;
+		}
+	});
+	if (candidates.length === 0) return null;
+	if (ref.tabId) {
+		// 内置浏览器目前没有把 tabId 暴露到 webContents 级别；按顺序匹配是最佳近似。
+		// 如未来 BrowserRuntimeState 增加 tabId→webContentsId 映射，可在此读取。
+		return candidates[0] ?? null;
+	}
+	// 优先选第一个非空 URL 的 webview（约定为 active tab）
+	const focused = candidates.find((c) => {
+		try {
+			return !!c.getURL();
+		} catch {
+			return false;
+		}
+	});
+	return focused ?? candidates[0] ?? null;
+}
+
+export async function acquirePageForHost(ref: BrowserTabRef): Promise<{
+	page: PwPage;
+	context: PwContext;
+	webContentsId: number;
+}> {
+	const state = await ensureBridge();
+	const target = resolveTargetWebContents(ref);
+	if (!target) {
+		throw new Error(
+			`未在 host ${ref.hostId} 中找到内置浏览器的 webview。请先在右侧栏打开 Browser 面板并访问任意页面。`
+		);
+	}
+	const cached = state.pageByWebContentsId.get(target.id);
+	if (cached && !cached.isClosed()) {
+		await ensurePageInstrumentation(state, cached);
+		return { page: cached, context: cached.context(), webContentsId: target.id };
+	}
+	const page = await findPageForWebContents(state, target);
+	if (!page) {
+		throw new Error(
+			'通过 CDP 未能定位到对应的 Playwright Page。可能页面正在加载或处于 about:blank。请等待页面加载后重试。'
+		);
+	}
+	state.pageByWebContentsId.set(target.id, page);
+	page.once('close', () => {
+		const current = state.pageByWebContentsId.get(target.id);
+		if (current === page) state.pageByWebContentsId.delete(target.id);
+	});
+	target.once('destroyed', () => {
+		state.pageByWebContentsId.delete(target.id);
+	});
+	await ensurePageInstrumentation(state, page);
+	return { page, context: page.context(), webContentsId: target.id };
+}
+
+export async function getPlaywrightStatus(): Promise<{
+	enabled: boolean;
+	connected: boolean;
+	port: number | null;
+}> {
+	const enabled = isAiBrowserEnabledForThisLaunch();
+	let port: number | null = null;
+	if (enabled) {
+		try {
+			const p = path.join(app.getPath('userData'), 'DevToolsActivePort');
+			if (existsSync(p)) {
+				port = readDevToolsActivePort();
+			}
+		} catch {
+			/* ignore */
+		}
+	}
+	return {
+		enabled,
+		connected: !!bridgeState,
+		port,
+	};
+}
+
+export async function disposePlaywrightBridge(): Promise<void> {
+	const state = bridgeState;
+	bridgeState = null;
+	if (!state) return;
+	try {
+		await state.browser.close();
+	} catch {
+		/* ignore */
+	}
+}

--- a/main-src/browser/playwrightTool.ts
+++ b/main-src/browser/playwrightTool.ts
@@ -1,0 +1,423 @@
+/**
+ * `Playwright` Agent 工具实现：通过 CDP 桥接驱动内置浏览器的 webview，
+ * 配合人形光标 + 拟人化时序，让 AI 自动化测试在用户眼前可视化执行。
+ *
+ * 该模块是工具层入口，与 toolExecutor 的其他工具（Browser、BrowserCapture）平级。
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import type { Locator, Page } from 'playwright-core';
+import { acquirePageForHost, getPlaywrightStatus } from './playwrightBridge.js';
+import {
+	humanClick,
+	humanHover,
+	humanPressKey,
+	humanScroll,
+	humanType,
+} from './humanizedActions.js';
+
+export type PlaywrightToolCall = {
+	id: string;
+	name: string;
+	arguments: Record<string, unknown>;
+};
+
+export type PlaywrightToolResult = {
+	toolCallId: string;
+	name: string;
+	content: string;
+	isError: boolean;
+};
+
+type ResolveLocatorOpts = {
+	role?: string;
+	roleName?: string;
+	roleExact?: boolean;
+	text?: string;
+	textExact?: boolean;
+	label?: string;
+	placeholder?: string;
+	testId?: string;
+	selector?: string;
+	nth?: number;
+};
+
+function pickLocator(page: Page, opts: ResolveLocatorOpts): Locator {
+	let loc: Locator | null = null;
+	const validRoles = [
+		'button', 'link', 'checkbox', 'radio', 'textbox', 'combobox', 'tab', 'menuitem',
+		'option', 'heading', 'img', 'list', 'listitem', 'navigation', 'main', 'banner',
+		'contentinfo', 'dialog', 'tooltip', 'alert', 'status', 'searchbox', 'switch', 'slider',
+	];
+	if (opts.role && validRoles.includes(opts.role)) {
+		loc = page.getByRole(opts.role as Parameters<Page['getByRole']>[0], {
+			name: opts.roleName,
+			exact: opts.roleExact,
+		});
+	} else if (opts.testId) {
+		loc = page.getByTestId(opts.testId);
+	} else if (opts.label) {
+		loc = page.getByLabel(opts.label);
+	} else if (opts.placeholder) {
+		loc = page.getByPlaceholder(opts.placeholder);
+	} else if (opts.text) {
+		loc = page.getByText(opts.text, { exact: opts.textExact });
+	} else if (opts.selector) {
+		loc = page.locator(opts.selector);
+	}
+	if (!loc) {
+		throw new Error(
+			'必须提供 selector / role / text / label / placeholder / testId 中的至少一个用于定位元素。'
+		);
+	}
+	if (typeof opts.nth === 'number' && Number.isFinite(opts.nth)) {
+		loc = loc.nth(opts.nth);
+	}
+	return loc;
+}
+
+function readArg<T>(args: Record<string, unknown>, ...keys: string[]): T | undefined {
+	for (const k of keys) {
+		if (Object.prototype.hasOwnProperty.call(args, k)) return args[k] as T;
+	}
+	return undefined;
+}
+
+function readBoolArg(args: Record<string, unknown>, ...keys: string[]): boolean | undefined {
+	const raw = readArg<unknown>(args, ...keys);
+	if (raw === undefined) return undefined;
+	if (raw === true || raw === 'true') return true;
+	if (raw === false || raw === 'false') return false;
+	return undefined;
+}
+
+function readStringArg(args: Record<string, unknown>, ...keys: string[]): string | undefined {
+	const raw = readArg<unknown>(args, ...keys);
+	return typeof raw === 'string' ? raw : undefined;
+}
+
+function readNumberArg(args: Record<string, unknown>, ...keys: string[]): number | undefined {
+	const raw = readArg<unknown>(args, ...keys);
+	if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
+	if (typeof raw === 'string') {
+		const n = Number(raw);
+		if (Number.isFinite(n)) return n;
+	}
+	return undefined;
+}
+
+function buildLocatorOpts(args: Record<string, unknown>): ResolveLocatorOpts {
+	return {
+		role: readStringArg(args, 'role'),
+		roleName: readStringArg(args, 'role_name', 'roleName', 'name'),
+		roleExact: readBoolArg(args, 'role_exact', 'roleExact'),
+		text: readStringArg(args, 'text'),
+		textExact: readBoolArg(args, 'text_exact', 'textExact'),
+		label: readStringArg(args, 'label'),
+		placeholder: readStringArg(args, 'placeholder'),
+		testId: readStringArg(args, 'test_id', 'testId'),
+		selector: readStringArg(args, 'selector'),
+		nth: readNumberArg(args, 'nth'),
+	};
+}
+
+function jsonResult(call: PlaywrightToolCall, payload: unknown): PlaywrightToolResult {
+	return {
+		toolCallId: call.id,
+		name: call.name,
+		content: JSON.stringify(payload, null, 2),
+		isError: false,
+	};
+}
+
+function errorResult(call: PlaywrightToolCall, message: string): PlaywrightToolResult {
+	return {
+		toolCallId: call.id,
+		name: call.name,
+		content: `Error: ${message}`,
+		isError: true,
+	};
+}
+
+function describeLocatorTarget(opts: ResolveLocatorOpts): string {
+	if (opts.role) return `${opts.role}${opts.roleName ? ` "${opts.roleName}"` : ''}`;
+	if (opts.testId) return `[data-testid="${opts.testId}"]`;
+	if (opts.label) return `label "${opts.label}"`;
+	if (opts.placeholder) return `placeholder "${opts.placeholder}"`;
+	if (opts.text) return `text "${opts.text}"`;
+	if (opts.selector) return opts.selector;
+	return '<element>';
+}
+
+async function snapshotPage(page: Page, maxChars: number): Promise<{
+	title: string;
+	url: string;
+	tree: string;
+}> {
+	// 通过 CDP 拿可访问性树（Page.accessibility 在 newer Playwright 已不暴露）。
+	type AxNode = {
+		nodeId?: string;
+		role?: { value?: string };
+		name?: { value?: string };
+		value?: { value?: string };
+		childIds?: string[];
+		ignored?: boolean;
+	};
+	let nodes: AxNode[] = [];
+	try {
+		const session = await page.context().newCDPSession(page);
+		const resp = (await session.send('Accessibility.getFullAXTree')) as { nodes?: AxNode[] };
+		nodes = resp.nodes ?? [];
+		await session.detach().catch(() => {});
+	} catch {
+		nodes = [];
+	}
+	const byId = new Map<string, AxNode>();
+	for (const n of nodes) {
+		if (n.nodeId) byId.set(n.nodeId, n);
+	}
+	const childSet = new Set<string>();
+	for (const n of nodes) for (const c of n.childIds ?? []) childSet.add(c);
+	const roots = nodes.filter((n) => n.nodeId && !childSet.has(n.nodeId));
+
+	function render(node: AxNode | undefined, depth: number, lines: string[]): void {
+		if (!node || node.ignored) {
+			for (const c of node?.childIds ?? []) render(byId.get(c), depth, lines);
+			return;
+		}
+		const role = node.role?.value ?? '';
+		const name = node.name?.value ? ` "${node.name.value}"` : '';
+		const value = node.value?.value ? ` =${JSON.stringify(node.value.value)}` : '';
+		if (role && role !== 'none' && role !== 'presentation') {
+			lines.push(`${'  '.repeat(depth)}- ${role}${name}${value}`);
+			for (const c of node.childIds ?? []) render(byId.get(c), depth + 1, lines);
+		} else {
+			for (const c of node.childIds ?? []) render(byId.get(c), depth, lines);
+		}
+	}
+	const lines: string[] = [];
+	for (const r of roots) render(r, 0, lines);
+	let tree = lines.join('\n');
+	if (!tree) tree = '(empty accessibility tree)';
+	if (tree.length > maxChars) tree = tree.slice(0, maxChars) + '\n... [truncated]';
+	return { title: await page.title().catch(() => ''), url: page.url(), tree };
+}
+
+function buildScreenshotPath(workspaceRoot: string | null): { full: string; rel: string | null } {
+	const fileName = `pw-${new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, 'Z')}.png`;
+	if (workspaceRoot) {
+		const rel = path.posix.join('.async', 'pw-captures', fileName);
+		const full = path.resolve(workspaceRoot, rel);
+		return { full, rel };
+	}
+	return { full: path.join(os.tmpdir(), 'async-pw-captures', fileName), rel: null };
+}
+
+export async function executePlaywrightTool(
+	call: PlaywrightToolCall,
+	ctx: { hostId: number; workspaceRoot: string | null }
+): Promise<PlaywrightToolResult> {
+	const action = String(call.arguments.action ?? '').trim();
+	if (!action) return errorResult(call, 'action is required');
+
+	if (action === 'status') {
+		const s = await getPlaywrightStatus();
+		return jsonResult(call, s);
+	}
+
+	let resolved: Awaited<ReturnType<typeof acquirePageForHost>>;
+	try {
+		resolved = await acquirePageForHost({
+			hostId: ctx.hostId,
+			tabId: readStringArg(call.arguments, 'tab_id', 'tabId'),
+		});
+	} catch (e) {
+		return errorResult(call, e instanceof Error ? e.message : String(e));
+	}
+	const { page } = resolved;
+
+	try {
+		switch (action) {
+			case 'navigate': {
+				const url = readStringArg(call.arguments, 'url');
+				if (!url) return errorResult(call, 'url is required for navigate');
+				const waitUntilRaw = readStringArg(call.arguments, 'wait_until', 'waitUntil') ?? 'load';
+				const waitUntil = (['load', 'domcontentloaded', 'networkidle', 'commit'] as const).includes(
+					waitUntilRaw as 'load'
+				)
+					? (waitUntilRaw as 'load' | 'domcontentloaded' | 'networkidle' | 'commit')
+					: 'load';
+				const timeoutMs = readNumberArg(call.arguments, 'timeout_ms', 'timeoutMs') ?? 30_000;
+				const resp = await page.goto(url, { waitUntil, timeout: timeoutMs });
+				return jsonResult(call, {
+					ok: true,
+					url: page.url(),
+					status: resp?.status() ?? null,
+					title: await page.title().catch(() => ''),
+				});
+			}
+			case 'click': {
+				const opts = buildLocatorOpts(call.arguments);
+				const loc = pickLocator(page, opts);
+				const target = describeLocatorTarget(opts);
+				const labelText = readStringArg(call.arguments, 'label_text', 'cursorLabel') ?? `点击 ${target}`;
+				const point = await humanClick(page, loc, { label: labelText });
+				return jsonResult(call, { ok: true, target, point });
+			}
+			case 'hover': {
+				const opts = buildLocatorOpts(call.arguments);
+				const loc = pickLocator(page, opts);
+				const target = describeLocatorTarget(opts);
+				const labelText = readStringArg(call.arguments, 'label_text', 'cursorLabel') ?? `悬停 ${target}`;
+				const point = await humanHover(page, loc, { label: labelText });
+				return jsonResult(call, { ok: true, target, point });
+			}
+			case 'fill': {
+				const opts = buildLocatorOpts(call.arguments);
+				const loc = pickLocator(page, opts);
+				const text = readStringArg(call.arguments, 'text', 'value') ?? '';
+				const target = describeLocatorTarget(opts);
+				const labelText = readStringArg(call.arguments, 'label_text', 'cursorLabel') ?? `填写 ${target}`;
+				await humanType(page, loc, text, {
+					label: labelText,
+					clearFirst: readBoolArg(call.arguments, 'clear_first', 'clearFirst') ?? true,
+					minPerCharMs: readNumberArg(call.arguments, 'min_per_char_ms') ?? 60,
+					maxPerCharMs: readNumberArg(call.arguments, 'max_per_char_ms') ?? 160,
+				});
+				return jsonResult(call, { ok: true, target, length: text.length });
+			}
+			case 'press_key': {
+				const key = readStringArg(call.arguments, 'key');
+				if (!key) return errorResult(call, 'key is required for press_key');
+				const labelText = readStringArg(call.arguments, 'label_text', 'cursorLabel') ?? `按键 ${key}`;
+				await humanPressKey(page, key, { label: labelText });
+				return jsonResult(call, { ok: true, key });
+			}
+			case 'scroll': {
+				const deltaY = readNumberArg(call.arguments, 'delta_y', 'deltaY') ?? 0;
+				if (!deltaY) return errorResult(call, 'delta_y is required for scroll');
+				await humanScroll(page, deltaY, {
+					stepPx: readNumberArg(call.arguments, 'step_px') ?? 120,
+					stepDelayMs: readNumberArg(call.arguments, 'step_delay_ms') ?? 30,
+				});
+				return jsonResult(call, { ok: true, deltaY });
+			}
+			case 'wait_for': {
+				const opts = buildLocatorOpts(call.arguments);
+				const stateRaw = readStringArg(call.arguments, 'state') ?? 'visible';
+				const waitState = (['attached', 'detached', 'visible', 'hidden'] as const).includes(
+					stateRaw as 'visible'
+				)
+					? (stateRaw as 'attached' | 'detached' | 'visible' | 'hidden')
+					: 'visible';
+				const timeoutMs = readNumberArg(call.arguments, 'timeout_ms', 'timeoutMs') ?? 15_000;
+				if (!opts.role && !opts.text && !opts.label && !opts.placeholder && !opts.testId && !opts.selector) {
+					// 等待页面就绪
+					await page.waitForLoadState('load', { timeout: timeoutMs });
+					return jsonResult(call, { ok: true, mode: 'load' });
+				}
+				const loc = pickLocator(page, opts);
+				await loc.waitFor({ state: waitState, timeout: timeoutMs });
+				return jsonResult(call, { ok: true, target: describeLocatorTarget(opts), state: waitState });
+			}
+			case 'evaluate': {
+				const expression = readStringArg(call.arguments, 'expression', 'js');
+				if (!expression) return errorResult(call, 'expression is required for evaluate');
+				const result = await page.evaluate(
+					(src) => {
+						// eslint-disable-next-line no-new-func
+						return new Function(`"use strict"; return (async () => { ${src} })();`)();
+					},
+					expression
+				);
+				let serialized: string;
+				try {
+					serialized = JSON.stringify(result);
+					if (serialized && serialized.length > 4000) serialized = serialized.slice(0, 4000) + '...[truncated]';
+				} catch {
+					serialized = String(result);
+				}
+				return jsonResult(call, { ok: true, result: serialized });
+			}
+			case 'snapshot': {
+				const maxChars = readNumberArg(call.arguments, 'max_chars', 'maxChars') ?? 8_000;
+				const snap = await snapshotPage(page, maxChars);
+				return jsonResult(call, snap);
+			}
+			case 'screenshot': {
+				const fullPage = readBoolArg(call.arguments, 'full_page', 'fullPage') ?? false;
+				const userPath = readStringArg(call.arguments, 'file_path', 'filePath');
+				const out = userPath
+					? { full: path.resolve(ctx.workspaceRoot ?? process.cwd(), userPath), rel: null as string | null }
+					: buildScreenshotPath(ctx.workspaceRoot);
+				fs.mkdirSync(path.dirname(out.full), { recursive: true });
+				const buf = await page.screenshot({ fullPage, type: 'png' });
+				fs.writeFileSync(out.full, buf);
+				return jsonResult(call, {
+					ok: true,
+					path: out.full,
+					relPath: out.rel,
+					sizeBytes: buf.length,
+					url: page.url(),
+				});
+			}
+			case 'assert': {
+				const opts = buildLocatorOpts(call.arguments);
+				const expectation = readStringArg(call.arguments, 'expect') ?? 'visible';
+				const expectedText = readStringArg(call.arguments, 'expected_text', 'expectedText');
+				const expectedCount = readNumberArg(call.arguments, 'expected_count', 'expectedCount');
+				const target = describeLocatorTarget(opts);
+				const loc = pickLocator(page, opts);
+				const timeout = readNumberArg(call.arguments, 'timeout_ms', 'timeoutMs') ?? 8_000;
+				switch (expectation) {
+					case 'visible':
+						await loc.waitFor({ state: 'visible', timeout });
+						break;
+					case 'hidden':
+						await loc.waitFor({ state: 'hidden', timeout });
+						break;
+					case 'has_text': {
+						if (!expectedText) return errorResult(call, 'expected_text required for has_text');
+						const actual = (await loc.first().textContent({ timeout })) ?? '';
+						if (!actual.includes(expectedText)) {
+							return errorResult(call, `assert has_text failed on ${target}: actual="${actual.trim().slice(0, 200)}"`);
+						}
+						break;
+					}
+					case 'has_value': {
+						if (expectedText == null) return errorResult(call, 'expected_text required for has_value');
+						const actual = await loc.first().inputValue({ timeout });
+						if (actual !== expectedText) {
+							return errorResult(call, `assert has_value failed on ${target}: actual="${actual}"`);
+						}
+						break;
+					}
+					case 'has_count': {
+						if (expectedCount == null) return errorResult(call, 'expected_count required for has_count');
+						const actual = await loc.count();
+						if (actual !== expectedCount) {
+							return errorResult(call, `assert has_count failed on ${target}: actual=${actual}`);
+						}
+						break;
+					}
+					case 'url_matches': {
+						if (!expectedText) return errorResult(call, 'expected_text (regex) required for url_matches');
+						if (!new RegExp(expectedText).test(page.url())) {
+							return errorResult(call, `assert url_matches failed: url=${page.url()}`);
+						}
+						break;
+					}
+					default:
+						return errorResult(call, `unknown expect "${expectation}"`);
+				}
+				return jsonResult(call, { ok: true, target, expect: expectation });
+			}
+			default:
+				return errorResult(call, `unknown action "${action}"`);
+		}
+	} catch (e) {
+		return errorResult(call, e instanceof Error ? e.message : String(e));
+	}
+}

--- a/main-src/index.ts
+++ b/main-src/index.ts
@@ -20,6 +20,8 @@ import { flushBotSessionStore, initBotSessionStore } from './bots/botSessionStor
 import { disposeAppTray, initAppTray } from './appTray.js';
 import { disposeBrowserCaptureProxy } from './browser/browserMitmProxy.js';
 import { SystemProxy as BrowserSystemProxy } from './browser/browserSystemProxy.js';
+import { applyAiBrowserStartupSwitches } from './browser/aiBrowserFlag.js';
+import { disposePlaywrightBridge } from './browser/playwrightBridge.js';
 
 function resolveAppIconPath(): string | undefined {
 	const iconSearchRoots =
@@ -48,6 +50,9 @@ function resolveAppIconPath(): string | undefined {
 }
 
 initWindowsConsoleUtf8();
+
+// 必须在 app.whenReady 之前调用 —— Chromium 命令行开关只在初始化前生效。
+applyAiBrowserStartupSwitches();
 
 // Intercept webview new-window requests and forward to host renderer
 // (Electron 12+ deprecated the new-window event; use setWindowOpenHandler instead)
@@ -85,6 +90,7 @@ app.on('before-quit', (e) => {
 		flushPendingSave(),
 		disposeBotController(),
 		disposeBrowserCaptureProxy(),
+		disposePlaywrightBridge(),
 		BrowserSystemProxy.hasSavedState() ? BrowserSystemProxy.disable() : Promise.resolve(),
 	]).finally(() => {
 		app.quit();

--- a/main-src/ipc/handlers/browserHandlers.ts
+++ b/main-src/ipc/handlers/browserHandlers.ts
@@ -52,6 +52,7 @@ import {
 } from '../../browser/browserMitmProxy.js';
 import { CaInstaller, type CaInstallScope } from '../../browser/browserCaInstaller.js';
 import { SystemProxy } from '../../browser/browserSystemProxy.js';
+import { getPlaywrightStatus } from '../../browser/playwrightBridge.js';
 
 function parseCaScope(options: unknown): CaInstallScope {
 	if (options && typeof options === 'object') {
@@ -199,6 +200,17 @@ export function registerBrowserHandlers(): void {
 	ipcMain.handle('browser:openWindow', async (event) => {
 		const hostId = resolveBrowserHostIdForSenderId(event.sender.id);
 		return { ok: await openBrowserWindowForHostId(hostId) };
+	});
+
+	ipcMain.handle('browser:pwStatus', async () => {
+		try {
+			return { ok: true as const, status: await getPlaywrightStatus() };
+		} catch (error) {
+			return {
+				ok: false as const,
+				error: error instanceof Error ? error.message : String(error),
+			};
+		}
 	});
 
 	ipcMain.handle('browserCapture:getState', async (event) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "node-forge": "^1.4.0",
         "node-pty": "^1.1.0",
         "openai": "^4.96.0",
+        "playwright-core": "^1.59.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-markdown": "^10.1.0",
@@ -9420,6 +9421,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmmirror.com/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/plist": {

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "node-forge": "^1.4.0",
     "node-pty": "^1.1.0",
     "openai": "^4.96.0",
+    "playwright-core": "^1.59.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-markdown": "^10.1.0",

--- a/src/AgentBrowserWindowSurface.tsx
+++ b/src/AgentBrowserWindowSurface.tsx
@@ -1,6 +1,7 @@
 import { buildBrowserFingerprintStealthScript } from './browserFingerprintStealth.js';
 import { getBrowserHookScript } from './browserHookScript.js';
 import { fingerprintSettingsToInjectPatch } from '../main-src/browser/browserFingerprintNormalize.js';
+import { humanCursorInitScript } from '../main-src/browser/humanCursor.js';
 import {
 	memo,
 	useCallback,
@@ -46,7 +47,7 @@ import {
 
 type AgentRightSidebarView = 'git' | 'plan' | 'file' | 'team' | 'browser' | 'agents';
 
-const BROWSER_HOME_URL = 'https://www.bing.com/';
+const BROWSER_HOME_URL = 'about:blank';
 const BROWSER_CAPTURE_DOCK_EXPANDED_KEY = 'async.browser.captureDock.expanded.v1';
 const BROWSER_CAPTURE_DOCK_HEIGHT_KEY = 'async.browser.captureDock.height.v1';
 const BROWSER_CAPTURE_DOCK_TAB_KEY = 'async.browser.captureDock.tab.v1';
@@ -929,6 +930,7 @@ const BrowserTabView = memo(
 	fingerprintScriptRef.current = fingerprintScript;
 	const hookScriptRef = useRef<string>(hookScript);
 	hookScriptRef.current = hookScript;
+	const cursorScriptRef = useRef<string>(humanCursorInitScript());
 	const hookEnabledRef = useRef<boolean>(hookEnabled);
 	hookEnabledRef.current = hookEnabled;
 	const onHookEventsRef = useRef<(tabId: string, events: unknown[]) => void>(onHookEvents);
@@ -998,6 +1000,9 @@ const BrowserTabView = memo(
 					/* webview might not have a render frame yet on cold start */
 				});
 			}
+			void node.executeJavaScript(cursorScriptRef.current, false).catch(() => {
+				/* cursor script is decorative, ignore failures */
+			});
 		};
 		const handleStopLoading = () => {
 			onLoading(tabIdRef.current, false, safeGetWebviewUrl(node));
@@ -1027,6 +1032,9 @@ const BrowserTabView = memo(
 					/* ignore */
 				});
 			}
+			void node.executeJavaScript(cursorScriptRef.current, false).catch(() => {
+				/* cursor script is decorative, ignore failures */
+			});
 			if (hookEnabledRef.current && hookScriptRef.current) {
 				void node.executeJavaScript(hookScriptRef.current, false).catch(() => {
 					/* ignore */
@@ -2069,25 +2077,56 @@ const AgentRightSidebarBrowserPanel = memo(function AgentRightSidebarBrowserPane
 			node: AsyncShellWebviewElement,
 			options: { selector: string }
 		): Promise<Record<string, unknown>> => {
-			const script = `
+			// Phase 1（同步脚本）：定位元素、滚到视口、fire-and-forget 启动光标动画。
+			// 不在脚本里 await 异步动画，避免 executeJavaScript 持有的 Promise 跨过
+			// click 触发的页面导航后失效（GUEST_VIEW_MANAGER_CALL 错误根因）。
+			const setupScript = `
 				(() => {
 					const args = ${JSON.stringify({ selector: options.selector })};
 					const target = document.querySelector(args.selector);
 					if (!target) {
-						return {
-							ok: false,
-							error: 'Selector did not match any element.',
-						};
+						return { ok: false, error: 'Selector did not match any element.' };
 					}
 					if (!(target instanceof HTMLElement)) {
-						return {
-							ok: false,
-							error: 'Matched node is not an HTMLElement.',
-						};
+						return { ok: false, error: 'Matched node is not an HTMLElement.' };
 					}
 					target.scrollIntoView({ block: 'center', inline: 'center', behavior: 'instant' });
+					const rect = target.getBoundingClientRect();
+					const cx = Math.round(rect.left + rect.width / 2);
+					const cy = Math.round(rect.top + rect.height / 2);
+					try {
+						const cursor = window.__asyncAiCursor;
+						if (cursor && typeof cursor.moveTo === 'function') {
+							const labelText = String(target.innerText || target.textContent || target.getAttribute('aria-label') || target.tagName.toLowerCase()).trim().slice(0, 40);
+							if (typeof cursor.label === 'function') cursor.label('点击 ' + (labelText || '元素'), 1800);
+							cursor.show();
+							// fire-and-forget; 渲染器侧 sleep 再发 click 脚本
+							Promise.resolve(cursor.moveTo(cx, cy)).then(() => cursor.click(cx, cy)).catch(() => {});
+						}
+					} catch { /* decorative */ }
+					return { ok: true, cx, cy };
+				})()
+			`;
+			const setup = await node.executeJavaScript<Record<string, unknown>>(setupScript, false);
+			if (setup?.ok === false) {
+				throw new Error(String(setup.error ?? 'Failed to locate element.'));
+			}
+			// 等光标动画走完（缓动 ~500ms + hover ~200ms + click 闪 ~150ms）。
+			await new Promise((r) => setTimeout(r, 850));
+
+			// Phase 2（同步脚本）：真实点击 + 读取结果。executeJavaScript 同步返回，
+			// 即便 click 触发了页面导航，这次 IPC 已经先完成了 send/return 周期。
+			const clickScript = `
+				(() => {
+					const args = ${JSON.stringify({ selector: options.selector })};
+					const target = document.querySelector(args.selector);
+					if (!target || !(target instanceof HTMLElement)) {
+						return { ok: false, error: 'Element no longer present.' };
+					}
 					target.focus?.();
 					const rect = target.getBoundingClientRect();
+					const cx = Math.round(rect.left + rect.width / 2);
+					const cy = Math.round(rect.top + rect.height / 2);
 					const beforeUrl = location.href;
 					const beforeTitle = document.title || '';
 					if (typeof target.click === 'function') {
@@ -2101,8 +2140,8 @@ const AgentRightSidebarBrowserPanel = memo(function AgentRightSidebarBrowserPane
 						tagName: target.tagName.toLowerCase(),
 						text: String(target.innerText || target.textContent || '').trim().slice(0, 500),
 						href: target instanceof HTMLAnchorElement ? target.href : '',
-						x: Math.round(rect.left + rect.width / 2),
-						y: Math.round(rect.top + rect.height / 2),
+						x: cx,
+						y: cy,
 						urlBefore: beforeUrl,
 						titleBefore: beforeTitle,
 						urlAfter: location.href,
@@ -2110,7 +2149,7 @@ const AgentRightSidebarBrowserPanel = memo(function AgentRightSidebarBrowserPane
 					};
 				})()
 			`;
-			const result = await node.executeJavaScript<Record<string, unknown>>(script, true);
+			const result = await node.executeJavaScript<Record<string, unknown>>(clickScript, true);
 			if (result?.ok === false) {
 				throw new Error(String(result.error ?? 'Failed to click element.'));
 			}
@@ -2137,6 +2176,36 @@ const AgentRightSidebarBrowserPanel = memo(function AgentRightSidebarBrowserPane
 			node: AsyncShellWebviewElement,
 			options: { selector: string; text: string; pressEnter?: boolean }
 		): Promise<Record<string, unknown>> => {
+			// Phase 1（同步）：定位、滚动、fire-and-forget 启动光标动画
+			const setupScript = `
+				(() => {
+					const args = ${JSON.stringify({ selector: options.selector })};
+					const target = document.querySelector(args.selector);
+					if (!target) return { ok: false, error: 'Selector did not match any element.' };
+					if (!(target instanceof HTMLElement)) return { ok: false, error: 'Matched node is not an HTMLElement.' };
+					target.scrollIntoView({ block: 'center', inline: 'center', behavior: 'instant' });
+					const rect = target.getBoundingClientRect();
+					const cx = Math.round(rect.left + rect.width / 2);
+					const cy = Math.round(rect.top + rect.height / 2);
+					try {
+						const cursor = window.__asyncAiCursor;
+						if (cursor && typeof cursor.moveTo === 'function') {
+							const labelHint = target.getAttribute('placeholder') || target.getAttribute('aria-label') || target.getAttribute('name') || target.tagName.toLowerCase();
+							if (typeof cursor.label === 'function') cursor.label('填写 ' + String(labelHint).slice(0, 40), 2000);
+							cursor.show();
+							Promise.resolve(cursor.moveTo(cx, cy)).then(() => cursor.click(cx, cy)).catch(() => {});
+						}
+					} catch { /* decorative */ }
+					return { ok: true, cx, cy };
+				})()
+			`;
+			const setup = await node.executeJavaScript<Record<string, unknown>>(setupScript, false);
+			if (setup?.ok === false) {
+				throw new Error(String(setup.error ?? 'Failed to locate input.'));
+			}
+			await new Promise((r) => setTimeout(r, 850));
+
+			// Phase 2（同步）：填值 + 逐字向 KeyCastr HUD 推送 + 可选回车
 			const script = `
 				(() => {
 					const args = ${JSON.stringify({
@@ -2146,16 +2215,10 @@ const AgentRightSidebarBrowserPanel = memo(function AgentRightSidebarBrowserPane
 					})};
 					const target = document.querySelector(args.selector);
 					if (!target) {
-						return {
-							ok: false,
-							error: 'Selector did not match any element.',
-						};
+						return { ok: false, error: 'Selector did not match any element.' };
 					}
 					if (!(target instanceof HTMLElement)) {
-						return {
-							ok: false,
-							error: 'Matched node is not an HTMLElement.',
-						};
+						return { ok: false, error: 'Matched node is not an HTMLElement.' };
 					}
 					const dispatchInput = (el) => {
 						el.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }));
@@ -2177,32 +2240,48 @@ const AgentRightSidebarBrowserPanel = memo(function AgentRightSidebarBrowserPane
 							el.value = value;
 						}
 					};
-					target.scrollIntoView({ block: 'center', inline: 'center', behavior: 'instant' });
+					const cursor = window.__asyncAiCursor;
 					target.focus?.();
 					let mode = 'unknown';
-					if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement || target instanceof HTMLSelectElement) {
+					const isFormControl =
+						target instanceof HTMLInputElement ||
+						target instanceof HTMLTextAreaElement ||
+						target instanceof HTMLSelectElement;
+					const useEditable = !isFormControl && target.isContentEditable;
+					mode = isFormControl
+						? target instanceof HTMLTextAreaElement
+							? 'textarea'
+							: target instanceof HTMLSelectElement
+								? 'select'
+								: 'input'
+						: useEditable
+							? 'contenteditable'
+							: 'value' in target
+								? 'value-property'
+								: 'textContent';
+					if (isFormControl) {
 						setNativeValue(target, args.text);
 						dispatchInput(target);
-						mode = target instanceof HTMLTextAreaElement ? 'textarea' : target instanceof HTMLSelectElement ? 'select' : 'input';
-					} else if (target.isContentEditable) {
+					} else if (useEditable) {
 						target.textContent = args.text;
 						dispatchInput(target);
-						mode = 'contenteditable';
 					} else if ('value' in target) {
-						try {
-							target.value = args.text;
-							dispatchInput(target);
-							mode = 'value-property';
-						} catch {
-							target.textContent = args.text;
-							dispatchInput(target);
-							mode = 'textContent';
-						}
+						try { target.value = args.text; dispatchInput(target); }
+						catch { target.textContent = args.text; dispatchInput(target); }
 					} else {
 						target.textContent = args.text;
 						dispatchInput(target);
-						mode = 'textContent';
 					}
+					// HUD 逐字滚出来（fire-and-forget；脚本同步返回，不阻塞 IPC）
+					try {
+						if (cursor && typeof cursor.key === 'function' && args.text.length > 0) {
+							const stagger = args.text.length > 60 ? 35 : 70;
+							for (let i = 0; i < args.text.length; i++) {
+								const ch = args.text.charAt(i);
+								setTimeout(() => { try { cursor.key(ch); } catch { /* */ } }, i * stagger);
+							}
+						}
+					} catch { /* decorative */ }
 					if (args.pressEnter) {
 						const keyboardInit = {
 							key: 'Enter',
@@ -2212,6 +2291,12 @@ const AgentRightSidebarBrowserPanel = memo(function AgentRightSidebarBrowserPane
 							bubbles: true,
 							cancelable: true,
 						};
+						try {
+							if (cursor && typeof cursor.key === 'function') {
+								const enterDelay = args.text.length * (args.text.length > 60 ? 35 : 70);
+								setTimeout(() => { try { cursor.key('Enter'); } catch { /* */ } }, enterDelay);
+							}
+						} catch { /* decorative */ }
 						target.dispatchEvent(new KeyboardEvent('keydown', keyboardInit));
 						target.dispatchEvent(new KeyboardEvent('keypress', keyboardInit));
 						target.dispatchEvent(new KeyboardEvent('keyup', keyboardInit));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3661,6 +3661,7 @@ function AppMainWorkspaceInner() {
 				currentId={currentId}
 				hasUnreadAgentReply={unreadAgentThreadIds.has(th.id)}
 				streamingThreadId={awaitingReply ? streamingThreadId : null}
+				awaitingReply={awaitingReply}
 				editingThreadId={editingThreadId}
 				editingThreadTitleDraft={editingThreadTitleDraft}
 				setEditingThreadTitleDraft={setEditingThreadTitleDraft}

--- a/src/app/AgentSidebarThreadItem.tsx
+++ b/src/app/AgentSidebarThreadItem.tsx
@@ -29,6 +29,8 @@ export type AgentSidebarThreadItemProps = {
 	hasUnreadAgentReply?: boolean;
 	/** Front-end 当前正在流式回复的线程 id；用于无延迟显示「正在回复」状态 */
 	streamingThreadId?: string | null;
+	/** 当前会话是否仍在等模型：暂停/结束后为 false，用于盖过尚未刷新的 `th.isAwaitingReply` */
+	awaitingReply?: boolean;
 	editingThreadId: string | null;
 	editingThreadTitleDraft: string;
 	setEditingThreadTitleDraft: (v: string) => void;
@@ -55,6 +57,7 @@ function AgentSidebarThreadItemImpl(props: AgentSidebarThreadItemProps) {
 		currentId,
 		hasUnreadAgentReply = false,
 		streamingThreadId = null,
+		awaitingReply = true,
 		editingThreadId,
 		editingThreadTitleDraft,
 		setEditingThreadTitleDraft,
@@ -75,8 +78,11 @@ function AgentSidebarThreadItemImpl(props: AgentSidebarThreadItemProps) {
 		(!workspace || !owningWs || normWorkspaceRootKey(owningWs) === normWorkspaceRootKey(workspace));
 	// 本地正在流式回复 → 立即显示「正在回复」，无需等待主进程列表刷新；
 	// 主进程列表也会同步置位 isAwaitingReply，作为兜底（例如刷新慢于本地状态）。
+	// 用户已暂停时本地 awaitingReply 先置 false，摘要仍可能短暂为「末条 user」— 当前激活行勿再显示工作中。
 	const isStreamingThisThread = streamingThreadId === th.id;
-	const isWorking = isStreamingThisThread || Boolean(th.isAwaitingReply);
+	const serverAwaiting = Boolean(th.isAwaitingReply);
+	const staleServerAwaiting = isActive && !awaitingReply;
+	const isWorking = isStreamingThisThread || (serverAwaiting && !staleServerAwaiting);
 	const showUnread = hasUnreadAgentReply && !isActive && !isWorking;
 
 	return (

--- a/src/contextMeterFormat.ts
+++ b/src/contextMeterFormat.ts
@@ -1,6 +1,15 @@
 import type { ComposerImageMeta, ComposerSegment } from './composerSegments';
 import { skillInvocationWire, slashCommandWire } from './composerSegments';
 import { isImagePath, type UserMessagePart } from './messageParts';
+import { isStructuredAssistantMessage, parseAgentAssistantPayload } from './agentStructuredMessage';
+
+/**
+ * 结构化 tool result 中 `image` 块的固定 token 预算。与 claude-code
+ * `tokenEstimation.ts` 的 `IMAGE_MAX_TOKEN_SIZE = 2000` 一致：base64 图片在 JSON 字符串里
+ * 会被 char/4 估算成几十万 token（1MB ≈ 1.33M base64 chars → ~325k tokens）而 API 真实
+ * 计费仅 ~2000，留作保守上界，避免 view_image 后上下文条直接爆掉。
+ */
+const STRUCTURED_TOOL_IMAGE_TOKENS = 2000;
 
 /** 与主进程 `modelContext.ts` 中 `MODEL_CONTEXT_WINDOW_DEFAULT` 一致，用于 UI 未填写时的展示上限 */
 export const DEFAULT_CONTEXT_WINDOW_TOKENS_UI = 200_000;
@@ -103,6 +112,42 @@ export function estimateComposerSegmentsImageTokens(segments: ReadonlyArray<Comp
 	return { tokens, confidence };
 }
 
+/**
+ * 解析结构化 assistant payload，把图片 base64 与文本内容分开计数。
+ * 返回 null 表示 content 不是结构化格式，由调用方走旧的 `content.length` 兜底。
+ */
+function structuredAssistantStats(content: string): { textChars: number; imageCount: number } | null {
+	if (!isStructuredAssistantMessage(content)) {
+		return null;
+	}
+	const payload = parseAgentAssistantPayload(content);
+	if (!payload) {
+		return null;
+	}
+	let textChars = 0;
+	let imageCount = 0;
+	for (const part of payload.parts) {
+		if (part.type === 'text') {
+			textChars += part.text.length;
+			continue;
+		}
+		// tool 调用：name + args(JSON) + 文本 result 都按字符算入文本；resultStructured 中
+		// 的 `image` 改用固定预算，避免 base64 数据被当作普通文本计成天文数字。
+		textChars += part.name.length + JSON.stringify(part.args).length + part.result.length;
+		if (Array.isArray(part.resultStructured)) {
+			for (const block of part.resultStructured) {
+				const t = (block as { type?: unknown }).type;
+				if (t === 'image') {
+					imageCount += 1;
+				} else if (t === 'text') {
+					textChars += String((block as { text?: unknown }).text ?? '').length;
+				}
+			}
+		}
+	}
+	return { textChars, imageCount };
+}
+
 function estimateUserPartsTextCharLength(parts: ReadonlyArray<UserMessagePart>): number {
 	let n = 0;
 	for (const part of parts) {
@@ -130,10 +175,17 @@ function imageMetaFromUserPart(part: Extract<UserMessagePart, { kind: 'image_ref
 }
 
 function estimateMessagesTextCharLength(
-	messages: ReadonlyArray<{ content: string; parts?: UserMessagePart[] }>
+	messages: ReadonlyArray<{ role?: 'user' | 'assistant'; content: string; parts?: UserMessagePart[] }>
 ): number {
 	let n = 0;
 	for (const message of messages) {
+		if (message.role === 'assistant') {
+			const stats = structuredAssistantStats(message.content);
+			if (stats) {
+				n += stats.textChars;
+				continue;
+			}
+		}
 		n += message.parts && message.parts.length > 0
 			? estimateUserPartsTextCharLength(message.parts)
 			: message.content.length;
@@ -142,11 +194,20 @@ function estimateMessagesTextCharLength(
 }
 
 function estimateMessageImageTokens(
-	messages: ReadonlyArray<{ content: string; parts?: UserMessagePart[] }>
+	messages: ReadonlyArray<{ role?: 'user' | 'assistant'; content: string; parts?: UserMessagePart[] }>
 ): ContextEstimate {
 	let tokens = 0;
 	let confidence: EstimateConfidence = 'high';
 	for (const message of messages) {
+		if (message.role === 'assistant') {
+			const stats = structuredAssistantStats(message.content);
+			if (stats && stats.imageCount > 0) {
+				tokens += stats.imageCount * STRUCTURED_TOOL_IMAGE_TOKENS;
+				// tool result 里的 image 块没有 width/height，固定预算属保守估计 → medium
+				confidence = downgradeConfidence(confidence, 'medium');
+			}
+			continue;
+		}
 		for (const part of message.parts ?? []) {
 			if (part.kind !== 'image_ref') {
 				continue;
@@ -167,7 +228,7 @@ function estimateMessageImageTokens(
  * 多模态：历史消息与草稿都优先基于结构化图片元数据估算；图片不再按 `@path` 字符长度计成本。
  */
 export function computeComposerContextUsedEstimate(args: {
-	messages: ReadonlyArray<{ content: string; parts?: UserMessagePart[] }>;
+	messages: ReadonlyArray<{ role?: 'user' | 'assistant'; content: string; parts?: UserMessagePart[] }>;
 	composerSegments: ReadonlyArray<ComposerSegment>;
 }): ContextEstimate {
 	const messageTextTokens = estimateTokensFromCharLength(estimateMessagesTextCharLength(args.messages));


### PR DESCRIPTION
## Summary

This branch introduces a **Playwright-backed browser automation bridge** for the agent, improves **on-screen AI cursor and keyboard feedback**, fixes a **context meter overcount** when structured assistant payloads embed base64 images, and corrects the **agent sidebar "replying"** indicator after the user pauses generation.

## What changed

### Playwright bridge and agent tools (main process)

- New Playwright integration: bridge, tool definitions, executor wiring, IPC handlers, and preload exposure so the renderer can drive browser automation in a controlled way.
- Humanized interaction layer: scroll/locate helpers and Playwright actions routed through a shared pipeline.

### Human cursor and KeyCastr-style key HUD

- Redesigned in-webview cursor visuals (arrow, gradient, glow, ripple/label).
- Bottom-center key HUD (KeyCastr-style pills) for typed characters and key presses, including modifiers and arrow glyphs; exposes `__asyncAiCursor.key(label)` for drivers.
- `humanType` / `humanPressKey` feed the HUD so typing feedback matches real input.

### Agent browser window surface

- Default home set to `about:blank`.
- Injects cursor/HUD init script on `did-start-loading` and `dom-ready` so state survives navigations.
- Click vs fill tooling split into setup (locate, scroll, fire-and-forget cursor animation) and action (synchronous click/fill + HUD) with a short delay between phases to avoid `GUEST_VIEW_MANAGER_CALL` failures when navigation invalidates in-flight `executeJavaScript` promises.

### Context meter (`contextMeterFormat`)

- Structured assistant payloads after `view_image` could embed full base64 in `resultStructured`, inflating naive `content.length / 4` estimates.
- Adds parsing that counts text-like portions by character length and applies a fixed per-image token charge for tool-result images (aligned with claude-code-style handling), preserving existing composer image math elsewhere.

### UI

- Agent sidebar: pass local `awaitingReply` into thread rows so stale `isAwaitingReply` does not keep the "replying" animation after the user pauses generation.
- Minor fix in `AgentSidebarThreadItem.tsx`.

## Testing

Manual verification recommended: agent browser tools (click, fill, type, keys), sidebar pause/reply state, and context meter with assistant payloads that include embedded images.

## Commits

- `41555f1` fix(ui): stop agent sidebar "replying" animation after user pauses generation
- `3a3e102` fix: AgentSidebarThreadItem.tsx
- `8f1114a` feat(browser): polish AI cursor visuals and KeyCastr-style key HUD; fix(context-meter) base64 image cost cap
