### PR TITLE
fix: OpenAI-compatible legacy tool_call XML and inflight stream snapshots

### DIFF
--- a/main-src/agent/agentLoop.ts
+++ b/main-src/agent/agentLoop.ts
@@ -82,6 +82,10 @@ import {
 import type { SendableMessage } from '../llm/sendResolved.js';
 import { userMessageTextForSend } from '../llm/sendResolved.js';
 import { repairAgentThreadMessagesForApi } from './agentToolProtocolRepair.js';
+import {
+	createLegacyToolCallStreamFilter,
+	extractLegacyToolCallsFromAssistantText,
+} from './legacyToolCallFromText.js';
 import { StructuredAssistantBuilder } from './structuredAssistantBuilder.js';
 import { parseAgentAssistantPayload } from '../../src/agentStructuredMessage.js';
 import { repairAnthropicToolPairing, repairOpenAIToolPairing } from './apiConversationRepair.js';
@@ -1075,6 +1079,7 @@ async function runOpenAILoop(
 		const tools = toOpenAITools(resolveVisibleToolPool());
 		let turnText = '';
 		const turnToolCalls: TurnTc[] = [];
+		const legacyToolStream = createLegacyToolCallStreamFilter(`legacy_r${round}_`);
 		let turnFinishReason: string | null = null;
 
 		// 每轮创建独立 AbortController，叠加在外部 signal 之上，用于超时自动中止
@@ -1141,8 +1146,11 @@ async function runOpenAILoop(
 				if (!delta) continue;
 
 				if (delta.content) {
-					turnText += delta.content;
-					handlers.onTextDelta(delta.content);
+					const visible = legacyToolStream.feed(delta.content);
+					if (visible) {
+						turnText += visible;
+						handlers.onTextDelta(visible);
+					}
 				}
 
 				// OpenAI 兼容：部分网关提供 reasoning_content（如 DeepSeek）
@@ -1211,7 +1219,28 @@ async function runOpenAILoop(
 			break;
 		}
 
+		const legacyTail = legacyToolStream.finish();
+		if (legacyTail) {
+			turnText += legacyTail;
+			handlers.onTextDelta(legacyTail);
+		}
+
 		turnText = unwrapAssistantContentEnvelope(turnText);
+		const hasNativeToolCalls = turnToolCalls.some((tc) => tc.name);
+		if (!hasNativeToolCalls) {
+			let legacyCalls = legacyToolStream.toolCalls;
+			if (legacyCalls.length === 0) {
+				const legacyParsed = extractLegacyToolCallsFromAssistantText(
+					turnText,
+					`legacy_r${round}_`
+				);
+				turnText = legacyParsed.text;
+				legacyCalls = legacyParsed.toolCalls;
+			}
+			for (const tc of legacyCalls) {
+				turnToolCalls.push(tc);
+			}
+		}
 		structured.appendText(turnText);
 
 		if (turnToolCalls.length === 0 || turnToolCalls.every((tc) => !tc.name)) {

--- a/main-src/agent/legacyToolCallFromText.test.ts
+++ b/main-src/agent/legacyToolCallFromText.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+	createLegacyToolCallStreamFilter,
+	extractLegacyToolCallsFromAssistantText,
+	stripLegacyToolCallMarkup,
+} from './legacyToolCallFromText.js';
+
+describe('legacyToolCallFromText', () => {
+	it('extracts tool calls and strips markup from assistant text', () => {
+		const raw =
+			'Hello\n<tool_call tool="Read">{"file_path":"src/App.tsx"}</tool_call>\nDone';
+		const { text, toolCalls } = extractLegacyToolCallsFromAssistantText(raw, 'tc_');
+		expect(text).toBe('Hello\n\nDone');
+		expect(toolCalls).toHaveLength(1);
+		expect(toolCalls[0]!.name).toBe('Read');
+		expect(JSON.parse(toolCalls[0]!.arguments)).toEqual({ file_path: 'src/App.tsx' });
+		expect(toolCalls[0]!.id.startsWith('tc_')).toBe(true);
+	});
+
+	it('stripLegacyToolCallMarkup removes blocks without returning calls', () => {
+		const raw = 'x<tool_call tool="Grep">{"pattern":"foo"}</tool_call>y';
+		expect(stripLegacyToolCallMarkup(raw)).toBe('xy');
+	});
+
+	it('stream filter suppresses tool_call chunks until closed', () => {
+		const f = createLegacyToolCallStreamFilter('s_');
+		expect(f.feed('before ')).toBe('before ');
+		expect(f.feed('<tool_call tool="Read">{"file_path":"a.ts"}')).toBe('');
+		expect(f.feed('</tool_call> after')).toBe(' after');
+		expect(f.finish()).toBe('');
+		expect(f.toolCalls).toHaveLength(1);
+		expect(f.toolCalls[0]!.name).toBe('Read');
+	});
+});

--- a/main-src/agent/legacyToolCallFromText.ts
+++ b/main-src/agent/legacyToolCallFromText.ts
@@ -1,0 +1,229 @@
+/**
+ * 部分 OpenAI 兼容网关（如小米）在 content 里输出 legacy `<tool_call>` XML，
+ * 而不填充 `delta.tool_calls`。Agent / Ask 需从正文解析或剥离这些标记。
+ */
+
+import { randomUUID } from 'node:crypto';
+
+const TOOL_CALL_OPEN = '<tool_call tool="';
+const TOOL_CALL_CLOSE = '</tool_call>';
+
+export type LegacyToolCallFromText = {
+	id: string;
+	name: string;
+	arguments: string;
+};
+
+function skipJsonObject(s: string, i: number): number {
+	if (s[i] !== '{') return -1;
+	let depth = 0;
+	let state: 'normal' | 'string' | 'escape' = 'normal';
+	for (let p = i; p < s.length; p++) {
+		const ch = s[p]!;
+		if (state === 'escape') {
+			state = 'string';
+			continue;
+		}
+		if (state === 'string') {
+			if (ch === '\\') state = 'escape';
+			else if (ch === '"') state = 'normal';
+			continue;
+		}
+		if (ch === '"') {
+			state = 'string';
+			continue;
+		}
+		if (ch === '{') depth++;
+		else if (ch === '}') {
+			depth--;
+			if (depth === 0) return p + 1;
+		}
+	}
+	return -1;
+}
+
+function parseToolCallHeader(
+	content: string,
+	absStart: number
+): { name: string; jsonStart: number } | null {
+	if (!content.startsWith(TOOL_CALL_OPEN, absStart)) return null;
+	const nameStart = absStart + TOOL_CALL_OPEN.length;
+	const nameQuote = content.indexOf('"', nameStart);
+	if (nameQuote === -1) return null;
+	const name = content.slice(nameStart, nameQuote);
+	let pos = nameQuote + 1;
+	while (pos < content.length && /\s/.test(content[pos]!)) pos++;
+	while (pos < content.length && content[pos] !== '>') {
+		if (content.startsWith('sub_parent="', pos)) {
+			pos += 'sub_parent="'.length;
+			const eq = content.indexOf('"', pos);
+			if (eq === -1) return null;
+			pos = eq + 1;
+			while (pos < content.length && /\s/.test(content[pos]!)) pos++;
+			continue;
+		}
+		if (content.startsWith('sub_depth="', pos)) {
+			pos += 'sub_depth="'.length;
+			const eq = content.indexOf('"', pos);
+			if (eq === -1) return null;
+			pos = eq + 1;
+			while (pos < content.length && /\s/.test(content[pos]!)) pos++;
+			continue;
+		}
+		return null;
+	}
+	if (pos >= content.length || content[pos] !== '>') return null;
+	return { name, jsonStart: pos + 1 };
+}
+
+/**
+ * 从助手正文中提取完整 `<tool_call>` 块，返回剥离后的文本与可执行的 tool_calls。
+ */
+export function extractLegacyToolCallsFromAssistantText(
+	text: string,
+	idPrefix = 'legacy_tc_'
+): { text: string; toolCalls: LegacyToolCallFromText[] } {
+	if (!text.includes(TOOL_CALL_OPEN)) {
+		return { text, toolCalls: [] };
+	}
+
+	const toolCalls: LegacyToolCallFromText[] = [];
+	const removeRanges: Array<{ start: number; end: number }> = [];
+	let from = 0;
+
+	while (from < text.length) {
+		const start = text.indexOf(TOOL_CALL_OPEN, from);
+		if (start === -1) break;
+		const hdr = parseToolCallHeader(text, start);
+		if (!hdr) break;
+		const jsonEnd = skipJsonObject(text, hdr.jsonStart);
+		if (jsonEnd === -1) break;
+		const closeIdx = text.indexOf(TOOL_CALL_CLOSE, jsonEnd);
+		if (closeIdx === -1) break;
+		const argsRaw = text.slice(hdr.jsonStart, jsonEnd);
+		try {
+			JSON.parse(argsRaw || '{}');
+		} catch {
+			from = closeIdx + TOOL_CALL_CLOSE.length;
+			continue;
+		}
+		toolCalls.push({
+			id: `${idPrefix}${toolCalls.length}_${randomUUID()}`,
+			name: hdr.name,
+			arguments: argsRaw || '{}',
+		});
+		removeRanges.push({ start, end: closeIdx + TOOL_CALL_CLOSE.length });
+		from = closeIdx + TOOL_CALL_CLOSE.length;
+	}
+
+	if (removeRanges.length === 0) {
+		return { text, toolCalls: [] };
+	}
+
+	let cleaned = text;
+	for (let i = removeRanges.length - 1; i >= 0; i--) {
+		const r = removeRanges[i]!;
+		cleaned = cleaned.slice(0, r.start) + cleaned.slice(r.end);
+	}
+	return { text: cleaned, toolCalls };
+}
+
+/** Ask 等无工具模式：仅移除完整 legacy tool_call 块，避免原始 XML 展示给用户。 */
+export function stripLegacyToolCallMarkup(text: string): string {
+	return extractLegacyToolCallsFromAssistantText(text).text;
+}
+
+const PARTIAL_TOOL_CALL_PREFIXES = [
+	'<',
+	'<t',
+	'<to',
+	'<too',
+	'<tool',
+	'<tool_',
+	'<tool_c',
+	'<tool_ca',
+	'<tool_cal',
+	'<tool_call',
+	'<tool_call ',
+	'<tool_call t',
+	'<tool_call to',
+	'<tool_call too',
+	'<tool_call tool',
+	'<tool_call tool=',
+	'<tool_call tool="',
+];
+
+function trailingPartialToolCallPrefix(s: string): string {
+	for (let len = PARTIAL_TOOL_CALL_PREFIXES.length - 1; len >= 0; len--) {
+		const p = PARTIAL_TOOL_CALL_PREFIXES[len]!;
+		if (s.endsWith(p)) return p;
+	}
+	return '';
+}
+
+/**
+ * 流式过滤：不把 `<tool_call>…</tool_call>` 正文增量下发给 UI，结束时再解析工具调用。
+ */
+export function createLegacyToolCallStreamFilter(idPrefix = 'legacy_tc_') {
+	let pending = '';
+	const toolCalls: LegacyToolCallFromText[] = [];
+
+	const feed = (chunk: string): string => {
+		if (!chunk) return '';
+		pending += chunk;
+		let visible = '';
+
+		while (pending.length > 0) {
+			const start = pending.indexOf(TOOL_CALL_OPEN);
+			if (start === -1) {
+				const partial = trailingPartialToolCallPrefix(pending);
+				visible += pending.slice(0, pending.length - partial.length);
+				pending = partial;
+				break;
+			}
+			visible += pending.slice(0, start);
+			pending = pending.slice(start);
+
+			const hdr = parseToolCallHeader(pending, 0);
+			if (!hdr) {
+				const partial = trailingPartialToolCallPrefix(pending);
+				if (partial) {
+					pending = partial;
+				}
+				break;
+			}
+			const jsonEnd = skipJsonObject(pending, hdr.jsonStart);
+			if (jsonEnd === -1) break;
+			const closeIdx = pending.indexOf(TOOL_CALL_CLOSE, jsonEnd);
+			if (closeIdx === -1) break;
+
+			const argsRaw = pending.slice(hdr.jsonStart, jsonEnd);
+			try {
+				JSON.parse(argsRaw || '{}');
+			} catch {
+				pending = pending.slice(closeIdx + TOOL_CALL_CLOSE.length);
+				continue;
+			}
+
+			toolCalls.push({
+				id: `${idPrefix}${toolCalls.length}_${randomUUID()}`,
+				name: hdr.name,
+				arguments: argsRaw || '{}',
+			});
+			pending = pending.slice(closeIdx + TOOL_CALL_CLOSE.length);
+		}
+
+		return visible;
+	};
+
+	const finish = (): string => {
+		const extracted = extractLegacyToolCallsFromAssistantText(pending, idPrefix);
+		for (const tc of extracted.toolCalls) {
+			toolCalls.push(tc);
+		}
+		pending = '';
+		return extracted.text;
+	};
+
+	return { feed, finish, get toolCalls() { return toolCalls; } };
+}

--- a/main-src/llm/openaiAdapter.ts
+++ b/main-src/llm/openaiAdapter.ts
@@ -20,6 +20,7 @@ import type { SendableMessage } from './sendResolved.js';
 import { userMessageTextForSend } from './sendResolved.js';
 import { buildOpenAIUserContent } from './resolvedUserSerialize.js';
 import { streamCodexOAuth } from './codexOAuthAdapter.js';
+import { stripLegacyToolCallMarkup } from '../agent/legacyToolCallFromText.js';
 
 export async function streamOpenAICompatible(
 	settings: ShellSettings,
@@ -232,7 +233,8 @@ export async function streamOpenAICompatible(
 		}
 
 		timeoutMgr.stop();
-		handlers.onDone(full, usage);
+		const cleaned = stripLegacyToolCallMarkup(full);
+		handlers.onDone(cleaned, usage);
 	} catch (e: unknown) {
 		timeoutMgr.stop();
 		if (options.signal.aborted) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -97,7 +97,8 @@ import { type ChatMessage, type ThreadInfo } from './threadTypes';
 import { normWorkspaceRootKey } from './workspaceRootKey';
 import { useAgentFileReview } from './hooks/useAgentFileReview';
 import { useComposer } from './hooks/useComposer';
-import { useStreaming } from './streamingStore';
+import { streamingStore, useStreaming } from './streamingStore';
+import { ensureDraftHasLiveBlocks } from './streamInflightSnapshot';
 import { DevProfiler } from './devProfiler';
 import { useEditorTabs, type EditorInlineDiffState, clampEditorTerminalHeight } from './hooks/useEditorTabs';
 import { useResizeRails } from './hooks/useResizeRails';
@@ -800,14 +801,17 @@ function AppMainWorkspaceInner() {
 			}
 			const draft = offThreadStreamDraftsRef.current[threadId];
 			if (draft) {
+				streamingStore.flush();
 				setStreaming(draft.streaming);
 				setStreamingThinking(draft.streamingThinking);
+				const normalized = ensureDraftHasLiveBlocks(draft);
+				setLiveAssistantBlocks(() => structuredClone(normalized.liveAssistantBlocks));
 				delete offThreadStreamDraftsRef.current[threadId];
 			}
 			setAwaitingReply(true);
 			setStreamingThreadId(threadId);
 		},
-		[setStreaming, setStreamingThinking, setAwaitingReply, setStreamingThreadId]
+		[setStreaming, setStreamingThinking, setLiveAssistantBlocks, setAwaitingReply, setStreamingThreadId]
 	);
 
 	const clearPlanQuestion = useCallback(() => {
@@ -1994,6 +1998,8 @@ function AppMainWorkspaceInner() {
 		confirmDeleteTimerRef,
 		clearTeamSession,
 		clearAgentSession,
+		ipcInFlightChatThreadIdRef,
+		offThreadStreamDraftsRef,
 		setEditorThreadHistoryOpen,
 		onNewThreadRef,
 	});

--- a/src/hooks/useStreamingChat.ts
+++ b/src/hooks/useStreamingChat.ts
@@ -9,11 +9,19 @@ import {
 	type SetStateAction,
 } from 'react';
 import { streamingStore } from '../streamingStore';
+import {
+	type OffThreadStreamDraft,
+	ensureDraftHasLiveBlocks,
+} from '../streamInflightSnapshot';
 import type { ComposerMode } from '../ComposerPlusMenu';
 import type { TeamSettings } from '../agentSettingsTypes';
 import { userMessageToSegments, type ComposerSegment } from '../composerSegments';
 import { segmentsToParts, type UserMessagePart } from '../messageParts';
-import { applyLiveAgentChatPayload, type LiveAgentBlocksState } from '../liveAgentBlocks';
+import {
+	applyLiveAgentChatPayload,
+	createEmptyLiveAgentBlocks,
+	type LiveAgentBlocksState,
+} from '../liveAgentBlocks';
 import type { UserModelEntry } from '../modelCatalog';
 import {
 	type AgentPendingPatch,
@@ -76,7 +84,7 @@ type StreamingSendRuntime = {
 	resetStreamingSession: (options?: { clearThread?: boolean }) => void;
 	clearInFlightIpcRouting: (threadId?: string | null) => void;
 	ipcInFlightChatThreadIdRef: MutableRefObject<string | null>;
-	offThreadStreamDraftsRef: MutableRefObject<Record<string, { streaming: string; streamingThinking: string }>>;
+	offThreadStreamDraftsRef: MutableRefObject<Record<string, OffThreadStreamDraft>>;
 	flashComposerAttachErr: (msg: string) => void;
 	t: TFunction;
 	clearAgentReviewForThread: (threadId: string) => void;
@@ -96,7 +104,7 @@ type StreamingSubscriptionRuntime = {
 	streamThreadRef: MutableRefObject<string | null>;
 	ipcInFlightChatThreadIdRef: MutableRefObject<string | null>;
 	ipcStreamNonceRef: MutableRefObject<number>;
-	offThreadStreamDraftsRef: MutableRefObject<Record<string, { streaming: string; streamingThinking: string }>>;
+	offThreadStreamDraftsRef: MutableRefObject<Record<string, OffThreadStreamDraft>>;
 	streamingToolPreviewClearTimerRef: MutableRefObject<number | null>;
 	setStreamingToolPreview: Dispatch<
 		SetStateAction<{ name: string; partialJson: string; index: number } | null>
@@ -184,7 +192,7 @@ export function useStreamingChat() {
 	const ipcInFlightChatThreadIdRef = useRef<string | null>(null);
 	/** 每次 beginStream 递增，与主进程回包 streamNonce 对齐，丢弃上一轮迟到的 done/error */
 	const ipcStreamNonceRef = useRef(0);
-	const offThreadStreamDraftsRef = useRef<Record<string, { streaming: string; streamingThinking: string }>>({});
+	const offThreadStreamDraftsRef = useRef<Record<string, OffThreadStreamDraft>>({});
 	const streamStartedAtRef = useRef<number | null>(null);
 	const firstTokenAtRef = useRef<number | null>(null);
 
@@ -580,18 +588,28 @@ export function useStreamingChatSubscription(runtime: StreamingSubscriptionRunti
 				rt.applyTeamPayload(payload);
 				return;
 			}
-			const draftRow = () => {
+			const ensureDraft = (): OffThreadStreamDraft => {
 				const m = rt.offThreadStreamDraftsRef.current;
-				if (!m[payload.threadId]) {
-					m[payload.threadId] = { streaming: '', streamingThinking: '' };
+				const tid = payload.threadId;
+				let row = m[tid];
+				if (!row) {
+					row = {
+						streaming: '',
+						streamingThinking: '',
+						liveAssistantBlocks: createEmptyLiveAgentBlocks(),
+					};
+					m[tid] = row;
+					return row;
 				}
-				return m[payload.threadId]!;
+				const normalized = ensureDraftHasLiveBlocks(row);
+				m[tid] = normalized;
+				return normalized;
 			};
 			const patchStream = (updater: (s: string) => string) => {
 				if (visible) {
 					rt.setStreaming(updater);
 				} else {
-					const d = draftRow();
+					const d = ensureDraft();
 					d.streaming = updater(d.streaming);
 				}
 			};
@@ -599,36 +617,46 @@ export function useStreamingChatSubscription(runtime: StreamingSubscriptionRunti
 				if (visible) {
 					rt.setStreamingThinking(updater);
 				} else {
-					const d = draftRow();
+					const d = ensureDraft();
 					d.streamingThinking = updater(d.streamingThinking);
 				}
 			};
 
-			const trackLiveBlocks =
-				(rt.composerMode === 'agent' || rt.composerMode === 'plan' || rt.composerMode === 'team') && visible;
-			const applyToolInputDeltaUi = (p: { name: string; partialJson: string; index: number }) => {
-				if (!visible) {
+			const upsertLiveBlocks = (
+				fragment: Parameters<typeof applyLiveAgentChatPayload>[1]
+			) => {
+				const agentLike =
+					rt.composerMode === 'agent' ||
+					rt.composerMode === 'plan' ||
+					rt.composerMode === 'team';
+				if (!agentLike) {
 					return;
 				}
-				if (rt.streamingToolPreviewClearTimerRef.current !== null) {
-					window.clearTimeout(rt.streamingToolPreviewClearTimerRef.current);
-					rt.streamingToolPreviewClearTimerRef.current = null;
+				if (visible) {
+					rt.setLiveAssistantBlocks((st) => applyLiveAgentChatPayload(st, fragment));
+				} else {
+					const d = ensureDraft();
+					d.liveAssistantBlocks = applyLiveAgentChatPayload(d.liveAssistantBlocks, fragment);
 				}
-				rt.setStreamingToolPreview({
+			};
+			const applyToolInputDeltaUi = (p: { name: string; partialJson: string; index: number }) => {
+				if (visible) {
+					if (rt.streamingToolPreviewClearTimerRef.current !== null) {
+						window.clearTimeout(rt.streamingToolPreviewClearTimerRef.current);
+						rt.streamingToolPreviewClearTimerRef.current = null;
+					}
+					rt.setStreamingToolPreview({
+						name: p.name,
+						partialJson: p.partialJson,
+						index: p.index,
+					});
+				}
+				upsertLiveBlocks({
+					type: 'tool_input_delta',
 					name: p.name,
 					partialJson: p.partialJson,
 					index: p.index,
 				});
-				if (trackLiveBlocks) {
-					rt.setLiveAssistantBlocks((st) =>
-						applyLiveAgentChatPayload(st, {
-							type: 'tool_input_delta',
-							name: p.name,
-							partialJson: p.partialJson,
-							index: p.index,
-						})
-					);
-				}
 			};
 
 			if (payload.type === 'delta') {
@@ -640,14 +668,10 @@ export function useStreamingChatSubscription(runtime: StreamingSubscriptionRunti
 						rt.markFirstToken();
 					}
 					patchStream((s) => s + payload.text);
-					if (trackLiveBlocks) {
-						rt.setLiveAssistantBlocks((st) =>
-							applyLiveAgentChatPayload(st, {
-								type: 'delta',
-								text: payload.text,
-							})
-						);
-					}
+					upsertLiveBlocks({
+						type: 'delta',
+						text: payload.text,
+					});
 				}
 			} else if (payload.type === 'tool_input_delta') {
 				if (!payload.parentToolCallId) {
@@ -663,14 +687,10 @@ export function useStreamingChatSubscription(runtime: StreamingSubscriptionRunti
 					return;
 				} else {
 					patchThinking((s) => s + payload.text);
-					if (trackLiveBlocks) {
-						rt.setLiveAssistantBlocks((st) =>
-							applyLiveAgentChatPayload(st, {
-								type: 'thinking_delta',
-								text: payload.text,
-							})
-						);
-					}
+					upsertLiveBlocks({
+						type: 'thinking_delta',
+						text: payload.text,
+					});
 				}
 			} else if (payload.type === 'tool_call') {
 				if (
@@ -720,16 +740,12 @@ export function useStreamingChatSubscription(runtime: StreamingSubscriptionRunti
 				}
 				const marker = `\n<tool_call tool="${payload.name}">${payload.args}</tool_call>\n`;
 				patchStream((s) => s + marker);
-				if (trackLiveBlocks) {
-					rt.setLiveAssistantBlocks((st) =>
-						applyLiveAgentChatPayload(st, {
-							type: 'tool_call',
-							name: payload.name,
-							args: payload.args,
-							toolCallId: payload.toolCallId,
-						})
-					);
-				}
+				upsertLiveBlocks({
+					type: 'tool_call',
+					name: payload.name,
+					args: payload.args,
+					toolCallId: payload.toolCallId,
+				});
 			} else if (payload.type === 'tool_result') {
 				if (!payload.parentToolCallId && visible) {
 					rt.setStreamingToolPreview(null);
@@ -742,27 +758,21 @@ export function useStreamingChatSubscription(runtime: StreamingSubscriptionRunti
 				const safe = truncated.split('</tool_result>').join('</tool\u200c_result>');
 				const marker = `<tool_result tool="${payload.name}" success="${payload.success}">${safe}</tool_result>\n`;
 				patchStream((s) => s + marker);
-				if (trackLiveBlocks) {
-					rt.setLiveAssistantBlocks((st) =>
-						applyLiveAgentChatPayload(st, {
-							type: 'tool_result',
-							name: payload.name,
-							result: truncated,
-							success: payload.success,
-							toolCallId: payload.toolCallId,
-						})
-					);
-				}
+				upsertLiveBlocks({
+					type: 'tool_result',
+					name: payload.name,
+					result: truncated,
+					success: payload.success,
+					toolCallId: payload.toolCallId,
+				});
 			} else if (payload.type === 'tool_progress') {
-				if (trackLiveBlocks && !payload.parentToolCallId) {
-					rt.setLiveAssistantBlocks((st) =>
-						applyLiveAgentChatPayload(st, {
-							type: 'tool_progress',
-							name: payload.name,
-							phase: payload.phase,
-							detail: payload.detail,
-						})
-					);
+				if (!payload.parentToolCallId) {
+					upsertLiveBlocks({
+						type: 'tool_progress',
+						name: payload.name,
+						phase: payload.phase,
+						detail: payload.detail,
+					});
 				}
 			} else if (payload.type === 'tool_approval_request') {
 				if (visible) {

--- a/src/hooks/useThreadActions.ts
+++ b/src/hooks/useThreadActions.ts
@@ -11,6 +11,8 @@ import {
 import { clearPersistedAgentFileChanges } from './../agentFileChangesPersist';
 import { voidShellDebugLog } from '../tabCloseDebug';
 import { normWorkspaceRootKey } from '../workspaceRootKey';
+import { snapshotInflightStoreIntoDraft, type OffThreadStreamDraft } from '../streamInflightSnapshot';
+import { shouldSkipReloadForSameThread } from '../threadReloadSkip';
 import type { ChatMessage, ThreadInfo } from '../threadTypes';
 import type { ComposerSegment } from '../composerSegments';
 import type { AgentFilePreviewState } from './useAgentFileReview';
@@ -102,6 +104,10 @@ export type UseThreadActionsParams = {
 	// session clears
 	clearTeamSession: (id: string) => void;
 	clearAgentSession: (id: string) => void;
+
+	/** 后台仍在跑的 chat 流线程；切走时快照 streamingStore 用 */
+	ipcInFlightChatThreadIdRef: MutableRefObject<string | null>;
+	offThreadStreamDraftsRef: MutableRefObject<Record<string, OffThreadStreamDraft>>;
 
 	// editor menu
 	setEditorThreadHistoryOpen: Dispatch<SetStateAction<boolean>>;
@@ -197,6 +203,8 @@ export function useThreadActions(params: UseThreadActionsParams): UseThreadActio
 		confirmDeleteTimerRef,
 		clearTeamSession,
 		clearAgentSession,
+		ipcInFlightChatThreadIdRef,
+		offThreadStreamDraftsRef,
 		setEditorThreadHistoryOpen,
 		onNewThreadRef,
 	} = params;
@@ -315,6 +323,12 @@ export function useThreadActions(params: UseThreadActionsParams): UseThreadActio
 			if (dev) {
 				console.log(`[perf] onSelectThread: pre-select Δ=${(tSelectIpcStart - t0).toFixed(1)}ms`);
 			}
+			snapshotInflightStoreIntoDraft({
+				leavingThreadId: currentIdRef.current,
+				selectedThreadId: id,
+				ipcInflightThreadId: ipcInFlightChatThreadIdRef.current,
+				draftsRef: offThreadStreamDraftsRef,
+			});
 			const alreadyCurrentThread = currentIdRef.current === id;
 			if (!alreadyCurrentThread) {
 				await shell.invoke('threads:select', id);
@@ -333,9 +347,11 @@ export function useThreadActions(params: UseThreadActionsParams): UseThreadActio
 			}
 
 			// 已展示该线程则跳过 IPC（须在 reset 之前读 ref，且勿用会被 reset 破坏的依赖）
-			const skipReloadSameThread =
-				messagesThreadIdRef.current === id ||
-				(currentIdRef.current === id && messagesRef.current.length > 0);
+			const skipReloadSameThread = shouldSkipReloadForSameThread(
+				id,
+				currentIdRef.current,
+				messagesThreadIdRef.current
+			);
 
 			if (dev) {
 				console.log(`[perf] onSelectThread: setting states for ${id}`);
@@ -423,6 +439,8 @@ export function useThreadActions(params: UseThreadActionsParams): UseThreadActio
 			setAgentFilePreview,
 			restoreInFlightThreadUiIfNeeded,
 			currentIdRef,
+			ipcInFlightChatThreadIdRef,
+			offThreadStreamDraftsRef,
 			messagesRef,
 			messagesThreadIdRef,
 			setEditorThreadHistoryOpen,

--- a/src/streamInflightSnapshot.test.ts
+++ b/src/streamInflightSnapshot.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { createEmptyLiveAgentBlocks } from './liveAgentBlocks';
+import { streamingStore } from './streamingStore';
+import {
+	ensureDraftHasLiveBlocks,
+	snapshotInflightStoreIntoDraft,
+	type OffThreadStreamDraft,
+} from './streamInflightSnapshot';
+
+describe('snapshotInflightStoreIntoDraft', () => {
+	beforeEach(() => {
+		vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+			queueMicrotask(() => cb(0));
+			return 0;
+		});
+		vi.stubGlobal('cancelAnimationFrame', () => {});
+		streamingStore.flush();
+		streamingStore.setStreaming('');
+		streamingStore.setStreamingThinking('');
+		streamingStore.resetLiveBlocks();
+	});
+
+	afterEach(() => {
+		streamingStore.flush();
+		streamingStore.setStreaming('');
+		streamingStore.setStreamingThinking('');
+		streamingStore.resetLiveBlocks();
+		vi.unstubAllGlobals();
+	});
+
+	it('在离开仍有后台流的线程时把 streamingStore 快照写入草稿', () => {
+		streamingStore.setStreaming('hello');
+		streamingStore.setStreamingThinking('t');
+		const draftsRef = {
+			current: {} as Record<string, OffThreadStreamDraft>,
+		};
+		snapshotInflightStoreIntoDraft({
+			leavingThreadId: 'thread-a',
+			selectedThreadId: 'thread-b',
+			ipcInflightThreadId: 'thread-a',
+			draftsRef,
+		});
+		expect(draftsRef.current['thread-a']?.streaming).toBe('hello');
+		expect(draftsRef.current['thread-a']?.streamingThinking).toBe('t');
+		expect(draftsRef.current['thread-a']?.liveAssistantBlocks.blocks).toEqual([]);
+	});
+
+	it('若 IPC 活动线程与离开的线程不一致则不快照', () => {
+		streamingStore.setStreaming('x');
+		const draftsRef = { current: {} as Record<string, OffThreadStreamDraft> };
+		snapshotInflightStoreIntoDraft({
+			leavingThreadId: 'thread-a',
+			selectedThreadId: 'thread-b',
+			ipcInflightThreadId: 'thread-c',
+			draftsRef,
+		});
+		expect(Object.keys(draftsRef.current).length).toBe(0);
+	});
+});
+
+describe('ensureDraftHasLiveBlocks', () => {
+	it('为仅有字符串的旧草稿补上 liveAssistantBlocks', () => {
+		const row = { streaming: 'a', streamingThinking: 'b' };
+		const out = ensureDraftHasLiveBlocks(row);
+		expect(out.liveAssistantBlocks).toEqual(createEmptyLiveAgentBlocks());
+	});
+});

--- a/src/streamInflightSnapshot.ts
+++ b/src/streamInflightSnapshot.ts
@@ -1,0 +1,47 @@
+import type { MutableRefObject } from 'react';
+import { createEmptyLiveAgentBlocks, type LiveAgentBlocksState } from './liveAgentBlocks';
+import { streamingStore } from './streamingStore';
+
+/** 离屏线程上累积的流式草稿（正文串 + 思考串 + 结构化 live blocks） */
+export type OffThreadStreamDraft = {
+	streaming: string;
+	streamingThinking: string;
+	liveAssistantBlocks: LiveAgentBlocksState;
+};
+
+/**
+ * 在切换离开某线程之前，把当前可见的流式缓冲快照到该线程的离屏草稿里。
+ * 否则「可见态」内容只存在于 streamingStore，切走后会被 reset 丢掉，只能靠切走后到达的 delta 补不全。
+ */
+export function snapshotInflightStoreIntoDraft(params: {
+	leavingThreadId: string | null;
+	selectedThreadId: string;
+	ipcInflightThreadId: string | null;
+	draftsRef: MutableRefObject<Record<string, OffThreadStreamDraft>>;
+}): void {
+	const { leavingThreadId, selectedThreadId, ipcInflightThreadId, draftsRef } = params;
+	if (!leavingThreadId || leavingThreadId === selectedThreadId) {
+		return;
+	}
+	if (ipcInflightThreadId !== leavingThreadId) {
+		return;
+	}
+	streamingStore.flush();
+	draftsRef.current[leavingThreadId] = {
+		streaming: streamingStore.getStreaming(),
+		streamingThinking: streamingStore.getStreamingThinking(),
+		liveAssistantBlocks: structuredClone(streamingStore.getLiveAssistantBlocks()),
+	};
+}
+
+/** 将仅有字符串字段的旧草稿补齐 liveAssistantBlocks，便于与快照合并 */
+export function ensureDraftHasLiveBlocks(row: Partial<OffThreadStreamDraft> & { streaming: string; streamingThinking: string }): OffThreadStreamDraft {
+	if (row.liveAssistantBlocks && Array.isArray(row.liveAssistantBlocks.blocks)) {
+		return row as OffThreadStreamDraft;
+	}
+	return {
+		streaming: row.streaming,
+		streamingThinking: row.streamingThinking,
+		liveAssistantBlocks: createEmptyLiveAgentBlocks(),
+	};
+}

--- a/src/threadReloadSkip.test.ts
+++ b/src/threadReloadSkip.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { shouldSkipReloadForSameThread } from './threadReloadSkip';
+
+describe('shouldSkipReloadForSameThread', () => {
+	it('只有当前线程与消息绑定线程都与选中 id 一致时才跳过 reload', () => {
+		expect(shouldSkipReloadForSameThread('a', 'a', 'a')).toBe(true);
+		expect(shouldSkipReloadForSameThread('a', 'b', 'a')).toBe(false);
+		expect(shouldSkipReloadForSameThread('a', 'a', 'b')).toBe(false);
+		expect(shouldSkipReloadForSameThread('a', null, 'a')).toBe(false);
+		expect(shouldSkipReloadForSameThread('a', 'a', null)).toBe(false);
+	});
+
+	it('修复：侧栏已切到 B 但消息尚未绑定到 B 时，不得视为「已是同线程」而跳过加载', () => {
+		// 例如刚点 B，loadMessages(B) 未完成，messagesThreadId 仍为 A
+		expect(shouldSkipReloadForSameThread('b', 'b', 'a')).toBe(false);
+	});
+});

--- a/src/threadReloadSkip.ts
+++ b/src/threadReloadSkip.ts
@@ -1,0 +1,13 @@
+/**
+ * 判断是否可跳过 loadMessages：仅当「当前选中线程」与「内存中消息绑定的线程」均为目标线程时成立。
+ * 避免 messagesThreadId 尚未跟上侧栏切换时误判为同线程，进而错误清空流式 UI。
+ */
+export function shouldSkipReloadForSameThread(
+	selectedThreadId: string,
+	currentThreadId: string | null,
+	messagesBoundThreadId: string | null
+): boolean {
+	return (
+		currentThreadId === selectedThreadId && messagesBoundThreadId === selectedThreadId
+	);
+}


### PR DESCRIPTION
## Summary

- Parse legacy `<tool_call>` XML in assistant text for OpenAI-compatible gateways (e.g. Xiaomi) so Agent mode can execute tools instead of stopping after plain text.
- Strip the same markup from Ask/Plan streaming replies so users do not see raw tool tags.
- Preserve per-thread streaming drafts when switching threads during an in-flight IPC stream (snapshot + reload skip).

Fixes #71.

## Test plan

- [ ] Xiaomi (or similar) model + OpenAI Compatible + Agent mode: tool calls run and the loop continues.
- [ ] Same model + Ask mode: no raw `<tool_call>` in the final message.
- [ ] Start a stream on thread A, switch to thread B and back: partial assistant output is restored.
- [ ] `npm test` — `legacyToolCallFromText`, `streamInflightSnapshot`, `threadReloadSkip`

Made with [Cursor](https://cursor.com)